### PR TITLE
Retire Gemini; OpenAI-only codegen and review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Agent instructions (agent-web)
 
-Shared brief for Builder/Reviewer AI (Gemini / Models) and any future coding
+Shared brief for Builder/Reviewer AI (OpenAI / Models) and any future coding
 agents. Live site: **https://saberistic.com** (`/`, `/about`, `/health`, `/hello`).
 
 ## Product rules

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -56,15 +56,11 @@ jobs:
           # App token: labels, comments, commits, PRs
           GITHUB_TOKEN: ${{ steps.builder.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          # ChatGPT (OpenAI) preferred when OPENAI_API_KEY is set
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           # Models inference (PAT preferred when Actions token returns 403)
           MODELS_TOKEN: ${{ secrets.MODELS_TOKEN || github.token }}
           GITHUB_MODELS_MODEL: ${{ vars.GITHUB_MODELS_MODEL }}
-          # Gemini optional backup / post-deploy visual
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
           CODEGEN_PROVIDER: ${{ vars.CODEGEN_PROVIDER }}
         run: |
           python scripts/run_agent.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.builder.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL }}

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -121,8 +121,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.reviewer.outputs.token }}
           GITHUB_TOKEN: ${{ steps.reviewer.outputs.token }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           ISSUE: ${{ steps.meta.outputs.issue }}
         run: |
           set -euo pipefail

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -48,8 +48,6 @@ jobs:
           GITHUB_MODELS_MODEL: ${{ vars.GITHUB_MODELS_MODEL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
           DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL }}
           SCREENSHOTS_REQUIRED: ${{ vars.SCREENSHOTS_REQUIRED }}
         run: |

--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -12,8 +12,8 @@ Workflow will move you through `status:in-progress`, then hand off with
 ## Definition of done
 
 - Implementation matches the issue scope (bug fix or feature as labeled).
-- For product code, Builder uses **OpenAI/ChatGPT** when `OPENAI_API_KEY` is set;
-  else **Gemini** (UI) / **GitHub Models** (non-UI) with mutual backup —
+- For product code, Builder uses **OpenAI/ChatGPT** (`OPENAI_API_KEY` required;
+  Gemini retired). Optional GitHub Models backup —
   [docs/MODELS.md](../docs/MODELS.md), [docs/DESIGN.md](../docs/DESIGN.md).
 - Verify/smoke and landing scaffolds may complete without a model call.
 - Branch / PR must reference `#issue` (`Closes #N`).
@@ -32,11 +32,11 @@ Workflow will move you through `status:in-progress`, then hand off with
 
 Stop, comment `@human-review` with the blocker, add `status:blocked`.
 
-Escalate when Models/Gemini codegen fails, or when acceptance criteria cannot
+Escalate when OpenAI/Models codegen fails, or when acceptance criteria cannot
 be met from the issue text.
 
 ## Special case: landing / UI design
 
-- Primary: OpenAI when `OPENAI_API_KEY` set; else Gemini; else Models
+- Primary: OpenAI (`OPENAI_API_KEY`)
 - Edit `site/`; keep brutal-minimalist brand rules in `.github/copilot-instructions.md`
   (shared agent brief) and [docs/DESIGN.md](../docs/DESIGN.md)

--- a/AGENTS/reviewer.md
+++ b/AGENTS/reviewer.md
@@ -12,7 +12,7 @@ Before approving you must:
 1. Capture **headless Chromium screenshots** via Actions Playwright
    (`scripts/screenshot_deploy.py` on the live deploy URL) and post them on the
    PR and issue — not Copilot / MCP browsers
-2. Run **Models/Gemini AI review** ([docs/MODELS.md](../docs/MODELS.md),
+2. Run **OpenAI / Models AI review** ([docs/MODELS.md](../docs/MODELS.md),
    [docs/DESIGN.md](../docs/DESIGN.md))
 3. Post an **`### acceptance_checklist`** that marks each acceptance criterion
    done/not_done with links to evidence (PR, commits, files, screenshots)

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ hello-world HTTP API used to exercise the loop.
 
 ## Docs
 
-- [Copilot (deferred)](docs/COPILOT.md) — rolled back; Gemini/Models are active
+- [Copilot (deferred)](docs/COPILOT.md) — rolled back; OpenAI is primary
 - [Labels](docs/LABELS.md) — label taxonomy and routing rules
 - [Identities](docs/IDENTITIES.md) — agent identity definitions
 - [Trace](docs/TRACE.md) — `agent-trace.jsonl` schema and jq queries
 - [Hello API](docs/HELLO_API.md) — local run and Render deploy
 - [Landing](docs/LANDING.md) — saberistic.com about page + DNS notes
-- [GitHub Models codegen](docs/MODELS.md) — Builder non-UI codegen
-- [Design AI (Gemini)](docs/DESIGN.md) — UI primary codegen
+- [Models / codegen](docs/MODELS.md) — OpenAI primary + Models backup
+- [Design AI](docs/DESIGN.md) — UI codegen via OpenAI
 - [Screenshots](docs/SCREENSHOTS.md) — pre-merge + post-deploy visual evidence
 - [Acceptance](docs/ACCEPTANCE.md) — checklist + evidence before close
 

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -7,7 +7,7 @@ and posted evidence.
 
 1. **Reviewer** (`agent:reviewer`) before approve:
    - Parses `## Acceptance criteria` from the issue body
-   - Verifies each item (heuristics + Gemini/Models)
+   - Verifies each item (heuristics + OpenAI/Models)
    - Posts `### acceptance_checklist` with status + evidence links
      (PR, commits, files, screenshot comments, deploy URL)
    - Checks off matching `- [ ]` boxes in the issue body when done

--- a/docs/COPILOT.md
+++ b/docs/COPILOT.md
@@ -1,8 +1,8 @@
 # GitHub Copilot (deferred)
 
 Copilot coding agent / code review was tried in this repo and **rolled back**.
-Builder and Reviewer again use **Gemini + GitHub Models** only
-([DESIGN.md](DESIGN.md), [MODELS.md](MODELS.md)).
+Builder and Reviewer again use **OpenAI** with optional **GitHub Models**
+backup ([DESIGN.md](DESIGN.md), [MODELS.md](MODELS.md)). Gemini is retired.
 
 `scripts/copilot_agent.py` remains in-tree unused. Re-enable only after
 `suggestedActors(CAN_BE_ASSIGNED)` includes `copilot-swe-agent` for a user PAT

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,22 +1,13 @@
-# Design AI for visual / UI changes
+# Design AI (OpenAI)
 
-Builder prefers **ChatGPT (OpenAI)** when `OPENAI_API_KEY` is set. Without it,
-UI issues use **Gemini**, then **GitHub Models** — see [MODELS.md](MODELS.md).
+Builder uses **ChatGPT (OpenAI)** for UI and product codegen. Gemini is retired.
 
-## Setup (ChatGPT)
+## Setup
 
 1. Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 2. Repo secret: `OPENAI_API_KEY`
 3. Optional variable: `OPENAI_MODEL` (default `gpt-4.1-mini`)
-4. Optional force: `CODEGEN_PROVIDER=openai` (or `chatgpt`)
-
-## Gemini (optional backup / post-deploy visual)
-
-1. [Google AI Studio](https://aistudio.google.com/apikey) → `GEMINI_API_KEY`
-2. Optional: `GEMINI_MODEL` (default `gemini-3.5-flash`)
-
-Gemini has been unreliable for HTML/CSS JSON codegen (typos like `FastAPH`,
-broken tags, bad `content_b64`). Prefer OpenAI for product PRs.
+4. Repo variable: `CODEGEN_PROVIDER=openai`
 
 ## Design brief baked into prompts
 

--- a/docs/IDENTITIES.md
+++ b/docs/IDENTITIES.md
@@ -8,9 +8,9 @@ mint an installation token (`actions/create-github-app-token`) and perform
 GitHub mutations **only** with that token so events attribute to the role bot —
 not `github-actions[bot]`.
 
-**Codegen:** Builder uses **Gemini** (UI) / **GitHub Models** (non-UI) with
-mutual backup — [DESIGN.md](DESIGN.md), [MODELS.md](MODELS.md). Copilot coding
-agent is deferred ([COPILOT.md](COPILOT.md)).
+**Codegen:** Builder uses **OpenAI** (required) with optional **GitHub Models**
+backup — [DESIGN.md](DESIGN.md), [MODELS.md](MODELS.md). Gemini is retired.
+Copilot coding agent is deferred ([COPILOT.md](COPILOT.md)).
 
 ## Confirmed role → identity → scope
 
@@ -49,9 +49,9 @@ Unrelated org install (not part of the agent loop): `digitalocean` (installation
 
 Builder also uses:
 
-- Optional `MODELS_TOKEN` secret (else Actions token) for Models inference
-- Secret `GEMINI_API_KEY` for UI codegen + backup / post-deploy visual AI
-  ([DESIGN.md](DESIGN.md))
+- Secret `OPENAI_API_KEY` for Builder/Reviewer/acceptance/post-deploy AI
+  ([MODELS.md](MODELS.md)); Gemini is retired
+- Optional `MODELS_TOKEN` for GitHub Models backup
 - Builder App must keep `contents: write` so `git/refs` branch creation works
 
 ## Actions job `permissions:` (must not exceed App)

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,39 +1,34 @@
 # Builder codegen providers
 
-Order when no `CODEGEN_PROVIDER` force is set:
-
-1. **OpenAI / ChatGPT** if `OPENAI_API_KEY` is set
-2. Else **Gemini** for UI issues (if `GEMINI_API_KEY`)
-3. Else **GitHub Models** (free Actions Models; use `MODELS_TOKEN` PAT on 403)
-
-Force with variable `CODEGEN_PROVIDER` = `openai` | `chatgpt` | `gemini` | `github-models`.
+**Gemini is retired.** Product codegen uses **OpenAI / ChatGPT** only
+(`OPENAI_API_KEY`), with optional **GitHub Models** backup.
 
 ## Flow
 
 1. Issue gets `agent:builder`
 2. Special cases: verify/smoke (no model); missing landing scaffold → block
-3. Model returns JSON file plan → Builder App commits + opens PR
-4. Reviewer (acceptance checklist + screenshots)
+3. OpenAI returns JSON file plan → Builder App commits + opens PR
+4. Thin child issues that say `Parent: #N` also pull the parent issue body into
+   the prompt
+5. Reviewer (acceptance checklist + screenshots)
 
 ## Auth
 
 | Token | Purpose |
 |-------|---------|
-| Builder App token (`GITHUB_TOKEN` in job) | Comments, labels, commits, PRs |
-| `OPENAI_API_KEY` | ChatGPT codegen (preferred) |
-| `MODELS_TOKEN` secret, else Actions `github.token` | GitHub Models inference |
-| `GEMINI_API_KEY` | Optional backup + post-deploy visual AI |
+| Builder App token | Comments, labels, commits, PRs |
+| `OPENAI_API_KEY` | **Required** ChatGPT codegen |
+| `MODELS_TOKEN` (optional) | GitHub Models backup if OpenAI fails |
 
-## Models
+## Variables
 
 | Variable | Default |
 |----------|---------|
+| `CODEGEN_PROVIDER` | `openai` (force `github-models` only if needed) |
 | `OPENAI_MODEL` | `gpt-4.1-mini` |
 | `GITHUB_MODELS_MODEL` | `openai/gpt-4o-mini` |
-| `GEMINI_MODEL` | `gemini-3.5-flash` |
 
 ## Limits
 
 - Max 12 files per issue
-- Minimal scoped changes; include tests when behavior changes
 - Prefer plain JSON `content` strings (not brittle `content_b64`)

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -12,7 +12,7 @@ When `agent:reviewer` runs on an open PR (workflow installs Playwright):
    (cold-start retries)
 2. Files land under `.agent/screenshots/pr-<n>/pre-*.png` on the PR branch
 3. Comments `### reviewer_screenshots_pre` on the **PR and linked issue**
-4. AI review (Gemini when `GEMINI_API_KEY` is set) runs
+4. AI review (OpenAI when `OPENAI_API_KEY` is set) runs
 5. Approve only if acceptance is met **and** screenshots posted
 
 Fail closed if the deploy URL is unreachable after retries.
@@ -30,7 +30,7 @@ CI `post-deploy-visual` job (after Render deploy hook):
    from PRs linked to the commit SHA
 4. Comments `### deploy_visual_check` on that issue (uploads under
    `.agent/screenshots/issue-<n>/post/`) including the `/health` JSON
-5. Includes pre shots when available and asks **Gemini** (multimodal) whether the
+5. Includes pre shots when available and asks **OpenAI** (vision) whether the
    issue change is visually visible vs pre-merge
 6. Labels `@human-review` / escalates if visual check fails
 
@@ -46,13 +46,13 @@ gets the before/after pair.
 |------|------|---------|
 | `DEPLOY_BASE_URL` | variable | default `https://saberistic.com` (empty var ignored) |
 | `SCREENSHOTS_REQUIRED` | variable | default true for Reviewer |
-| `GEMINI_API_KEY` | secret | post-deploy visual AI + Builder/Reviewer codegen |
-| `GEMINI_MODEL` | variable | default `gemini-3.5-flash` |
+| `OPENAI_API_KEY` | secret | AI review + post-deploy visual + Builder codegen |
+| `OPENAI_MODEL` | variable | default `gpt-4.1-mini` |
 | `RENDER_DEPLOY_HOOK_URL` | secret | deploy trigger |
 
 ## Scripts / workflows
 
 - `scripts/screenshot_deploy.py` — headless capture + upload + comment
-- `scripts/post_deploy_visual.py` — post-deploy capture + Gemini visibility check
+- `scripts/post_deploy_visual.py` — post-deploy capture + OpenAI vision check
 - `.github/workflows/reviewer.yml` — pre-merge Playwright install + capture
 - `.github/workflows/ci.yml` — `post-deploy-visual` job

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -194,19 +194,24 @@ def heuristic_check(criterion: str, evidence: dict[str, Any]) -> dict[str, Any] 
     if (
         "kind: gemini" in text
         or "kind:gemini" in text
+        or "kind: openai" in text
+        or "kind:openai" in text
         or "kind: copilot" in text
         or "kind:copilot" in text
         or ("gemini" in text and "codegen" in text)
+        or ("openai" in text and "codegen" in text)
         or ("copilot" in text and "codegen" in text)
     ):
         urls = (
-            _comment_urls(evidence, "kind: `copilot`")
+            _comment_urls(evidence, "kind: `openai`")
+            or _comment_urls(evidence, "kind: openai")
+            or _comment_urls(evidence, "kind: `copilot`")
             or _comment_urls(evidence, "kind: copilot")
             or _comment_urls(evidence, "kind: `gemini`")
             or _comment_urls(evidence, "kind: gemini")
         )
         if urls:
-            status, note, ev = "done", "Builder reported Copilot/Gemini codegen", urls
+            status, note, ev = "done", "Builder reported Copilot/OpenAI/Models codegen", urls
         elif _comment_urls(evidence, "kind: `github-models`") or _comment_urls(
             evidence, "kind: github-models"
         ):
@@ -215,7 +220,7 @@ def heuristic_check(criterion: str, evidence: dict[str, Any]) -> dict[str, Any] 
             ev = _comment_urls(evidence, "kind:")
         else:
             status = "not_done"
-            note = "No Builder kind: copilot/gemini/github-models comment"
+            note = "No Builder kind: openai/copilot/github-models comment"
 
     elif "screenshot" in text and ("reviewer" in text or "pr" in text):
         urls = _comment_urls(evidence, "reviewer_screenshots_pre")
@@ -320,27 +325,25 @@ def _extract_json(text: str) -> dict[str, Any]:
 
 
 def _chat(system: str, user: str) -> str:
-    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    if key:
-        model = os.environ.get("GEMINI_MODEL") or "gemini-3.5-flash"
-        url = (
-            "https://generativelanguage.googleapis.com/v1beta/models/"
-            f"{urllib.parse.quote(model, safe='')}:generateContent"
-            f"?key={urllib.parse.quote(key.strip())}"
-        )
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if openai_key and openai_key.strip():
+        model = os.environ.get("OPENAI_MODEL") or "gpt-4.1-mini"
         payload = {
-            "systemInstruction": {"parts": [{"text": system}]},
-            "contents": [{"role": "user", "parts": [{"text": user}]}],
-            "generationConfig": {
-                "temperature": 0.1,
-                "responseMimeType": "application/json",
-            },
+            "model": model,
+            "temperature": 0.1,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
         }
         req = urllib.request.Request(
-            url,
+            "https://api.openai.com/v1/chat/completions",
             data=json.dumps(payload).encode("utf-8"),
             method="POST",
             headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {openai_key.strip()}",
                 "Content-Type": "application/json",
                 "User-Agent": "agent-web-acceptance",
             },
@@ -348,20 +351,17 @@ def _chat(system: str, user: str) -> str:
         try:
             with urllib.request.urlopen(req, timeout=180) as resp:
                 body = json.loads(resp.read().decode("utf-8"))
-            texts = []
-            for cand in body.get("candidates") or []:
-                for part in (cand.get("content") or {}).get("parts") or []:
-                    if part.get("text"):
-                        texts.append(str(part["text"]))
-            content = "\n".join(texts).strip()
-            if content:
-                return content
+            choices = body.get("choices") or []
+            if choices:
+                content = (choices[0].get("message") or {}).get("content")
+                if content:
+                    return str(content)
         except Exception:
             pass
 
     token = os.environ.get("MODELS_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if not token:
-        raise GitHubError("no GEMINI_API_KEY or MODELS_TOKEN for acceptance AI")
+        raise GitHubError("no OPENAI_API_KEY or MODELS_TOKEN for acceptance AI")
     model = os.environ.get("GITHUB_MODELS_MODEL") or "openai/gpt-4o-mini"
     payload = {
         "model": model,

--- a/scripts/codegen_models.py
+++ b/scripts/codegen_models.py
@@ -17,13 +17,9 @@ from typing import Any
 from github_api import GitHubError, api, post_issue_comment, split_repo, token
 
 DEFAULT_MODEL = "openai/gpt-4o-mini"
-DEFAULT_GEMINI_MODEL = "gemini-3.5-flash"
 DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
 MODELS_URL = "https://models.github.ai/inference/chat/completions"
 OPENAI_URL = "https://api.openai.com/v1/chat/completions"
-GEMINI_URL_TMPL = (
-    "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
-)
 MAX_FILES = 12
 MAX_FILE_CHARS = 80_000
 CONTEXT_FILES = (
@@ -51,11 +47,6 @@ def models_token() -> str:
     return value
 
 
-def gemini_api_key() -> str | None:
-    value = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    return value.strip() if value and value.strip() else None
-
-
 def openai_api_key() -> str | None:
     value = os.environ.get("OPENAI_API_KEY")
     return value.strip() if value and value.strip() else None
@@ -65,7 +56,7 @@ def is_agent_infra_issue(title: str, body: str) -> bool:
     """True only for Reviewer/screenshot *infra* work, not product UI issues.
 
     Product issues often mention screenshots in acceptance criteria; those must
-    still go through Gemini/codegen, not the docs-sync shortcut.
+    still go through OpenAI/codegen, not the docs-sync shortcut.
     """
     title_l = title.lower()
     text = f"{title}\n{body}".lower()
@@ -230,69 +221,13 @@ def chat_completion_openai(*, model: str, system: str, user: str) -> str:
     return str(content)
 
 
-def chat_completion_gemini(*, model: str, system: str, user: str) -> str:
-    key = gemini_api_key()
-    if not key:
-        raise GitHubError("missing GEMINI_API_KEY")
-    url = GEMINI_URL_TMPL.format(model=urllib.parse.quote(model, safe=""))
-    payload = {
-        "systemInstruction": {"parts": [{"text": system}]},
-        "contents": [{"role": "user", "parts": [{"text": user}]}],
-        "generationConfig": {
-            "temperature": 0.2,
-            "responseMimeType": "application/json",
-        },
-    }
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        f"{url}?key={urllib.parse.quote(key)}",
-        data=data,
-        method="POST",
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": "agent-web-builder",
-        },
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=180) as resp:
-            body = json.loads(resp.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        raise GitHubError(f"Gemini API ({model}) -> {exc.code}: {detail}") from exc
-
-    candidates = body.get("candidates") or []
-    if not candidates:
-        raise GitHubError(f"Gemini ({model}) returned no candidates: {body!r}")
-    finish = candidates[0].get("finishReason")
-    parts = ((candidates[0].get("content") or {}).get("parts")) or []
-    texts = [str(p.get("text") or "") for p in parts if isinstance(p, dict)]
-    content = "\n".join(t for t in texts if t).strip()
-    if not content:
-        raise GitHubError(
-            f"Gemini ({model}) empty content (finishReason={finish}): {body!r}"
-        )
-    return content
-
-
 def chat_completion(*, provider: str, model: str, system: str, user: str) -> str:
     if provider == "openai":
         return chat_completion_openai(model=model, system=system, user=user)
     if provider == "gemini":
-        # Try configured model, then known-good aliases if the id is retired.
-        models = [model]
-        for alt in ("gemini-3.5-flash", "gemini-flash-latest", "gemini-2.5-flash-lite"):
-            if alt not in models:
-                models.append(alt)
-        errors: list[str] = []
-        for mid in models:
-            try:
-                return chat_completion_gemini(model=mid, system=system, user=user)
-            except Exception as exc:
-                errors.append(str(exc))
-                # Only rotate on missing-model / not-found style failures.
-                if not re.search(r"\b404\b|NOT_FOUND|no longer available|not found", str(exc), re.I):
-                    raise
-        raise GitHubError("Gemini failed for all models: " + " | ".join(errors))
+        raise GitHubError(
+            "Gemini is retired for this repo; set OPENAI_API_KEY / CODEGEN_PROVIDER=openai"
+        )
     return chat_completion_github(model=model, system=system, user=user)
 
 
@@ -455,53 +390,34 @@ def json_system_prompt(*, ui: bool) -> str:
 def select_provider(title: str, body: str) -> tuple[str, str]:
     """Return (provider, model).
 
-    Policy:
-    - CODEGEN_PROVIDER force: openai|chatgpt|gemini|github-models|models
-    - Else if OPENAI_API_KEY set → OpenAI (ChatGPT) primary for all product work
-    - Else UI → Gemini (when key set), else GitHub Models
-    - Else non-UI → GitHub Models, else Gemini
+    Policy (Gemini retired):
+    - CODEGEN_PROVIDER force: openai|chatgpt|github-models|models
+    - Else OpenAI when OPENAI_API_KEY is set (required for product work)
+    - Else GitHub Models only as last-resort backup
     """
+    del title, body  # selection no longer depends on UI vs non-UI for Gemini
     force = (os.environ.get("CODEGEN_PROVIDER") or "").strip().lower()
     if force in {"openai", "chatgpt"}:
         return "openai", os.environ.get("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
-    if force in {"gemini", "github-models", "models"}:
-        if force == "gemini":
-            return "gemini", os.environ.get("GEMINI_MODEL") or DEFAULT_GEMINI_MODEL
+    if force in {"github-models", "models"}:
         return "github-models", os.environ.get("GITHUB_MODELS_MODEL") or DEFAULT_MODEL
+    if force == "gemini":
+        raise GitHubError(
+            "CODEGEN_PROVIDER=gemini is retired; use openai (OPENAI_API_KEY)"
+        )
 
     if openai_api_key():
         return "openai", os.environ.get("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
-
-    ui = is_ui_design_issue(title, body)
-    has_gemini = bool(gemini_api_key())
-    models_model = os.environ.get("GITHUB_MODELS_MODEL") or DEFAULT_MODEL
-    gemini_model = os.environ.get("GEMINI_MODEL") or DEFAULT_GEMINI_MODEL
-
-    if ui and has_gemini:
-        return "gemini", gemini_model
-    if not ui:
-        return "github-models", models_model
-    return "github-models", models_model
+    return "github-models", os.environ.get("GITHUB_MODELS_MODEL") or DEFAULT_MODEL
 
 
 def _other_provider(provider: str) -> tuple[str, str]:
-    """Pick a backup provider different from the primary."""
+    """Backup: OpenAI ↔ GitHub Models only (no Gemini)."""
     openai_model = os.environ.get("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
     models_model = os.environ.get("GITHUB_MODELS_MODEL") or DEFAULT_MODEL
-    gemini_model = os.environ.get("GEMINI_MODEL") or DEFAULT_GEMINI_MODEL
-
     if provider == "openai":
-        if gemini_api_key():
-            return "gemini", gemini_model
         return "github-models", models_model
-    if provider == "gemini":
-        if openai_api_key():
-            return "openai", openai_model
-        return "github-models", models_model
-    # github-models
-    if openai_api_key():
-        return "openai", openai_model
-    return "gemini", gemini_model
+    return "openai", openai_model
 
 
 def build_with_models(
@@ -515,6 +431,14 @@ def build_with_models(
 ) -> dict[str, Any]:
     root = cwd or Path.cwd()
     ui = is_ui_design_issue(title, body)
+    if not openai_api_key() and (os.environ.get("CODEGEN_PROVIDER") or "").strip().lower() not in {
+        "github-models",
+        "models",
+    }:
+        raise GitHubError(
+            "OPENAI_API_KEY is required for Builder codegen (Gemini retired). "
+            "Set the secret or force CODEGEN_PROVIDER=github-models."
+        )
     provider, model = select_provider(title, body)
     brief_text = brief.read_text(encoding="utf-8") if brief.is_file() else ""
     owner, name = split_repo(repo)
@@ -524,13 +448,26 @@ def build_with_models(
     branch = f"builder/{issue}-{slugify(title)}"
 
     system = json_system_prompt(ui=ui)
+    # Thin planner child issues often only say "User flow" — pull parent context.
+    parent = ""
+    m = re.search(r"(?:Parent|Child of)\s*:?\s*#(\d+)", body, re.I)
+    if m:
+        try:
+            pdata = api("GET", f"/repos/{owner}/{name}/issues/{m.group(1)}")
+            parent = (
+                f"\n## Parent issue #{m.group(1)}: {pdata.get('title')}\n"
+                f"{(pdata.get('body') or '')[:12000]}\n"
+            )
+        except Exception:
+            parent = ""
     user = (
         f"Repository: {repo}\n"
         f"Issue: #{issue}\n"
         f"Title: {title}\n"
         f"UI/design focus: {ui}\n"
         f"Live reference (if relevant): https://saberistic.com/\n\n"
-        f"## Issue body\n{body.strip() or '(empty)'}\n\n"
+        f"## Issue body\n{body.strip() or '(empty)'}\n"
+        f"{parent}\n"
         f"## Builder brief\n{brief_text[:5000]}\n\n"
         f"{repo_context(root, ui=ui)}\n"
     )
@@ -538,17 +475,11 @@ def build_with_models(
     try:
         raw = chat_completion(provider=provider, model=model, system=system, user=user)
     except Exception as primary_exc:
-        # Mutual backup across OpenAI ↔ Gemini ↔ GitHub Models.
         alt_provider, alt_model = _other_provider(provider)
         if alt_provider == "openai" and not openai_api_key():
             raise GitHubError(
                 f"{provider} failed: {primary_exc}\n"
                 "OpenAI backup unavailable (missing OPENAI_API_KEY)."
-            ) from primary_exc
-        if alt_provider == "gemini" and not gemini_api_key():
-            raise GitHubError(
-                f"{provider} failed: {primary_exc}\n"
-                "Gemini backup unavailable (missing GEMINI_API_KEY)."
             ) from primary_exc
         try:
             raw = chat_completion(
@@ -569,7 +500,6 @@ def build_with_models(
         plan = extract_json(raw)
         files = validate_plan(plan)
     except Exception as parse_exc:
-        # One repair pass: prefer plain content strings (not brittle base64).
         repair_user = (
             f"{user}\n\n"
             "## Previous invalid model output (fix and return valid JSON only)\n"

--- a/scripts/copilot_agent.py
+++ b/scripts/copilot_agent.py
@@ -45,7 +45,7 @@ def copilot_token() -> str:
 def copilot_enabled() -> bool:
     """True when we should attempt Copilot coding agent first."""
     force = (os.environ.get("CODEGEN_PROVIDER") or "").strip().lower()
-    if force in {"models", "github-models", "gemini"}:
+    if force in {"models", "github-models", "openai", "chatgpt"}:
         return False
     if force == "copilot":
         return True
@@ -359,7 +359,7 @@ def copilot_review_verdict(repo: str, issue: int, pr_number: int) -> dict[str, A
         meets = False
         reasons = [
             "Copilot code review did not arrive in time; "
-            "fail closed (set COPILOT_TOKEN / enable code review, or rely on Models/Gemini AI)"
+            "fail closed (set COPILOT_TOKEN / enable code review, or rely on OpenAI/Models AI)"
         ]
 
     return {

--- a/scripts/post_deploy_visual.py
+++ b/scripts/post_deploy_visual.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""After deploy: capture post screenshots and ask Gemini if the issue change is visible."""
+"""After deploy: capture post screenshots and ask OpenAI if the issue change is visible."""
 
 from __future__ import annotations
 
@@ -68,8 +68,8 @@ def record_health(
     return {"path": f"{prefix}/deploy-health.json", "url": raw_url, "json": json.dumps(slim)}
 
 
-def gemini_key() -> str | None:
-    value = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+def openai_key() -> str | None:
+    value = os.environ.get("OPENAI_API_KEY")
     return value.strip() if value and value.strip() else None
 
 
@@ -126,23 +126,25 @@ def list_pre_urls(repo: str, ref: str, pr: int | None) -> list[str]:
     return urls
 
 
-def gemini_visual_check(
+def visual_ai_check(
     *,
     issue_title: str,
     issue_body: str,
     pre_paths: list[Path],
     post_paths: list[Path],
 ) -> dict:
-    key = gemini_key()
+    """Compare before/after screenshots via OpenAI vision (Gemini retired)."""
+    key = openai_key()
     if not key:
         return {
             "visible": None,
-            "summary": "GEMINI_API_KEY missing; skipped visual AI check",
+            "summary": "OPENAI_API_KEY missing; skipped visual AI check",
             "decision": "skip",
         }
-    model = os.environ.get("GEMINI_MODEL") or "gemini-3.5-flash"
-    parts: list[dict] = [
+    model = os.environ.get("OPENAI_MODEL") or "gpt-4.1-mini"
+    content: list[dict] = [
         {
+            "type": "text",
             "text": (
                 "You compare before/after screenshots of a deployed website.\n"
                 "Return ONLY JSON: "
@@ -151,57 +153,57 @@ def gemini_visual_check(
                 "fail if unchanged or unrelated.\n\n"
                 f"Issue title: {issue_title}\n"
                 f"Issue body:\n{(issue_body or '')[:4000]}\n"
-            )
+            ),
         }
     ]
     for label, paths in (("BEFORE", pre_paths), ("AFTER", post_paths)):
-        parts.append({"text": f"\n{label} screenshots follow."})
-        for path in paths:
-            parts.append(
+        content.append({"type": "text", "text": f"\n{label} screenshots follow."})
+        for p in paths:
+            b64 = base64.b64encode(p.read_bytes()).decode("ascii")
+            content.append(
                 {
-                    "inline_data": {
-                        "mime_type": "image/png",
-                        "data": base64.b64encode(path.read_bytes()).decode("ascii"),
-                    }
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{b64}"},
                 }
             )
-    url = (
-        "https://generativelanguage.googleapis.com/v1beta/models/"
-        f"{urllib.parse.quote(model, safe='')}:generateContent"
-        f"?key={urllib.parse.quote(key)}"
-    )
     payload = {
-        "contents": [{"role": "user", "parts": parts}],
-        "generationConfig": {"temperature": 0.1, "responseMimeType": "application/json"},
+        "model": model,
+        "temperature": 0.1,
+        "response_format": {"type": "json_object"},
+        "messages": [{"role": "user", "content": content}],
     }
     req = urllib.request.Request(
-        url,
+        "https://api.openai.com/v1/chat/completions",
         data=json.dumps(payload).encode("utf-8"),
         method="POST",
-        headers={"Content-Type": "application/json", "User-Agent": "agent-web-visual"},
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+            "User-Agent": "agent-web-visual",
+        },
     )
     try:
         with urllib.request.urlopen(req, timeout=180) as resp:
             body = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
-        raise GitHubError(f"Gemini visual -> {exc.code}: {detail}") from exc
-    text = ""
-    for cand in body.get("candidates") or []:
-        for part in (cand.get("content") or {}).get("parts") or []:
-            text += str(part.get("text") or "")
-    text = text.strip()
+        raise GitHubError(f"OpenAI visual -> {exc.code}: {detail}") from exc
+    choices = body.get("choices") or []
+    out_text = ""
+    if choices:
+        out_text = str((choices[0].get("message") or {}).get("content") or "").strip()
     try:
-        data = json.loads(text)
+        data = json.loads(out_text)
     except json.JSONDecodeError:
-        start, end = text.find("{"), text.rfind("}")
-        data = json.loads(text[start : end + 1]) if start >= 0 and end > start else {}
+        s, e = out_text.find("{"), out_text.rfind("}")
+        data = json.loads(out_text[s : e + 1]) if s >= 0 and e > s else {}
     return {
         "visible": data.get("visible"),
-        "summary": str(data.get("summary") or text[:500]),
+        "summary": str(data.get("summary") or out_text[:500]),
         "decision": str(data.get("decision") or "fail").lower(),
         "model": model,
     }
+
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -274,7 +276,7 @@ def main(argv: list[str] | None = None) -> int:
                 f".agent/screenshots/issue-{issue_num}/pre",
             )
 
-        visual = gemini_visual_check(
+        visual = visual_ai_check(
             issue_title=issue.get("title") or "",
             issue_body=issue.get("body") or "",
             pre_paths=pre_files,

--- a/scripts/review_models.py
+++ b/scripts/review_models.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """AI-backed PR review against issue acceptance criteria.
 
-Prefers OpenAI (ChatGPT) when OPENAI_API_KEY is set, then Gemini, then
-GitHub Models.
+Prefers OpenAI (ChatGPT) when OPENAI_API_KEY is set, then GitHub Models.
+Gemini is retired.
 """
 
 from __future__ import annotations
@@ -11,7 +11,6 @@ import json
 import os
 import re
 import urllib.error
-import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -112,49 +111,8 @@ def chat_github(system: str, user: str, model: str | None = None) -> tuple[str, 
     return str(content), model
 
 
-def chat_gemini(system: str, user: str, model: str | None = None) -> tuple[str, str]:
-    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    if not key:
-        raise GitHubError("missing GEMINI_API_KEY")
-    model = model or os.environ.get("GEMINI_MODEL") or "gemini-3.5-flash"
-    url = (
-        "https://generativelanguage.googleapis.com/v1beta/models/"
-        f"{urllib.parse.quote(model, safe='')}:generateContent"
-        f"?key={urllib.parse.quote(key.strip())}"
-    )
-    payload = {
-        "systemInstruction": {"parts": [{"text": system}]},
-        "contents": [{"role": "user", "parts": [{"text": user}]}],
-        "generationConfig": {
-            "temperature": 0.1,
-            "responseMimeType": "application/json",
-        },
-    }
-    req = urllib.request.Request(
-        url,
-        data=json.dumps(payload).encode("utf-8"),
-        method="POST",
-        headers={"Content-Type": "application/json", "User-Agent": "agent-web-reviewer"},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=180) as resp:
-            body = json.loads(resp.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        raise GitHubError(f"Gemini API -> {exc.code}: {detail}") from exc
-    texts = []
-    for cand in body.get("candidates") or []:
-        for part in (cand.get("content") or {}).get("parts") or []:
-            if part.get("text"):
-                texts.append(str(part["text"]))
-    content = "\n".join(texts).strip()
-    if not content:
-        raise GitHubError(f"Gemini empty content: {body!r}")
-    return content, model
-
-
 def chat(system: str, user: str, model: str | None = None) -> tuple[str, str]:
-    """Prefer OpenAI, then Gemini, then GitHub Models."""
+    """OpenAI first, then GitHub Models. Gemini is retired."""
     errors: list[str] = []
     if openai_api_key():
         try:
@@ -163,11 +121,6 @@ def chat(system: str, user: str, model: str | None = None) -> tuple[str, str]:
             )
         except Exception as exc:
             errors.append(f"openai: {exc}")
-    if os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"):
-        try:
-            return chat_gemini(system, user, model=os.environ.get("GEMINI_MODEL"))
-        except Exception as exc:
-            errors.append(f"gemini: {exc}")
     try:
         return chat_github(system, user, model=model)
     except Exception as exc:

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -296,7 +296,7 @@ def role_builder(repo: str, issue: int, brief: Path) -> None:
             return
 
     # Screenshot / reviewer infra: already implemented in-repo — document + done PR path
-    # without calling Models (often 403) or Gemini UI prompts.
+    # without calling Models (often 403) or OpenAI UI prompts.
     # Landing/product issues must never take this shortcut (AC may mention screenshots).
     try:
         from codegen_models import is_agent_infra_issue
@@ -370,7 +370,7 @@ def role_builder(repo: str, issue: int, brief: Path) -> None:
         write_builder_handoff("reviewer")
         return
 
-    # Product work: GitHub Models default; Gemini primary for UI/design (mutual backup).
+    # Product work: OpenAI primary; GitHub Models optional backup.
     try:
         from codegen_models import build_with_models
 
@@ -392,11 +392,11 @@ def role_builder(repo: str, issue: int, brief: Path) -> None:
             repo,
             issue,
             (
-                "Codegen failed (OpenAI / GitHub Models / Gemini).\n\n"
+                "Codegen failed (OpenAI / GitHub Models).\n\n"
                 f"`{exc}`\n\n"
-                "Preferred: ChatGPT via `OPENAI_API_KEY` (set `CODEGEN_PROVIDER=openai`). "
-                "Backup: free GitHub Models / Gemini. "
-                "See docs/MODELS.md + docs/DESIGN.md. "
+                "Required: ChatGPT via `OPENAI_API_KEY` (`CODEGEN_PROVIDER=openai`). "
+                "Optional backup: GitHub Models (`MODELS_TOKEN`). Gemini is retired. "
+                "See docs/MODELS.md. "
                 "If `git/refs` returns 403 for the Builder App, grant the App "
                 "`contents: write` on this repository."
             ),
@@ -580,14 +580,14 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
         if os.environ.get("SCREENSHOTS_REQUIRED", "true").lower() in {"1", "true", "yes"}:
             hard_fail_reasons.append(f"required deploy screenshots failed: {exc}")
 
-    # Models/Gemini AI review (required for approve path).
+    # OpenAI / Models AI review (required for approve path).
     ai_block = ""
     try:
         from review_models import ai_review
 
         verdict = ai_review(repo, issue, pr_number)
         ai_block += (
-            f"- ai_provider: `models-or-gemini`\n"
+            f"- ai_provider: `openai-or-models`\n"
             f"- ai_model: `{verdict.get('model')}`\n"
             f"- ai_decision: `{verdict.get('decision')}`\n"
             f"- ai_summary: {verdict.get('summary')}\n"

--- a/tests/test_codegen_provider.py
+++ b/tests/test_codegen_provider.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import base64
 import os
 
+import pytest
+
 from codegen_models import is_ui_design_issue, select_provider, validate_plan
+from github_api import GitHubError
 
 
 def test_about_page_is_ui() -> None:
@@ -14,7 +17,6 @@ def test_about_page_is_ui() -> None:
 
 def test_validate_plan_accepts_unpadded_content_b64() -> None:
     text = "<!doctype html><html><body>About</body></html>"
-    # Intentionally omit '=' padding that models often drop.
     unpadded = base64.b64encode(text.encode()).decode().rstrip("=")
     assert "=" not in unpadded
     files = validate_plan(
@@ -25,12 +27,8 @@ def test_validate_plan_accepts_unpadded_content_b64() -> None:
 
 def test_select_provider_prefers_openai_when_key_set(monkeypatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
     monkeypatch.delenv("CODEGEN_PROVIDER", raising=False)
-    provider, model = select_provider(
-        "About page: dedicated route",
-        "brutal minimal landing CTA hero",
-    )
+    provider, model = select_provider("About page", "landing CTA")
     assert provider == "openai"
     assert "gpt" in model
 
@@ -42,33 +40,14 @@ def test_select_provider_force_openai(monkeypatch) -> None:
     assert provider == "openai"
 
 
-def test_select_provider_ui_prefers_gemini_without_openai(monkeypatch) -> None:
+def test_select_provider_gemini_force_raises(monkeypatch) -> None:
+    monkeypatch.setenv("CODEGEN_PROVIDER", "gemini")
+    with pytest.raises(GitHubError, match="retired"):
+        select_provider("any", "any")
+
+
+def test_select_provider_without_openai_uses_models(monkeypatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
     monkeypatch.delenv("CODEGEN_PROVIDER", raising=False)
-    provider, model = select_provider(
-        "About page: dedicated route",
-        "brutal minimal landing CTA hero",
-    )
-    assert provider == "gemini"
-    assert "gemini" in model
-
-
-def test_select_provider_non_ui_prefers_models(monkeypatch) -> None:
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
-    monkeypatch.delenv("CODEGEN_PROVIDER", raising=False)
-    provider, _model = select_provider(
-        "Fix /health JSON shape",
-        "API bug: health endpoint should return status ok",
-    )
-    assert provider == "github-models"
-
-
-def test_select_provider_ui_without_gemini_uses_models(monkeypatch) -> None:
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-    monkeypatch.delenv("CODEGEN_PROVIDER", raising=False)
-    provider, _model = select_provider("Landing hero CTA", "update landing css hero")
+    provider, _model = select_provider("Landing hero CTA", "update landing")
     assert provider == "github-models"


### PR DESCRIPTION
## Summary
- Remove all Gemini API paths from Builder, Reviewer, acceptance, and post-deploy visual checks
- Require OpenAI (`OPENAI_API_KEY`) with optional GitHub Models backup only
- Pull parent issue body into thin child prompts (helps #42 / #43 / #44)
- Update workflows and docs to match

## Test plan
- [x] `pytest tests/test_codegen_provider.py tests/test_review_models.py`
- [ ] After merge: confirm Builder no longer receives `GEMINI_*` env
- [ ] Re-queue #42 with parent AC once this lands


Made with [Cursor](https://cursor.com)