### PR TITLE
Prefer Cursor SDK for post-deploy visual checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install Playwright
+      - name: Install Playwright + agent deps
         run: |
           pip install playwright==1.49.1
           python -m playwright install --with-deps chromium
+          pip install -r requirements-agents.txt
       - name: Mint Builder token for uploads/comments
         id: builder
         uses: actions/create-github-app-token@v2
@@ -82,8 +83,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.builder.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          CURSOR_MODEL: ${{ vars.CURSOR_MODEL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+          VISUAL_PROVIDER: ${{ vars.VISUAL_PROVIDER }}
           DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL }}
         run: |
           set -euo pipefail

--- a/docs/IDENTITIES.md
+++ b/docs/IDENTITIES.md
@@ -50,8 +50,9 @@ Unrelated org install (not part of the agent loop): `digitalocean` (installation
 
 Builder also uses:
 
-- Secret `CURSOR_API_KEY` for Builder cloud coding ([MODELS.md](MODELS.md))
-- Optional `OPENAI_API_KEY` for Reviewer/acceptance/post-deploy AI + codegen backup
+- Secret `CURSOR_API_KEY` for Builder coding + Reviewer + post-deploy visual
+  ([MODELS.md](MODELS.md))
+- Optional `OPENAI_API_KEY` backup for review / acceptance / visual / codegen
 - Optional `MODELS_TOKEN` for GitHub Models backup
 - Builder App must keep `contents: write` so `git/refs` branch creation works
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,8 +1,8 @@
-# Builder / Reviewer model providers
+# Builder / Reviewer / visual model providers
 
-**Builder codegen** and **Reviewer AI** (PR review + acceptance) prefer the
-**Cursor Agent SDK** when `CURSOR_API_KEY` is set. OpenAI and GitHub Models are
-backups (OpenAI quota is often exhausted).
+**Builder codegen**, **Reviewer AI** (PR review + acceptance), and
+**post-deploy visual** prefer the **Cursor Agent SDK** when `CURSOR_API_KEY`
+is set. OpenAI and GitHub Models are backups (OpenAI quota is often exhausted).
 
 ## Builder flow
 
@@ -20,12 +20,19 @@ backups (OpenAI quota is often exhausted).
 3. Acceptance AI uses the same `chat()` stack
 4. Force with `REVIEW_PROVIDER=cursor|openai|github-models`
 
+## Post-deploy visual flow
+
+1. CI `post-deploy-visual` after Render deploy
+2. `scripts/post_deploy_visual.py` → Cursor (`mode=plan`, read local PNGs) →
+   OpenAI vision backup
+3. Force with `VISUAL_PROVIDER=cursor|openai`
+
 ## Auth
 
 | Token | Purpose |
 |-------|---------|
 | Builder / Reviewer App tokens | Comments, labels, commits, PRs, reviews |
-| `CURSOR_API_KEY` | **Preferred** Cursor SDK for Builder + Reviewer |
+| `CURSOR_API_KEY` | **Preferred** Cursor SDK for Builder + Reviewer + visual |
 | `OPENAI_API_KEY` | Optional backup for review / acceptance / visual |
 | `MODELS_TOKEN` (optional) | GitHub Models last-resort backup |
 
@@ -35,6 +42,7 @@ backups (OpenAI quota is often exhausted).
 |----------|---------|
 | `CODEGEN_PROVIDER` | unset → Cursor if key present, else OpenAI, else Models |
 | `REVIEW_PROVIDER` | unset → Cursor if key present, else OpenAI, else Models |
+| `VISUAL_PROVIDER` | unset → Cursor if key present, else OpenAI |
 | `CURSOR_MODEL` | `composer-2.5` |
 | `CURSOR_RUNTIME` | `local` in Actions (Builder) |
 | `OPENAI_MODEL` | `gpt-4o-mini` |
@@ -44,7 +52,8 @@ backups (OpenAI quota is often exhausted).
 
 1. Create a Cursor API key (user or team service account)
 2. Repo secret: `CURSOR_API_KEY`
-3. Repo variables: `CODEGEN_PROVIDER=cursor`, optionally `REVIEW_PROVIDER=cursor`
+3. Repo variables: `CODEGEN_PROVIDER=cursor`, optionally `REVIEW_PROVIDER=cursor`,
+   `VISUAL_PROVIDER=cursor`
 4. Optional: `CURSOR_MODEL=composer-2.5`, `CURSOR_RUNTIME=local`
 5. For Builder **cloud** only: connect GitHub so Cursor can clone/open PRs
 

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -12,7 +12,7 @@ When `agent:reviewer` runs on an open PR (workflow installs Playwright):
    (cold-start retries)
 2. Files land under `.agent/screenshots/pr-<n>/pre-*.png` on the PR branch
 3. Comments `### reviewer_screenshots_pre` on the **PR and linked issue**
-4. AI review (OpenAI when `OPENAI_API_KEY` is set) runs
+4. AI review (Cursor preferred when `CURSOR_API_KEY` is set) runs
 5. Approve only if acceptance is met **and** screenshots posted
 
 Fail closed if the deploy URL is unreachable after retries.
@@ -30,8 +30,9 @@ CI `post-deploy-visual` job (after Render deploy hook):
    from PRs linked to the commit SHA
 4. Comments `### deploy_visual_check` on that issue (uploads under
    `.agent/screenshots/issue-<n>/post/`) including the `/health` JSON
-5. Includes pre shots when available and asks **OpenAI** (vision) whether the
-   issue change is visually visible vs pre-merge
+5. Includes pre shots when available and asks **Cursor** (preferred) or
+   **OpenAI** vision backup whether the issue change is visually visible vs
+   pre-merge
 6. Labels `@human-review` / escalates if visual check fails
 
 If no issue can be resolved, screenshots still upload under
@@ -46,13 +47,16 @@ gets the before/after pair.
 |------|------|---------|
 | `DEPLOY_BASE_URL` | variable | default `https://saberistic.com` (empty var ignored) |
 | `SCREENSHOTS_REQUIRED` | variable | default true for Reviewer |
-| `OPENAI_API_KEY` | secret | AI review + post-deploy visual + Builder codegen |
+| `CURSOR_API_KEY` | secret | **Preferred** post-deploy visual + Reviewer/Builder |
+| `CURSOR_MODEL` | variable | default `composer-2.5` |
+| `VISUAL_PROVIDER` | variable | unset → Cursor then OpenAI; force `cursor` / `openai` |
+| `OPENAI_API_KEY` | secret | Optional backup for visual / review / codegen |
 | `OPENAI_MODEL` | variable | default `gpt-4.1-mini` |
 | `RENDER_DEPLOY_HOOK_URL` | secret | deploy trigger |
 
 ## Scripts / workflows
 
 - `scripts/screenshot_deploy.py` — headless capture + upload + comment
-- `scripts/post_deploy_visual.py` — post-deploy capture + OpenAI vision check
+- `scripts/post_deploy_visual.py` — post-deploy capture + Cursor/OpenAI visual check
 - `.github/workflows/reviewer.yml` — pre-merge Playwright install + capture
 - `.github/workflows/ci.yml` — `post-deploy-visual` job

--- a/scripts/post_deploy_visual.py
+++ b/scripts/post_deploy_visual.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""After deploy: capture post screenshots and ask OpenAI if the issue change is visible."""
+"""After deploy: capture post screenshots and ask Cursor (preferred) / OpenAI
+whether the issue change is visible.
+"""
 
 from __future__ import annotations
 
@@ -22,6 +24,9 @@ from screenshot_deploy import (
     upload_to_branch,
     wait_healthy,
 )
+
+DEFAULT_CURSOR_MODEL = "composer-2.5"
+DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
 
 
 def record_health(
@@ -66,6 +71,11 @@ def record_health(
     if raw_url:
         print(f"deploy_health_url={raw_url}")
     return {"path": f"{prefix}/deploy-health.json", "url": raw_url, "json": json.dumps(slim)}
+
+
+def cursor_api_key() -> str | None:
+    value = os.environ.get("CURSOR_API_KEY")
+    return value.strip() if value and value.strip() else None
 
 
 def openai_key() -> str | None:
@@ -126,22 +136,127 @@ def list_pre_urls(repo: str, ref: str, pr: int | None) -> list[str]:
     return urls
 
 
-def visual_ai_check(
+def _parse_visual_json(text: str, *, model: str, provider: str) -> dict:
+    text = (text or "").strip()
+    fence = re.search(r"```(?:json)?\s*([\s\S]*?)```", text)
+    if fence:
+        text = fence.group(1).strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        start, end = text.find("{"), text.rfind("}")
+        if start < 0 or end <= start:
+            raise GitHubError(f"{provider} visual did not return JSON: {text[:400]!r}")
+        data = json.loads(text[start : end + 1])
+    if not isinstance(data, dict):
+        raise GitHubError(f"{provider} visual JSON root must be object")
+    decision = str(data.get("decision") or "fail").lower()
+    if decision not in {"pass", "fail", "skip"}:
+        decision = "fail"
+    return {
+        "visible": data.get("visible"),
+        "summary": str(data.get("summary") or text[:500]),
+        "decision": decision,
+        "model": model,
+        "provider": provider,
+    }
+
+
+def _visual_prompt(
+    issue_title: str,
+    issue_body: str,
+    pre_paths: list[Path],
+    post_paths: list[Path],
+) -> str:
+    pre_list = "\n".join(f"- {p.resolve()}" for p in pre_paths) or "- (none)"
+    post_list = "\n".join(f"- {p.resolve()}" for p in post_paths) or "- (none)"
+    return (
+        "READ-ONLY VISUAL CHECK. Do not create, edit, delete, or move any files. "
+        "Do not run mutating shell/git commands. Do not open PRs.\n"
+        "Open the screenshot PNG paths below (Read tool) and compare before vs after.\n"
+        "Respond with JSON only (no prose outside JSON):\n"
+        '{"visible": boolean, "summary": "string", "decision": "pass"|"fail"}\n'
+        "pass if the post screenshots clearly show the issue change; "
+        "fail if unchanged or unrelated.\n\n"
+        f"Issue title: {issue_title}\n"
+        f"Issue body:\n{(issue_body or '')[:4000]}\n\n"
+        f"BEFORE screenshot paths:\n{pre_list}\n\n"
+        f"AFTER screenshot paths:\n{post_list}\n"
+    )
+
+
+def visual_ai_check_cursor(
     *,
     issue_title: str,
     issue_body: str,
     pre_paths: list[Path],
     post_paths: list[Path],
 ) -> dict:
-    """Compare before/after screenshots via OpenAI vision (Gemini retired)."""
+    key = cursor_api_key()
+    if not key:
+        raise GitHubError("missing CURSOR_API_KEY")
+    model = os.environ.get("CURSOR_MODEL") or DEFAULT_CURSOR_MODEL
+    try:
+        from cursor_sdk import Agent, AgentOptions, LocalAgentOptions
+    except ImportError as exc:
+        raise GitHubError(
+            "cursor-sdk is not installed; pip install -r requirements-agents.txt"
+        ) from exc
+
+    prompt = _visual_prompt(issue_title, issue_body, pre_paths, post_paths)
+    try:
+        result = Agent.prompt(
+            prompt,
+            AgentOptions(
+                model=model,
+                api_key=key,
+                name="post-deploy-visual",
+                mode="plan",
+                local=LocalAgentOptions(cwd=os.getcwd()),
+            ),
+        )
+    except TypeError:
+        try:
+            result = Agent.prompt(
+                prompt,
+                {
+                    "model": model,
+                    "apiKey": key,
+                    "name": "post-deploy-visual",
+                    "mode": "plan",
+                    "local": {"cwd": os.getcwd()},
+                },
+            )
+        except Exception as exc:
+            raise GitHubError(f"Cursor visual failed: {exc}") from exc
+    except Exception as exc:
+        raise GitHubError(f"Cursor visual failed: {exc}") from exc
+
+    status = getattr(result, "status", None)
+    text = (getattr(result, "result", None) or "").strip()
+    if status != "finished":
+        raise GitHubError(
+            f"Cursor visual run status={status!r} "
+            f"agent_id={getattr(result, 'agent_id', '')} "
+            f"result={text[:400]!r}"
+        )
+    if not text:
+        raise GitHubError("Cursor visual returned empty content")
+    return _parse_visual_json(text, model=model, provider="cursor")
+
+
+def visual_ai_check_openai(
+    *,
+    issue_title: str,
+    issue_body: str,
+    pre_paths: list[Path],
+    post_paths: list[Path],
+) -> dict:
+    """OpenAI vision backup when Cursor is unavailable."""
     key = openai_key()
     if not key:
-        return {
-            "visible": None,
-            "summary": "OPENAI_API_KEY missing; skipped visual AI check",
-            "decision": "skip",
-        }
-    model = os.environ.get("OPENAI_MODEL") or "gpt-4.1-mini"
+        raise GitHubError("missing OPENAI_API_KEY")
+    model = os.environ.get("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
     content: list[dict] = [
         {
             "type": "text",
@@ -192,18 +307,71 @@ def visual_ai_check(
     out_text = ""
     if choices:
         out_text = str((choices[0].get("message") or {}).get("content") or "").strip()
-    try:
-        data = json.loads(out_text)
-    except json.JSONDecodeError:
-        s, e = out_text.find("{"), out_text.rfind("}")
-        data = json.loads(out_text[s : e + 1]) if s >= 0 and e > s else {}
-    return {
-        "visible": data.get("visible"),
-        "summary": str(data.get("summary") or out_text[:500]),
-        "decision": str(data.get("decision") or "fail").lower(),
-        "model": model,
-    }
+    return _parse_visual_json(out_text, model=model, provider="openai")
 
+
+def visual_ai_check(
+    *,
+    issue_title: str,
+    issue_body: str,
+    pre_paths: list[Path],
+    post_paths: list[Path],
+) -> dict:
+    """Compare before/after screenshots: Cursor preferred, OpenAI backup."""
+    force = (os.environ.get("VISUAL_PROVIDER") or "").strip().lower()
+    errors: list[str] = []
+
+    def _try_cursor() -> dict | None:
+        if not cursor_api_key():
+            return None
+        try:
+            return visual_ai_check_cursor(
+                issue_title=issue_title,
+                issue_body=issue_body,
+                pre_paths=pre_paths,
+                post_paths=post_paths,
+            )
+        except Exception as exc:
+            errors.append(f"cursor: {exc}")
+            return None
+
+    def _try_openai() -> dict | None:
+        if not openai_key():
+            return None
+        try:
+            return visual_ai_check_openai(
+                issue_title=issue_title,
+                issue_body=issue_body,
+                pre_paths=pre_paths,
+                post_paths=post_paths,
+            )
+        except Exception as exc:
+            errors.append(f"openai: {exc}")
+            return None
+
+    if force in {"cursor", "cursor-sdk", "composer"}:
+        order = ["cursor", "openai"]
+    elif force in {"openai", "chatgpt"}:
+        order = ["openai", "cursor"]
+    else:
+        order = ["cursor", "openai"]
+
+    for name in order:
+        got = _try_cursor() if name == "cursor" else _try_openai()
+        if got is not None:
+            return got
+
+    if not cursor_api_key() and not openai_key():
+        return {
+            "visible": None,
+            "summary": "CURSOR_API_KEY and OPENAI_API_KEY missing; skipped visual AI check",
+            "decision": "skip",
+            "model": "",
+            "provider": "none",
+        }
+    raise GitHubError(
+        "visual AI check failed: " + " | ".join(errors or ["no providers"])
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -251,8 +419,6 @@ def main(argv: list[str] | None = None) -> int:
         )
 
         if not issue_num:
-            # Still leave a durable comment trail on the commit via Actions summary;
-            # file is already on the default branch under .agent/deploy/<sha>/.
             print(
                 "No issue number in commit message / linked PR; "
                 f"uploaded post screenshots: {post_urls}; {health_line}"
@@ -265,7 +431,6 @@ def main(argv: list[str] | None = None) -> int:
 
         issue = api("GET", f"/repos/{owner}/{name}/issues/{issue_num}")
 
-        # Local pre shots if present from reviewer artifact checkout; else remote URLs only
         pre_files = sorted(Path("trace/screenshots").glob("pre-*.png"))
         pre_urls = list_pre_urls(args.repo, default, args.pr) if not pre_files else []
         if pre_files:
@@ -291,6 +456,7 @@ def main(argv: list[str] | None = None) -> int:
                 "- phase: `post-deploy`",
                 f"- issue: #{issue_num}",
                 health_line,
+                f"- visual_provider: `{visual.get('provider')}`",
                 f"- visual_decision: `{visual.get('decision')}`",
                 f"- visual_visible: `{visual.get('visible')}`",
                 f"- visual_model: `{visual.get('model')}`",
@@ -303,7 +469,6 @@ def main(argv: list[str] | None = None) -> int:
             ) + "\n"
         post_issue_comment(args.repo, issue_num, body)
 
-        # Refresh acceptance checklist with live deploy evidence when possible.
         try:
             from acceptance import (
                 post_checklist,

--- a/tests/test_post_deploy_visual.py
+++ b/tests/test_post_deploy_visual.py
@@ -1,0 +1,122 @@
+"""Unit tests for post-deploy visual provider selection (no live API)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from github_api import GitHubError
+
+from post_deploy_visual import (
+    _parse_visual_json,
+    visual_ai_check,
+)
+
+
+def test_parse_visual_json_fenced() -> None:
+    raw = '```json\n{"visible": true, "summary": "ok", "decision": "pass"}\n```'
+    data = _parse_visual_json(raw, model="m", provider="cursor")
+    assert data["decision"] == "pass"
+    assert data["visible"] is True
+    assert data["provider"] == "cursor"
+
+
+def test_visual_ai_check_skips_without_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("VISUAL_PROVIDER", raising=False)
+    result = visual_ai_check(
+        issue_title="t",
+        issue_body="b",
+        pre_paths=[],
+        post_paths=[],
+    )
+    assert result["decision"] == "skip"
+    assert result["provider"] == "none"
+
+
+def test_visual_ai_check_prefers_cursor(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "ck_test")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("VISUAL_PROVIDER", raising=False)
+    post = tmp_path / "post-home.png"
+    post.write_bytes(b"png")
+    with patch(
+        "post_deploy_visual.visual_ai_check_cursor",
+        return_value={
+            "visible": True,
+            "summary": "seen",
+            "decision": "pass",
+            "model": "composer-2.5",
+            "provider": "cursor",
+        },
+    ) as cursor:
+        with patch("post_deploy_visual.visual_ai_check_openai") as openai:
+            result = visual_ai_check(
+                issue_title="Email-only form",
+                issue_body="Remove phone",
+                pre_paths=[],
+                post_paths=[post],
+            )
+    assert result["provider"] == "cursor"
+    assert result["decision"] == "pass"
+    cursor.assert_called_once()
+    openai.assert_not_called()
+
+
+def test_visual_ai_check_falls_back_to_openai(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "ck_test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk_test")
+    monkeypatch.delenv("VISUAL_PROVIDER", raising=False)
+    post = tmp_path / "post-home.png"
+    post.write_bytes(b"png")
+    with patch(
+        "post_deploy_visual.visual_ai_check_cursor",
+        side_effect=GitHubError("cursor down"),
+    ):
+        with patch(
+            "post_deploy_visual.visual_ai_check_openai",
+            return_value={
+                "visible": True,
+                "summary": "backup",
+                "decision": "pass",
+                "model": "gpt-4o-mini",
+                "provider": "openai",
+            },
+        ) as openai:
+            result = visual_ai_check(
+                issue_title="t",
+                issue_body="b",
+                pre_paths=[],
+                post_paths=[post],
+            )
+    assert result["provider"] == "openai"
+    openai.assert_called_once()
+
+
+def test_visual_ai_check_force_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "ck_test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk_test")
+    monkeypatch.setenv("VISUAL_PROVIDER", "openai")
+    with patch("post_deploy_visual.visual_ai_check_cursor") as cursor:
+        with patch(
+            "post_deploy_visual.visual_ai_check_openai",
+            return_value={
+                "visible": False,
+                "summary": "forced",
+                "decision": "fail",
+                "model": "gpt",
+                "provider": "openai",
+            },
+        ):
+            result = visual_ai_check(
+                issue_title="t",
+                issue_body="b",
+                pre_paths=[],
+                post_paths=[],
+            )
+    assert result["provider"] == "openai"
+    cursor.assert_not_called()


### PR DESCRIPTION
## Summary
- `scripts/post_deploy_visual.py` now prefers **Cursor Agent SDK** (`mode=plan`, local PNG paths) for before/after visual checks; OpenAI vision is backup.
- CI `post-deploy-visual` installs `requirements-agents.txt` and passes `CURSOR_API_KEY` / `VISUAL_PROVIDER`.
- Docs updated: `MODELS.md`, `SCREENSHOTS.md`, `IDENTITIES.md`.

Fixes the post-#58 CI failure mode where OpenAI `429 insufficient_quota` failed an otherwise healthy deploy.

## Test plan
- [x] `pytest tests/test_post_deploy_visual.py -q`
- [ ] After merge to main, confirm `### deploy_visual_check` shows `visual_provider: cursor` (or openai only if Cursor unavailable)


Made with [Cursor](https://cursor.com)