### PR TITLE
Use Cursor Agent SDK for Builder coding

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     if: github.event.label.name == 'agent:builder'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     permissions:
       contents: write
       issues: write
@@ -35,6 +35,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install agent dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-agents.txt
+
       - name: Mark in progress
         env:
           GH_TOKEN: ${{ steps.builder.outputs.token }}
@@ -56,6 +61,9 @@ jobs:
           # App token: labels, comments, commits, PRs
           GITHUB_TOKEN: ${{ steps.builder.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          # Cursor SDK cloud agent (preferred coding path)
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          CURSOR_MODEL: ${{ vars.CURSOR_MODEL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           # Models inference (PAT preferred when Actions token returns 403)

--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -12,9 +12,9 @@ Workflow will move you through `status:in-progress`, then hand off with
 ## Definition of done
 
 - Implementation matches the issue scope (bug fix or feature as labeled).
-- For product code, Builder uses **OpenAI/ChatGPT** (`OPENAI_API_KEY` required;
-  Gemini retired). Optional GitHub Models backup —
-  [docs/MODELS.md](../docs/MODELS.md), [docs/DESIGN.md](../docs/DESIGN.md).
+- For product code, Builder uses the **Cursor Agent SDK** cloud agent
+  (`CURSOR_API_KEY`; `CODEGEN_PROVIDER=cursor`). Optional OpenAI / GitHub Models
+  backup — [docs/MODELS.md](../docs/MODELS.md), [docs/DESIGN.md](../docs/DESIGN.md).
 - Verify/smoke and landing scaffolds may complete without a model call.
 - Branch / PR must reference `#issue` (`Closes #N`).
 - Tests relevant to the change are added or updated when behavior changes.
@@ -32,11 +32,11 @@ Workflow will move you through `status:in-progress`, then hand off with
 
 Stop, comment `@human-review` with the blocker, add `status:blocked`.
 
-Escalate when OpenAI/Models codegen fails, or when acceptance criteria cannot
-be met from the issue text.
+Escalate when Cursor/OpenAI/Models codegen fails, or when acceptance criteria
+cannot be met from the issue text.
 
 ## Special case: landing / UI design
 
-- Primary: OpenAI (`OPENAI_API_KEY`)
+- Primary: Cursor cloud agent (`CURSOR_API_KEY`)
 - Edit `site/`; keep brutal-minimalist brand rules in `.github/copilot-instructions.md`
   (shared agent brief) and [docs/DESIGN.md](../docs/DESIGN.md)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ hello-world HTTP API used to exercise the loop.
 - [Trace](docs/TRACE.md) — `agent-trace.jsonl` schema and jq queries
 - [Hello API](docs/HELLO_API.md) — local run and Render deploy
 - [Landing](docs/LANDING.md) — saberistic.com about page + DNS notes
-- [Models / codegen](docs/MODELS.md) — OpenAI primary + Models backup
-- [Design AI](docs/DESIGN.md) — UI codegen via OpenAI
+- [Models / codegen](docs/MODELS.md) — Cursor SDK primary + OpenAI/Models backup
+- [Design AI](docs/DESIGN.md) — UI coding via Cursor / OpenAI
 - [Screenshots](docs/SCREENSHOTS.md) — pre-merge + post-deploy visual evidence
 - [Acceptance](docs/ACCEPTANCE.md) — checklist + evidence before close
 

--- a/docs/COPILOT.md
+++ b/docs/COPILOT.md
@@ -1,8 +1,8 @@
 # GitHub Copilot (deferred)
 
 Copilot coding agent / code review was tried in this repo and **rolled back**.
-Builder and Reviewer again use **OpenAI** with optional **GitHub Models**
-backup ([DESIGN.md](DESIGN.md), [MODELS.md](MODELS.md)). Gemini is retired.
+Builder and Reviewer again use the **Cursor Agent SDK** (preferred) with
+optional OpenAI / GitHub Models backup ([DESIGN.md](DESIGN.md), [MODELS.md](MODELS.md)).
 
 `scripts/copilot_agent.py` remains in-tree unused. Re-enable only after
 `suggestedActors(CAN_BE_ASSIGNED)` includes `copilot-swe-agent` for a user PAT

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,6 +1,7 @@
 # Design AI (OpenAI)
 
-Builder uses **ChatGPT (OpenAI)** for UI and product codegen. Gemini is retired.
+Builder uses the **Cursor Agent SDK** (cloud) for UI and product coding when
+`CURSOR_API_KEY` is set. OpenAI remains an optional JSON-codegen backup.
 
 ## Setup
 

--- a/docs/IDENTITIES.md
+++ b/docs/IDENTITIES.md
@@ -8,9 +8,10 @@ mint an installation token (`actions/create-github-app-token`) and perform
 GitHub mutations **only** with that token so events attribute to the role bot —
 not `github-actions[bot]`.
 
-**Codegen:** Builder uses **OpenAI** (required) with optional **GitHub Models**
-backup — [DESIGN.md](DESIGN.md), [MODELS.md](MODELS.md). Gemini is retired.
-Copilot coding agent is deferred ([COPILOT.md](COPILOT.md)).
+**Codegen:** Builder uses the **Cursor Agent SDK** (cloud) when
+`CURSOR_API_KEY` is set; OpenAI / GitHub Models are optional backups —
+[DESIGN.md](DESIGN.md), [MODELS.md](MODELS.md). Copilot coding agent is deferred
+([COPILOT.md](COPILOT.md)).
 
 ## Confirmed role → identity → scope
 
@@ -49,8 +50,8 @@ Unrelated org install (not part of the agent loop): `digitalocean` (installation
 
 Builder also uses:
 
-- Secret `OPENAI_API_KEY` for Builder/Reviewer/acceptance/post-deploy AI
-  ([MODELS.md](MODELS.md)); Gemini is retired
+- Secret `CURSOR_API_KEY` for Builder cloud coding ([MODELS.md](MODELS.md))
+- Optional `OPENAI_API_KEY` for Reviewer/acceptance/post-deploy AI + codegen backup
 - Optional `MODELS_TOKEN` for GitHub Models backup
 - Builder App must keep `contents: write` so `git/refs` branch creation works
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,34 +1,50 @@
 # Builder codegen providers
 
-**Gemini is retired.** Product codegen uses **OpenAI / ChatGPT** only
-(`OPENAI_API_KEY`), with optional **GitHub Models** backup.
+Product coding uses the **Cursor Agent SDK** (cloud agent + auto PR) when
+`CURSOR_API_KEY` is set. OpenAI and GitHub Models remain optional backups.
 
 ## Flow
 
 1. Issue gets `agent:builder`
 2. Special cases: verify/smoke (no model); missing landing scaffold → block
-3. OpenAI returns JSON file plan → Builder App commits + opens PR
+3. **Cursor cloud agent** implements the change and opens a PR
+   (`auto_create_pr`, `skip_reviewer_request`)
 4. Thin child issues that say `Parent: #N` also pull the parent issue body into
    the prompt
 5. Reviewer (acceptance checklist + screenshots)
+
+Fallback (JSON file plan → Builder App commits) only when provider is
+`openai` or `github-models`.
 
 ## Auth
 
 | Token | Purpose |
 |-------|---------|
-| Builder App token | Comments, labels, commits, PRs |
-| `OPENAI_API_KEY` | **Required** ChatGPT codegen |
-| `MODELS_TOKEN` (optional) | GitHub Models backup if OpenAI fails |
+| Builder App token | Comments, labels, status handoff |
+| `CURSOR_API_KEY` | **Preferred** Cursor SDK cloud coding ([Integrations](https://cursor.com/dashboard/integrations) or team service account) |
+| `OPENAI_API_KEY` | Optional ChatGPT JSON codegen backup |
+| `MODELS_TOKEN` (optional) | GitHub Models last-resort backup |
 
 ## Variables
 
 | Variable | Default |
 |----------|---------|
-| `CODEGEN_PROVIDER` | `openai` (force `github-models` only if needed) |
+| `CODEGEN_PROVIDER` | unset → Cursor if key present, else OpenAI, else Models. Force: `cursor` \| `openai` \| `github-models` |
+| `CURSOR_MODEL` | `composer-2.5` |
 | `OPENAI_MODEL` | `gpt-4.1-mini` |
 | `GITHUB_MODELS_MODEL` | `openai/gpt-4o-mini` |
 
-## Limits
+## Cursor setup
+
+1. Create a Cursor API key (user or team service account)
+2. Repo secret: `CURSOR_API_KEY`
+3. Repo variable: `CODEGEN_PROVIDER=cursor` (recommended while OpenAI is rate-limited)
+4. Optional: `CURSOR_MODEL=composer-2.5`
+5. Ensure the Cursor account can open PRs on `saberistic-team/agent-web`
+
+Docs: [Cursor Python SDK](https://cursor.com/docs/sdk/python)
+
+## Limits (OpenAI / Models JSON path only)
 
 - Max 12 files per issue
 - Prefer plain JSON `content` strings (not brittle `content_b64`)

--- a/requirements-agents.txt
+++ b/requirements-agents.txt
@@ -1,0 +1,3 @@
+# Dependencies for Actions agents (Builder / optional local tooling).
+# Keep out of requirements.txt so Render/hello API stays lean.
+cursor-sdk>=0.1.9

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -196,14 +196,19 @@ def heuristic_check(criterion: str, evidence: dict[str, Any]) -> dict[str, Any] 
         or "kind:gemini" in text
         or "kind: openai" in text
         or "kind:openai" in text
+        or "kind: cursor" in text
+        or "kind:cursor" in text
         or "kind: copilot" in text
         or "kind:copilot" in text
         or ("gemini" in text and "codegen" in text)
         or ("openai" in text and "codegen" in text)
+        or ("cursor" in text and "codegen" in text)
         or ("copilot" in text and "codegen" in text)
     ):
         urls = (
-            _comment_urls(evidence, "kind: `openai`")
+            _comment_urls(evidence, "kind: `cursor`")
+            or _comment_urls(evidence, "kind: cursor")
+            or _comment_urls(evidence, "kind: `openai`")
             or _comment_urls(evidence, "kind: openai")
             or _comment_urls(evidence, "kind: `copilot`")
             or _comment_urls(evidence, "kind: copilot")
@@ -211,7 +216,7 @@ def heuristic_check(criterion: str, evidence: dict[str, Any]) -> dict[str, Any] 
             or _comment_urls(evidence, "kind: gemini")
         )
         if urls:
-            status, note, ev = "done", "Builder reported Copilot/OpenAI/Models codegen", urls
+            status, note, ev = "done", "Builder reported Cursor/OpenAI/Models codegen", urls
         elif _comment_urls(evidence, "kind: `github-models`") or _comment_urls(
             evidence, "kind: github-models"
         ):
@@ -220,7 +225,7 @@ def heuristic_check(criterion: str, evidence: dict[str, Any]) -> dict[str, Any] 
             ev = _comment_urls(evidence, "kind:")
         else:
             status = "not_done"
-            note = "No Builder kind: openai/copilot/github-models comment"
+            note = "No Builder kind: cursor/openai/copilot/github-models comment"
 
     elif "screenshot" in text and ("reviewer" in text or "pr" in text):
         urls = _comment_urls(evidence, "reviewer_screenshots_pre")

--- a/scripts/codegen_cursor.py
+++ b/scripts/codegen_cursor.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Builder codegen via Cursor Agent SDK (cloud runtime).
+
+Uses a Cursor-hosted cloud agent against this GitHub repo with auto_create_pr.
+Requires CURSOR_API_KEY (user or team service-account key).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from github_api import GitHubError, api, post_issue_comment, split_repo
+
+DEFAULT_CURSOR_MODEL = "composer-2.5"
+
+
+def cursor_api_key() -> str | None:
+    value = os.environ.get("CURSOR_API_KEY")
+    return value.strip() if value and value.strip() else None
+
+
+def cursor_model() -> str:
+    return (os.environ.get("CURSOR_MODEL") or DEFAULT_CURSOR_MODEL).strip()
+
+
+def _repo_https_url(repo: str) -> str:
+    owner, name = split_repo(repo)
+    return f"https://github.com/{owner}/{name}"
+
+
+def _parent_context(repo: str, body: str) -> str:
+    m = re.search(r"(?:Parent|Child of)\s*:?\s*#(\d+)", body, re.I)
+    if not m:
+        return ""
+    owner, name = split_repo(repo)
+    try:
+        pdata = api("GET", f"/repos/{owner}/{name}/issues/{m.group(1)}")
+    except Exception:
+        return ""
+    return (
+        f"\n## Parent issue #{m.group(1)}: {pdata.get('title')}\n"
+        f"{(pdata.get('body') or '')[:12000]}\n"
+    )
+
+
+def build_prompt(
+    *,
+    repo: str,
+    issue: int,
+    title: str,
+    body: str,
+    brief: Path,
+) -> str:
+    brief_text = brief.read_text(encoding="utf-8") if brief.is_file() else ""
+    design = Path("docs/DESIGN.md")
+    design_text = design.read_text(encoding="utf-8")[:4000] if design.is_file() else ""
+    brand = Path(".github/copilot-instructions.md")
+    brand_text = brand.read_text(encoding="utf-8")[:4000] if brand.is_file() else ""
+    parent = _parent_context(repo, body)
+    return (
+        f"You are the Builder agent for `{repo}`.\n"
+        f"Implement GitHub issue #{issue} end-to-end on a new branch and open a PR.\n\n"
+        "Hard rules:\n"
+        f"- PR title like `builder: {title} (#{issue})`\n"
+        f"- PR body MUST include `Closes #{issue}`\n"
+        f"- Commit messages MUST include `builder(#{issue}): …`\n"
+        "- Never push to main/master; only work on a feature branch\n"
+        "- Stay in scope of this issue; no drive-by refactors\n"
+        "- Add/update tests under tests/ when behavior changes\n"
+        "- Follow brutal-minimalist brand rules below for any UI work\n"
+        "- Live site reference: https://saberistic.com/\n\n"
+        f"## Issue #{issue}: {title}\n"
+        f"{body.strip() or '(empty)'}\n"
+        f"{parent}\n"
+        f"## Builder brief\n{brief_text[:5000]}\n\n"
+        f"## Brand / agent instructions\n{brand_text}\n\n"
+        f"## Design notes\n{design_text}\n"
+    )
+
+
+def _pr_number_from_url(url: str) -> int | None:
+    if not url:
+        return None
+    path = urlparse(url).path.rstrip("/")
+    m = re.search(r"/pull/(\d+)$", path)
+    return int(m.group(1)) if m else None
+
+
+def _wait_for_linked_pr(repo: str, issue: int, *, timeout_s: int = 180) -> dict | None:
+    from codegen_models import linked_open_prs
+
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        prs = linked_open_prs(repo, issue)
+        if prs:
+            return prs[0]
+        time.sleep(5)
+    return None
+
+
+def build_with_cursor(
+    repo: str,
+    issue: int,
+    *,
+    title: str,
+    body: str,
+    brief: Path,
+) -> dict[str, Any]:
+    key = cursor_api_key()
+    if not key:
+        raise GitHubError("missing CURSOR_API_KEY for Cursor SDK codegen")
+
+    try:
+        from cursor_sdk import (
+            Agent,
+            CloudAgentOptions,
+            CloudRepository,
+            CursorAgentError,
+        )
+    except ImportError as exc:
+        raise GitHubError(
+            "cursor-sdk is not installed; pip install -r requirements-agents.txt"
+        ) from exc
+
+    model = cursor_model()
+    prompt = build_prompt(
+        repo=repo, issue=issue, title=title, body=body, brief=brief
+    )
+    repo_url = _repo_https_url(repo)
+    owner, name = split_repo(repo)
+    default = api("GET", f"/repos/{owner}/{name}").get("default_branch") or "main"
+
+    try:
+        with Agent.create(
+            model=model,
+            api_key=key,
+            name=f"builder-{issue}",
+            cloud=CloudAgentOptions(
+                repos=[
+                    CloudRepository(
+                        url=repo_url,
+                        starting_ref=default,
+                    )
+                ],
+                auto_create_pr=True,
+                skip_reviewer_request=True,
+            ),
+        ) as agent:
+            agent_id = getattr(agent, "agent_id", None) or getattr(
+                agent, "agentId", None
+            )
+            run = agent.send(prompt)
+            run_id = getattr(run, "id", None)
+            result = run.wait()
+    except CursorAgentError as exc:
+        retryable = getattr(exc, "is_retryable", False)
+        raise GitHubError(
+            f"Cursor SDK startup failed (retryable={retryable}): {exc}"
+        ) from exc
+
+    status = getattr(result, "status", None)
+    if status != "finished":
+        raise GitHubError(
+            f"Cursor cloud run did not finish: status={status!r} "
+            f"agent_id={getattr(result, 'agent_id', '')} "
+            f"run_id={getattr(result, 'id', '')} "
+            f"result={getattr(result, 'result', '')[:500]!r}"
+        )
+
+    branch = ""
+    pr_url = ""
+    git = getattr(result, "git", None)
+    branches = getattr(git, "branches", None) or ()
+    if branches:
+        branch = getattr(branches[0], "branch", "") or ""
+        pr_url = getattr(branches[0], "pr_url", "") or ""
+
+    pr_number = _pr_number_from_url(pr_url)
+    created = bool(pr_number)
+    if not pr_number:
+        linked = _wait_for_linked_pr(repo, issue)
+        if linked:
+            pr_number = int(linked["number"])
+            pr_url = linked.get("html_url") or pr_url
+            branch = linked.get("head", {}).get("ref") or branch
+            created = False
+        else:
+            raise GitHubError(
+                "Cursor run finished but no PR was found. "
+                f"agent_id={getattr(result, 'agent_id', '')} "
+                f"run_id={getattr(result, 'id', '')} "
+                f"git={git!r}"
+            )
+
+    # Ensure issue linkage for Gate / Reviewer if Cursor omitted Closes.
+    try:
+        pr = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}")
+        pr_body = pr.get("body") or ""
+        if f"#{issue}" not in pr_body:
+            api(
+                "PATCH",
+                f"/repos/{owner}/{name}/pulls/{pr_number}",
+                body={
+                    "body": (
+                        f"Closes #{issue}\n\n{pr_body}".strip()
+                        + "\n\n### Codegen\n"
+                        f"- provider: `cursor`\n"
+                        f"- model: `{model}`\n"
+                        f"- agent_id: `{getattr(result, 'agent_id', '')}`\n"
+                        f"- run_id: `{getattr(result, 'id', '')}`\n"
+                    )
+                },
+            )
+    except Exception:
+        pass
+
+    comment = (
+        "### builder_result\n"
+        "- kind: `cursor`\n"
+        f"- model: `{model}`\n"
+        f"- agent_id: `{getattr(result, 'agent_id', agent_id or '')}`\n"
+        f"- run_id: `{getattr(result, 'id', run_id or '')}`\n"
+        f"- branch: `{branch or 'unknown'}`\n"
+        f"- pr: #{pr_number}\n"
+        f"- pr_url: {pr_url or '(none)'}\n"
+        f"- created_pr: `{str(created).lower()}`\n"
+        f"- summary: {(getattr(result, 'result', '') or '')[:500]}\n"
+    )
+    post_issue_comment(repo, issue, comment)
+    return {
+        "provider": "cursor",
+        "model": model,
+        "ui_design": False,
+        "branch": branch,
+        "pr": pr_number,
+        "files": [],
+        "created_pr": created,
+        "agent_id": getattr(result, "agent_id", ""),
+        "run_id": getattr(result, "id", ""),
+    }

--- a/scripts/codegen_models.py
+++ b/scripts/codegen_models.py
@@ -224,9 +224,11 @@ def chat_completion_openai(*, model: str, system: str, user: str) -> str:
 def chat_completion(*, provider: str, model: str, system: str, user: str) -> str:
     if provider == "openai":
         return chat_completion_openai(model=model, system=system, user=user)
+    if provider == "cursor":
+        raise GitHubError("cursor provider uses build_with_cursor, not chat_completion")
     if provider == "gemini":
         raise GitHubError(
-            "Gemini is retired for this repo; set OPENAI_API_KEY / CODEGEN_PROVIDER=openai"
+            "Gemini is retired for this repo; set CURSOR_API_KEY / CODEGEN_PROVIDER=cursor"
         )
     return chat_completion_github(model=model, system=system, user=user)
 
@@ -387,36 +389,55 @@ def json_system_prompt(*, ui: bool) -> str:
     )
 
 
+def cursor_api_key() -> str | None:
+    value = os.environ.get("CURSOR_API_KEY")
+    return value.strip() if value and value.strip() else None
+
+
 def select_provider(title: str, body: str) -> tuple[str, str]:
     """Return (provider, model).
 
-    Policy (Gemini retired):
-    - CODEGEN_PROVIDER force: openai|chatgpt|github-models|models
-    - Else OpenAI when OPENAI_API_KEY is set (required for product work)
-    - Else GitHub Models only as last-resort backup
+    Policy:
+    - CODEGEN_PROVIDER force: cursor|openai|chatgpt|github-models|models
+    - Else Cursor when CURSOR_API_KEY is set (preferred for coding)
+    - Else OpenAI when OPENAI_API_KEY is set
+    - Else GitHub Models last-resort backup
     """
-    del title, body  # selection no longer depends on UI vs non-UI for Gemini
+    del title, body
     force = (os.environ.get("CODEGEN_PROVIDER") or "").strip().lower()
+    if force in {"cursor", "cursor-sdk", "composer"}:
+        return "cursor", os.environ.get("CURSOR_MODEL") or "composer-2.5"
     if force in {"openai", "chatgpt"}:
         return "openai", os.environ.get("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
     if force in {"github-models", "models"}:
         return "github-models", os.environ.get("GITHUB_MODELS_MODEL") or DEFAULT_MODEL
     if force == "gemini":
         raise GitHubError(
-            "CODEGEN_PROVIDER=gemini is retired; use openai (OPENAI_API_KEY)"
+            "CODEGEN_PROVIDER=gemini is retired; use cursor or openai"
         )
 
+    if cursor_api_key():
+        return "cursor", os.environ.get("CURSOR_MODEL") or "composer-2.5"
     if openai_api_key():
         return "openai", os.environ.get("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
     return "github-models", os.environ.get("GITHUB_MODELS_MODEL") or DEFAULT_MODEL
 
 
 def _other_provider(provider: str) -> tuple[str, str]:
-    """Backup: OpenAI ↔ GitHub Models only (no Gemini)."""
+    """Backup chain: cursor → openai → github-models (and reverse)."""
     openai_model = os.environ.get("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
     models_model = os.environ.get("GITHUB_MODELS_MODEL") or DEFAULT_MODEL
-    if provider == "openai":
+    cursor_model = os.environ.get("CURSOR_MODEL") or "composer-2.5"
+    if provider == "cursor":
+        if openai_api_key():
+            return "openai", openai_model
         return "github-models", models_model
+    if provider == "openai":
+        if cursor_api_key():
+            return "cursor", cursor_model
+        return "github-models", models_model
+    if cursor_api_key():
+        return "cursor", cursor_model
     return "openai", openai_model
 
 
@@ -431,15 +452,23 @@ def build_with_models(
 ) -> dict[str, Any]:
     root = cwd or Path.cwd()
     ui = is_ui_design_issue(title, body)
-    if not openai_api_key() and (os.environ.get("CODEGEN_PROVIDER") or "").strip().lower() not in {
-        "github-models",
-        "models",
-    }:
-        raise GitHubError(
-            "OPENAI_API_KEY is required for Builder codegen (Gemini retired). "
-            "Set the secret or force CODEGEN_PROVIDER=github-models."
-        )
     provider, model = select_provider(title, body)
+    if provider == "cursor":
+        from codegen_cursor import build_with_cursor
+
+        return build_with_cursor(
+            repo, issue, title=title, body=body, brief=brief
+        )
+    force = (os.environ.get("CODEGEN_PROVIDER") or "").strip().lower()
+    if (
+        provider == "openai"
+        and not openai_api_key()
+        and force not in {"github-models", "models"}
+    ):
+        raise GitHubError(
+            "OPENAI_API_KEY missing. Prefer CURSOR_API_KEY / CODEGEN_PROVIDER=cursor, "
+            "or set OPENAI_API_KEY, or force CODEGEN_PROVIDER=github-models."
+        )
     brief_text = brief.read_text(encoding="utf-8") if brief.is_file() else ""
     owner, name = split_repo(repo)
     default = api("GET", f"/repos/{owner}/{name}").get("default_branch") or "main"
@@ -476,10 +505,19 @@ def build_with_models(
         raw = chat_completion(provider=provider, model=model, system=system, user=user)
     except Exception as primary_exc:
         alt_provider, alt_model = _other_provider(provider)
+        if alt_provider == "cursor" and cursor_api_key():
+            from codegen_cursor import build_with_cursor
+
+            result = build_with_cursor(
+                repo, issue, title=title, body=body, brief=brief
+            )
+            result["note"] = f"{provider}_failed: {primary_exc}; used_cursor"
+            return result
         if alt_provider == "openai" and not openai_api_key():
             raise GitHubError(
                 f"{provider} failed: {primary_exc}\n"
-                "OpenAI backup unavailable (missing OPENAI_API_KEY)."
+                "OpenAI backup unavailable (missing OPENAI_API_KEY). "
+                "Set CURSOR_API_KEY for Cursor SDK codegen."
             ) from primary_exc
         try:
             raw = chat_completion(

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -392,10 +392,11 @@ def role_builder(repo: str, issue: int, brief: Path) -> None:
             repo,
             issue,
             (
-                "Codegen failed (OpenAI / GitHub Models).\n\n"
+                "Codegen failed (Cursor SDK / OpenAI / GitHub Models).\n\n"
                 f"`{exc}`\n\n"
-                "Required: ChatGPT via `OPENAI_API_KEY` (`CODEGEN_PROVIDER=openai`). "
-                "Optional backup: GitHub Models (`MODELS_TOKEN`). Gemini is retired. "
+                "Preferred: Cursor cloud agent via `CURSOR_API_KEY` "
+                "(`CODEGEN_PROVIDER=cursor`). "
+                "Optional: OpenAI (`OPENAI_API_KEY`) or GitHub Models (`MODELS_TOKEN`). "
                 "See docs/MODELS.md. "
                 "If `git/refs` returns 403 for the Builder App, grant the App "
                 "`contents: write` on this repository."

--- a/tests/test_codegen_cursor.py
+++ b/tests/test_codegen_cursor.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Unit tests for Cursor SDK codegen helpers (no live API)."""
+
+from __future__ import annotations
+
+from codegen_cursor import _pr_number_from_url, build_prompt
+
+
+def test_pr_number_from_url() -> None:
+    assert (
+        _pr_number_from_url("https://github.com/org/repo/pull/42") == 42
+    )
+    assert _pr_number_from_url("") is None
+
+
+def test_build_prompt_includes_issue(tmp_path) -> None:
+    brief = tmp_path / "builder.md"
+    brief.write_text("Be minimal.\n", encoding="utf-8")
+    text = build_prompt(
+        repo="saberistic-team/agent-web",
+        issue=42,
+        title="User flow",
+        body="Parent: #41\nDo the flow.",
+        brief=brief,
+    )
+    assert "#42" in text
+    assert "Closes #42" in text
+    assert "User flow" in text
+    assert "Be minimal." in text

--- a/tests/test_codegen_provider.py
+++ b/tests/test_codegen_provider.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import os
 
 import pytest
 
@@ -25,7 +24,17 @@ def test_validate_plan_accepts_unpadded_content_b64() -> None:
     assert files == [{"path": "site/about.html", "content": text}]
 
 
-def test_select_provider_prefers_openai_when_key_set(monkeypatch) -> None:
+def test_select_provider_prefers_cursor_when_key_set(monkeypatch) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "cursor_test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("CODEGEN_PROVIDER", raising=False)
+    provider, model = select_provider("About page", "landing CTA")
+    assert provider == "cursor"
+    assert "composer" in model
+
+
+def test_select_provider_prefers_openai_without_cursor(monkeypatch) -> None:
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.delenv("CODEGEN_PROVIDER", raising=False)
     provider, model = select_provider("About page", "landing CTA")
@@ -35,9 +44,18 @@ def test_select_provider_prefers_openai_when_key_set(monkeypatch) -> None:
 
 def test_select_provider_force_openai(monkeypatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
     monkeypatch.setenv("CODEGEN_PROVIDER", "chatgpt")
     provider, _model = select_provider("any", "any")
     assert provider == "openai"
+
+
+def test_select_provider_force_cursor(monkeypatch) -> None:
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    monkeypatch.setenv("CODEGEN_PROVIDER", "cursor")
+    provider, model = select_provider("any", "any")
+    assert provider == "cursor"
+    assert "composer" in model
 
 
 def test_select_provider_gemini_force_raises(monkeypatch) -> None:
@@ -46,8 +64,9 @@ def test_select_provider_gemini_force_raises(monkeypatch) -> None:
         select_provider("any", "any")
 
 
-def test_select_provider_without_openai_uses_models(monkeypatch) -> None:
+def test_select_provider_without_keys_uses_models(monkeypatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
     monkeypatch.delenv("CODEGEN_PROVIDER", raising=False)
     provider, _model = select_provider("Landing hero CTA", "update landing")
     assert provider == "github-models"


### PR DESCRIPTION
## Summary
- Prefer **Cursor Agent SDK** cloud agents (`CURSOR_API_KEY`, `composer-2.5`, `auto_create_pr`) for Builder product coding
- Keep OpenAI / GitHub Models as optional backups after OpenAI rate limits
- Install `requirements-agents.txt` in Builder workflow; raise timeout to 90m
- Docs + provider selection + acceptance evidence for `kind: cursor`

## Setup required before requeue
1. Add repo secret `CURSOR_API_KEY` from [Cursor Integrations](https://cursor.com/dashboard/integrations) (or team service account)
2. Set variable `CODEGEN_PROVIDER=cursor`
3. Ensure the Cursor account can open PRs on this repo

## Test plan
- [x] unit tests for provider selection + cursor prompt helpers
- [ ] After secret is set: requeue #42/#43/#44 and confirm `kind: cursor` builder_result


Made with [Cursor](https://cursor.com)