### PR TITLE
fix(agents): Planner/Reviewer lessons from #55/#58

### DIFF
--- a/AGENTS/planner.md
+++ b/AGENTS/planner.md
@@ -7,10 +7,14 @@ to move work out of that state.
 
 You turn intake into routed work:
 
-- Keep a **single issue** when there is one independent change area.
-- **Spawn child issues** when there are **more than one independent change
-  areas**. Target granularity: **each child should be completable in one
-  commit**.
+- Keep a **single issue** when there is one independent change area (default).
+- **Spawn child issues** only for **true independent work packages**.
+  Target granularity: **each child should be completable in one commit**.
+
+Prefer an explicit `## Work packages` (or `Change areas` / `Children`) bullet
+list on the parent. Do **not** spawn children from narrative headings such as
+Summary, Current/Desired behavior, Implementation hints, User flow, Requirements,
+or Acceptance criteria (learned from [#55](https://github.com/saberistic-team/agent-web/issues/55)).
 
 Before any issue enters `status:queued`, it must already carry:
 
@@ -20,8 +24,10 @@ Before any issue enters `status:queued`, it must already carry:
 
 If you spawn children, write their numbers (one per line) to
 `trace/planner-<parent>-children.txt`, and ensure each child already has
-`agent:*`, `type:*`, and `status:queued`. The parent is then marked done by
-the workflow.
+`agent:*`, `type:*`, and `status:queued`. Each child body must include the
+parent’s `## Acceptance criteria` (or a minimal checkbox linking back to the
+parent) so Reviewer can verify without re-planning. The parent is then marked
+done by the workflow.
 
 ## Definition of done
 

--- a/AGENTS/reviewer.md
+++ b/AGENTS/reviewer.md
@@ -49,6 +49,14 @@ Any of these is an automatic request-changes — do not approve:
 
 Document in the PR review body. Nits alone → approve with comments.
 
+Do **not** request changes solely for:
+
+- files under `.agent/screenshots/` (Reviewer evidence; allowed)
+- noisy or file-by-file commit history (Gate squash-merges to `main`)
+- wording/style nits when acceptance criteria are met
+
+(`scripts/review_models.py` enforces this; learned from [#58](https://github.com/saberistic-team/agent-web/issues/58).)
+
 ## Constraints
 
 - Review via GitHub PR review APIs — do not “approve” only by issue comment.

--- a/scripts/review_models.py
+++ b/scripts/review_models.py
@@ -355,41 +355,61 @@ def ai_review(repo: str, issue: int, pr_number: int) -> dict[str, Any]:
         '  "summary": "string"\n'
         "}\n"
         "Approve ONLY if the PR clearly implements the issue acceptance criteria.\n"
-        "Request changes if the PR is a no-op, scaffold sync, unrelated files, "
+        "Request changes if the PR is a no-op, scaffold sync, product-unrelated files, "
         "or leaves acceptance criteria unmet.\n"
+        "Do NOT request changes solely for:\n"
+        "- files under `.agent/screenshots/` (allowed Reviewer evidence)\n"
+        "- noisy/file-by-file commit history (gate squash-merges to main)\n"
+        "- wording/style nits when acceptance criteria are met\n"
+        "If acceptance criteria are met, set decision=approved and meets_acceptance=true.\n"
         "Be concrete in reasons.\n"
     )
     user = json.dumps(ctx, indent=2)
     raw, model = chat(system, user, model=model)
     data = extract_json(raw)
     decision = str(data.get("decision") or "").lower().replace("_", "-")
+    meets = bool(data.get("meets_acceptance"))
     if decision not in {"approved", "changes-requested"}:
-        meets = bool(data.get("meets_acceptance"))
         decision = "approved" if meets else "changes-requested"
     reasons = data.get("reasons") or []
     if not isinstance(reasons, list):
         reasons = [str(reasons)]
+    # Drop nit reasons that must not block when acceptance is met (#58).
+    nit_re = re.compile(
+        r"screenshot|\.agent/screenshots|commit history|squash|nit\b|wording|style",
+        re.I,
+    )
     issue_blob = f"{ctx.get('issue_title')}\n{ctx.get('issue_body')}".lower()
     infra_issue = bool(
         re.search(r"screenshot|headless|playwright|visual (check|evidence)", issue_blob)
     )
     if looks_like_scaffold_sync(ctx) and not infra_issue:
         decision = "changes-requested"
+        meets = False
         reasons = [
             "PR looks like Builder scaffold sync (sync commits / boilerplate body), "
             "not an implementation of the issue"
         ] + [str(r) for r in reasons]
     elif looks_like_scaffold_sync(ctx) and infra_issue:
         decision = "approved"
+        meets = True
         reasons = [
             "Infra/screenshot issue: docs sync acceptable when screenshot scripts "
             "already live on main"
         ] + [str(r) for r in reasons]
+    elif meets and decision == "changes-requested":
+        # Acceptance met + only nits → approve (learned from #58 review loop).
+        non_nits = [str(r) for r in reasons if not nit_re.search(str(r))]
+        if not non_nits:
+            decision = "approved"
+            reasons = ["Acceptance criteria met; remaining notes are nits only"] + [
+                str(r) for r in reasons
+            ]
+        else:
+            reasons = non_nits
     return {
         "decision": decision,
-        "meets_acceptance": bool(data.get("meets_acceptance"))
-        if decision == "approved"
-        else False,
+        "meets_acceptance": True if decision == "approved" else False,
         "reasons": [str(r) for r in reasons][:12],
         "summary": str(data.get("summary") or ""),
         "model": model,

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -119,6 +119,117 @@ def close_linked_open_prs(repo: str, issue: int, reason: str) -> None:
         )
 
 
+# Narrative / meta H2s must never become Planner children (learned from #55).
+PLANNER_SKIP_SECTIONS = {
+    "summary",
+    "goal",
+    "acceptance",
+    "acceptance criteria",
+    "out of scope",
+    "notes",
+    "recommended deploy",
+    "recommended deploy (easiest)",
+    "alternatives",
+    "context",
+    "background",
+    "source",
+    "about",
+    "about (public linkedin facts)",
+    "selected experience",
+    "selected experience (brief)",
+    "design",
+    "constraints",
+    "current behavior",
+    "current behavior (study notes)",
+    "desired behavior",
+    "implementation hints",
+    "implementation notes",
+    "user flow",
+    "requirements",
+    "routes",
+    "environment variables",
+    "local development",
+    "database schema",
+    "tests",
+    "production",
+    "production (render)",
+    "parent context",
+    "study notes",
+    "what was wrong",
+    "follow-up",
+}
+
+
+def extract_acceptance_section(body: str) -> str:
+    """Return the ## Acceptance criteria section (heading + bullets), if any."""
+    match = re.search(
+        r"(?ims)^##\s+Acceptance criteria\s*\n(.*?)(?=^##\s+|\Z)",
+        body or "",
+    )
+    if not match:
+        return ""
+    return f"## Acceptance criteria\n\n{match.group(1).strip()}\n"
+
+
+def child_issue_body(parent_issue: int, area: str, parent_body: str) -> str:
+    """Build a child issue body with scope + parent acceptance criteria."""
+    acceptance = extract_acceptance_section(parent_body)
+    if not acceptance:
+        acceptance = (
+            "## Acceptance criteria\n\n"
+            f"- [ ] Implements scoped change from parent #{parent_issue}\n"
+        )
+    return (
+        f"Child of #{parent_issue} (one-commit unit).\n\n"
+        f"## Scope\n\n{area.strip()}\n\n"
+        f"Parent: #{parent_issue}\n\n"
+        f"{acceptance}"
+    )
+
+
+def plan_change_areas(body: str) -> list[str]:
+    """Choose independent one-commit work areas from an issue body.
+
+    Prefer an explicit ``## Work packages`` (or Change areas / Children) bullet
+    list. Otherwise only treat remaining H2s as areas after skipping narrative
+    sections — never invent children from study notes / desired-behavior prose.
+    """
+    text = body or ""
+    work_pkg = re.search(
+        r"(?ims)^##\s+(Work packages|Change areas|Children|Implementation units)\s*\n"
+        r"(.*?)(?=^##\s+|\Z)",
+        text,
+    )
+    if work_pkg:
+        items = re.findall(
+            r"(?m)^\s*[-*]\s+(?:\[[ xX]\]\s+)?(.+)$",
+            work_pkg.group(2),
+        )
+        areas = [item.strip() for item in items if item.strip()]
+        return areas[:4]
+
+    sections = [
+        s.strip()
+        for s in re.findall(r"(?m)^##\s+(.+)$", text)
+        if s.strip().lower() not in PLANNER_SKIP_SECTIONS
+    ]
+    # Ignore leftover prose headings that are not actionable work packages.
+    actionable = [
+        s
+        for s in sections
+        if re.match(
+            r"(?i)^(add|implement|update|fix|remove|refactor|migrate|wire|docs?)\b",
+            s,
+        )
+        or re.search(r"(?i)\b(api|ui|form|webhook|email|db|schema|test)\b", s)
+    ]
+    if len(actionable) > 1:
+        return actionable[:4]
+
+    # Never treat Acceptance criteria checkboxes as work packages (#55).
+    return []
+
+
 def role_planner(repo: str, issue: int, brief: Path) -> None:
     data = get_issue(repo, issue)
     title = data.get("title") or f"issue-{issue}"
@@ -135,44 +246,7 @@ def role_planner(repo: str, issue: int, brief: Path) -> None:
             type_label = "type:feature"
         ensure_label(repo, issue, type_label)
 
-    # Independent change areas: prefer explicit work-package headings.
-    # Ignore acceptance checklists and meta sections so Planner does not
-    # explode one feature into one child per checkbox.
-    skip_sections = {
-        "summary",
-        "goal",
-        "acceptance",
-        "acceptance criteria",
-        "out of scope",
-        "notes",
-        "recommended deploy",
-        "recommended deploy (easiest)",
-        "alternatives",
-        "context",
-        "background",
-        "source",
-        "about",
-        "about (public linkedin facts)",
-        "selected experience",
-        "selected experience (brief)",
-        "design",
-        "constraints",
-    }
-    sections = [
-        s.strip()
-        for s in re.findall(r"(?m)^##\s+(.+)$", body)
-        if s.strip().lower() not in skip_sections
-    ]
-    # Only treat checklist items as areas when there are no usable sections
-    # and the list is small (real work breakdown, not acceptance criteria).
-    tasks = re.findall(r"(?m)^\s*[-*] \[.\] (.+)$", body)
-    if sections:
-        areas = sections
-    elif 1 < len(tasks) <= 4:
-        areas = tasks
-    else:
-        areas = []
-
+    areas = plan_change_areas(body)
     max_children = 4
     agent_label = "agent:docs" if type_label == "type:docs" else "agent:builder"
 
@@ -186,11 +260,7 @@ def role_planner(repo: str, issue: int, brief: Path) -> None:
                 f"/repos/{owner}/{name}/issues",
                 body={
                     "title": f"{title}: {area.strip()[:80]}",
-                    "body": (
-                        f"Child of #{issue} (one-commit unit).\n\n"
-                        f"## Scope\n\n{area.strip()}\n\n"
-                        f"Parent: #{issue}"
-                    ),
+                    "body": child_issue_body(issue, area, body),
                     "labels": [agent_label, type_label, "status:queued"],
                 },
             )

--- a/tests/test_planner_areas.py
+++ b/tests/test_planner_areas.py
@@ -1,0 +1,106 @@
+"""Planner change-area extraction (no GitHub API)."""
+
+from __future__ import annotations
+
+from run_agent import (
+    child_issue_body,
+    extract_acceptance_section,
+    plan_change_areas,
+)
+
+ISSUE_55_STYLE = """
+## Summary
+
+Ship email-on-submit.
+
+## Current behavior (study notes)
+
+Emails only after Stripe pay.
+
+## Desired behavior
+
+Email on submit regardless of payment.
+
+## Out of scope
+
+Admin UI.
+
+## Implementation hints
+
+| Area | Files |
+|------|--------|
+| Submit | app/main.py |
+
+## Acceptance criteria
+
+- [ ] Email only contact
+- [ ] Lead email on submit
+"""
+
+
+def test_plan_change_areas_keeps_narrative_issue_single() -> None:
+    assert plan_change_areas(ISSUE_55_STYLE) == []
+
+
+def test_plan_change_areas_uses_work_packages_bullets() -> None:
+    body = """
+## Summary
+
+Parent feature.
+
+## Work packages
+
+- Add submit-time Resend lead emails
+- Remove phone contact from form/API
+- Update PROJECT_BRIEF docs
+
+## Acceptance criteria
+
+- [ ] Done
+"""
+    areas = plan_change_areas(body)
+    assert areas == [
+        "Add submit-time Resend lead emails",
+        "Remove phone contact from form/API",
+        "Update PROJECT_BRIEF docs",
+    ]
+
+
+def test_plan_change_areas_actionable_h2s() -> None:
+    body = """
+## Summary
+
+Multi-area feature.
+
+## Add Resend lead emails on submit
+
+Wire create_brief.
+
+## Remove phone contact option
+
+UI + API.
+
+## Acceptance criteria
+
+- [ ] Both done
+"""
+    areas = plan_change_areas(body)
+    assert areas == [
+        "Add Resend lead emails on submit",
+        "Remove phone contact option",
+    ]
+
+
+def test_child_issue_body_copies_acceptance_criteria() -> None:
+    body = child_issue_body(55, "Remove phone", ISSUE_55_STYLE)
+    assert "Child of #55" in body
+    assert "## Scope" in body
+    assert "Remove phone" in body
+    assert "## Acceptance criteria" in body
+    assert "Email only contact" in body
+    assert extract_acceptance_section(ISSUE_55_STYLE).startswith("## Acceptance criteria")
+
+
+def test_child_issue_body_fallback_when_no_acceptance() -> None:
+    body = child_issue_body(9, "Wire webhook", "## Summary\n\nNo AC here.\n")
+    assert "Implements scoped change from parent #9" in body

--- a/tests/test_review_models.py
+++ b/tests/test_review_models.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from review_models import extract_json
+from unittest.mock import patch
+
+from review_models import ai_review, extract_json
 
 
 def test_extract_json_recovers_truncated_approved() -> None:
@@ -23,3 +25,47 @@ def test_extract_json_full_object() -> None:
     data = extract_json(raw)
     assert data["decision"] == "changes-requested"
     assert data["meets_acceptance"] is False
+
+
+def test_ai_review_approves_when_acceptance_met_despite_screenshot_nits() -> None:
+    """#58: AI requested changes for .agent/screenshots + history while AC met."""
+    fake_ctx = {
+        "issue_title": "Brief form emails",
+        "issue_body": "## Acceptance criteria\n\n- [ ] Email on submit\n",
+        "pr_title": "builder: implement",
+        "pr_body": "Closes #58",
+        "commit_messages": ["builder(#58): implement", "review: record pre-home.png"],
+        "files": [{"path": "app/main.py", "patch": "+notify"}],
+    }
+    raw = (
+        '{"decision":"changes-requested","meets_acceptance":true,'
+        '"reasons":["Adds unrelated .agent/screenshots/pr-60/pre-home.png",'
+        '"Commit history should be squashed"],'
+        '"summary":"AC met but nits"}'
+    )
+    with patch("review_models.collect_pr_context", return_value=fake_ctx):
+        with patch("review_models.chat", return_value=(raw, "test-model")):
+            verdict = ai_review("o/r", 58, 60)
+    assert verdict["decision"] == "approved"
+    assert verdict["meets_acceptance"] is True
+
+
+def test_ai_review_keeps_changes_when_real_reason_and_acceptance_claimed() -> None:
+    fake_ctx = {
+        "issue_title": "Brief form emails",
+        "issue_body": "## Acceptance criteria\n\n- [ ] Email on submit\n",
+        "pr_title": "builder: implement",
+        "pr_body": "Closes #58",
+        "commit_messages": ["builder(#58): implement"],
+        "files": [{"path": "app/main.py", "patch": "+notify"}],
+    }
+    raw = (
+        '{"decision":"changes-requested","meets_acceptance":true,'
+        '"reasons":["Lead emails only run after Stripe succeeds; 502 skips inbox"],'
+        '"summary":"real gap"}'
+    )
+    with patch("review_models.collect_pr_context", return_value=fake_ctx):
+        with patch("review_models.chat", return_value=(raw, "test-model")):
+            verdict = ai_review("o/r", 58, 60)
+    assert verdict["decision"] == "changes-requested"
+    assert verdict["meets_acceptance"] is False


### PR DESCRIPTION
## Summary
- **Planner** (`scripts/run_agent.py`, `AGENTS/planner.md`): do not split issues on narrative headings (Current/Desired behavior, Implementation hints, …); prefer explicit `## Work packages`; copy parent acceptance criteria onto children.
- **Reviewer** (`scripts/review_models.py`, `AGENTS/reviewer.md`): if acceptance is met, do not hard-fail on `.agent/screenshots/` or commit-history nits (learned from #58 review loop / human merge override).

Follow-up to closed [#55](https://github.com/saberistic-team/agent-web/issues/55) / [#58](https://github.com/saberistic-team/agent-web/issues/58).

## Test plan
- [x] `pytest tests/test_planner_areas.py tests/test_review_models.py -q`
- [ ] Confirm a #55-shaped issue body plans as **single** (no children)
- [ ] Confirm `## Work packages` bullets still spawn children with AC copied


Made with [Cursor](https://cursor.com)