### PR TITLE
Fix Reviewer to use main Cursor stack (not PR tree)

### DIFF
--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -15,9 +15,10 @@ jobs:
       checks: read
       models: read
     steps:
-      - name: Checkout
+      - name: Checkout main (agent scripts + Cursor review stack)
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Mint Reviewer App token
@@ -44,7 +45,8 @@ jobs:
           pip install playwright==1.49.1
           python -m playwright install --with-deps chromium
 
-      - name: Checkout linked PR head
+      - name: Checkout linked PR head into pr-head/
+        id: prhead
         env:
           GH_TOKEN: ${{ steps.reviewer.outputs.token }}
         run: |
@@ -53,14 +55,19 @@ jobs:
           PR="$(gh pr list --repo "${{ github.repository }}" --state open --json number,title,body,headRefName,headRefOid \
             --jq "[.[] | select((.title|contains(\"#${ISSUE}\")) or (.body|contains(\"#${ISSUE}\")) or (.body|test(\"Closes #${ISSUE}\";\"i\")))] | .[0]")"
           if [[ -z "${PR}" || "${PR}" == "null" ]]; then
-            echo "No open PR linked to #${ISSUE}; reviewing against default checkout."
+            echo "No open PR linked to #${ISSUE}."
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           REF="$(echo "${PR}" | jq -r .headRefName)"
           SHA="$(echo "${PR}" | jq -r .headRefOid)"
-          echo "Checking out PR head ${REF} @ ${SHA}"
+          echo "Fetching PR head ${REF} @ ${SHA} into pr-head/"
+          rm -rf pr-head
           git fetch origin "${REF}"
-          git checkout --force "${SHA}"
+          git worktree add --detach pr-head "${SHA}"
+          echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
 
       - name: Run reviewer agent
         env:
@@ -77,6 +84,8 @@ jobs:
           SCREENSHOTS_REQUIRED: ${{ vars.SCREENSHOTS_REQUIRED }}
           COVERAGE_UNIT_MIN: ${{ vars.COVERAGE_UNIT_MIN }}
           COVERAGE_INTEGRATION_MIN: ${{ vars.COVERAGE_INTEGRATION_MIN }}
+          # Coverage measures the PR tree; agent scripts stay on main.
+          COVERAGE_ROOT: ${{ github.workspace }}/pr-head
         run: |
           python scripts/run_agent.py \
             --role reviewer \

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -15,7 +15,13 @@ from pathlib import Path
 
 DEFAULT_UNIT_MIN = 90.0
 DEFAULT_INTEGRATION_MIN = 70.0
-ROOT = Path(__file__).resolve().parent.parent
+
+
+def _root() -> Path:
+    override = (os.environ.get("COVERAGE_ROOT") or "").strip()
+    if override:
+        return Path(override).resolve()
+    return Path(__file__).resolve().parent.parent
 
 
 def _env_float(name: str, default: float) -> float:
@@ -25,14 +31,20 @@ def _env_float(name: str, default: float) -> float:
     return float(raw)
 
 
-def _run(cmd: list[str]) -> int:
-    print("+", " ".join(cmd), flush=True)
-    proc = subprocess.run(cmd, cwd=ROOT)
+def _run(cmd: list[str], *, cwd: Path) -> int:
+    print("+", " ".join(cmd), f"(cwd={cwd})", flush=True)
+    proc = subprocess.run(cmd, cwd=cwd)
     return int(proc.returncode)
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Repo root to measure (default: COVERAGE_ROOT or this repo)",
+    )
     parser.add_argument(
         "--unit-min",
         type=float,
@@ -44,6 +56,10 @@ def main(argv: list[str] | None = None) -> int:
         default=_env_float("COVERAGE_INTEGRATION_MIN", DEFAULT_INTEGRATION_MIN),
     )
     args = parser.parse_args(argv)
+    root = (args.root or _root()).resolve()
+    if not (root / "app").is_dir():
+        print(f"FAIL: no app/ under {root}", file=sys.stderr)
+        return 1
 
     py = sys.executable
     unit_rc = _run(
@@ -58,9 +74,9 @@ def main(argv: list[str] | None = None) -> int:
             "--cov-branch",
             "--cov-report=term-missing",
             f"--cov-fail-under={args.unit_min:g}",
-        ]
+        ],
+        cwd=root,
     )
-    # Fresh coverage for the integration suite (do not merge with unit).
     integration_rc = _run(
         [
             py,
@@ -73,25 +89,26 @@ def main(argv: list[str] | None = None) -> int:
             "--cov-branch",
             "--cov-report=term-missing",
             f"--cov-fail-under={args.integration_min:g}",
-        ]
+        ],
+        cwd=root,
     )
 
     if unit_rc != 0:
         print(
             f"FAIL: unit coverage of app/ is below {args.unit_min:g}% "
-            "(or unit tests failed).",
+            f"(or unit tests failed) under {root}.",
             file=sys.stderr,
         )
     if integration_rc != 0:
         print(
             f"FAIL: integration coverage of app/ is below {args.integration_min:g}% "
-            "(or integration tests failed).",
+            f"(or integration tests failed) under {root}.",
             file=sys.stderr,
         )
     if unit_rc == 0 and integration_rc == 0:
         print(
             f"OK: unit>={args.unit_min:g}% and integration>={args.integration_min:g}% "
-            "on app/"
+            f"on app/ ({root})"
         )
         return 0
     return 1

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -570,10 +570,14 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
                 "service coverage check failed "
                 "(unit ≥90% / integration ≥70% of app/ required)"
             )
-    if app_touched or Path("app").is_dir():
+    if app_touched:
+        cov_root = (os.environ.get("COVERAGE_ROOT") or "").strip()
+        cov_cmd = [sys.executable, "scripts/check_coverage.py"]
+        if cov_root:
+            cov_cmd.extend(["--root", cov_root])
         try:
             cov = subprocess.run(
-                [sys.executable, "scripts/check_coverage.py"],
+                cov_cmd,
                 capture_output=True,
                 text=True,
                 check=False,
@@ -594,7 +598,7 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
             hard_fail_reasons.append(f"service coverage check failed to run: {exc}")
             coverage_note = f"- coverage: failed (`{exc}`)\n"
     else:
-        coverage_note = "- coverage: skipped (no app/ service changes)\n"
+        coverage_note = "- coverage: skipped (PR does not touch app/*.py)\n"
 
     # Pre-merge deploy screenshots (baseline before approve/merge)
     screenshot_note = ""


### PR DESCRIPTION
## Summary
- Reviewer was checking out the PR head for the whole job, so old PRs ran pre-Cursor \`review_models.py\` → OpenAI 429
- Now: checkout **main** for agent scripts; PR head only in \`pr-head/\` for coverage via \`COVERAGE_ROOT\`
- Coverage hard-fail only when the PR touches \`app/*.py\`

## Test plan
- [ ] Merge, requeue #42/#44, confirm AI provider is Cursor and #44 can approve without coverage


Made with [Cursor](https://cursor.com)