### PR TITLE
fix(builder): stop #67 loop — reuse PR head + binary-safe commits

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -18,6 +18,14 @@ triggers): copy `type:*` and `priority:*` from the issue, and set
 `review:needs-review`. Never put `agent:*` or `status:*` on the PR — see
 [docs/LABELS.md](../docs/LABELS.md).
 
+When an open PR already links the issue (`Closes #N` / title `#N`), **reuse that
+PR’s head branch** for every follow-up commit. Do not invent a second
+`builder/{issue}-…` branch from a retitled slug — that forks Reviewer off the
+real PR and causes change-request loops.
+
+Binary assets (PNG/JPEG/WebP/etc.) must be committed as raw bytes, never through
+UTF-8 text rewrite (that corrupts PNG magic and breaks OG share images).
+
 ## Definition of done
 
 - Implementation matches the issue scope (bug fix or feature as labeled).

--- a/scripts/codegen_cursor.py
+++ b/scripts/codegen_cursor.py
@@ -94,6 +94,7 @@ def build_prompt(
             "- Follow brutal-minimalist brand rules below for any UI work\n"
             "- Live site reference: https://saberistic.com/\n"
             "- Do not modify .github/workflows agent orchestration unless required\n"
+            "- Binary assets (PNG/JPEG/WebP) must remain valid binary files\n"
         )
     else:
         ship_rules = (
@@ -102,10 +103,12 @@ def build_prompt(
             f"- PR body MUST include `Closes #{issue}`\n"
             f"- Commit messages MUST include `builder(#{issue}): …`\n"
             "- Never push to main/master; only work on a feature branch\n"
+            "- If an open PR already closes this issue, continue on that PR branch\n"
             "- Stay in scope of this issue; no drive-by refactors\n"
             "- Add/update tests under tests/ when behavior changes\n"
             "- Follow brutal-minimalist brand rules below for any UI work\n"
             "- Live site reference: https://saberistic.com/\n"
+            "- Binary assets (PNG/JPEG/WebP) must remain valid binary files\n"
         )
     return (
         f"You are the Builder agent for `{repo}`.\n"
@@ -144,7 +147,7 @@ def _should_skip(rel: str) -> bool:
     return any(rel.startswith(p) or f"/{p}" in f"/{rel}" for p in SKIP_PATH_PREFIXES)
 
 
-def _collect_changed_files(root: Path) -> list[tuple[str, str]]:
+def _collect_changed_files(root: Path) -> list[tuple[str, str | bytes]]:
     """Return (path, content) for tracked+untracked changes vs HEAD."""
     proc = subprocess.run(
         ["git", "status", "--porcelain", "-u"],
@@ -186,7 +189,7 @@ def _collect_changed_files(root: Path) -> list[tuple[str, str]]:
             seen.add(p)
             unique.append(p)
 
-    from codegen_models import MAX_FILE_CHARS
+    from codegen_models import MAX_FILE_CHARS, is_binary_path
 
     max_files = int(os.environ.get("CURSOR_MAX_FILES") or "30")
     if not unique:
@@ -197,13 +200,19 @@ def _collect_changed_files(root: Path) -> list[tuple[str, str]]:
             + ", ".join(unique[:20])
         )
 
-    out: list[tuple[str, str]] = []
+    out: list[tuple[str, str | bytes]] = []
     for rel in unique:
         path = root / rel
         if not path.is_file():
             # deleted file — skip for now (Builder Contents API path is put-only)
             continue
-        text = path.read_text(encoding="utf-8", errors="replace")
+        if is_binary_path(rel):
+            data = path.read_bytes()
+            if len(data) > MAX_FILE_CHARS:
+                raise GitHubError(f"file too large after Cursor edit: {rel}")
+            out.append((rel, data))
+            continue
+        text = path.read_text(encoding="utf-8")
         if len(text) > MAX_FILE_CHARS:
             raise GitHubError(f"file too large after Cursor edit: {rel}")
         out.append((rel, text))
@@ -228,7 +237,6 @@ def _build_local(
     key: str,
 ) -> dict[str, Any]:
     from cursor_sdk import Agent, CursorAgentError, LocalAgentOptions
-    from codegen_models import ensure_branch, linked_open_prs, put_file
 
     root = Path.cwd()
     prompt = build_prompt(
@@ -272,15 +280,16 @@ def _build_local(
     default = api("GET", f"/repos/{owner}/{name}").get("default_branch") or "main"
     ref = api("GET", f"/repos/{owner}/{name}/git/ref/heads/{default}")
     base_sha = ref["object"]["sha"]
-    branch = f"builder/{issue}-{_slugify(title)}"
+    from codegen_models import ensure_branch, put_file, resolve_builder_branch
+
+    branch, existing_pr = resolve_builder_branch(repo, issue, title)
     ensure_branch(repo, branch, base_sha)
     commit_message = f"builder(#{issue}): implement via Cursor SDK"
     for path, content in files:
         put_file(repo, branch, path, content, f"{commit_message} ({path})")
 
-    prs = linked_open_prs(repo, issue)
-    if prs:
-        pr_number = int(prs[0]["number"])
+    if existing_pr:
+        pr_number = int(existing_pr["number"])
         created = False
     else:
         pr = api(

--- a/scripts/codegen_models.py
+++ b/scripts/codegen_models.py
@@ -109,9 +109,48 @@ def is_ui_design_issue(title: str, body: str) -> bool:
     )
 
 
+BINARY_PATH_SUFFIXES = (
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".gif",
+    ".ico",
+    ".pdf",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".otf",
+    ".zip",
+)
+
+
 def slugify(text: str, limit: int = 40) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
     return (slug or "work")[:limit]
+
+
+def is_binary_path(path: str) -> bool:
+    """Return True when Contents API must preserve raw bytes (not UTF-8 text)."""
+    lower = path.lower()
+    return any(lower.endswith(suffix) for suffix in BINARY_PATH_SUFFIXES)
+
+
+def resolve_builder_branch(
+    repo: str, issue: int, title: str
+) -> tuple[str, dict[str, Any] | None]:
+    """Prefer an open linked PR head so Builder never forks a parallel branch.
+
+    Title-derived slugs drift (e.g. ``P1 — …`` vs bare title) and previously
+    created ghost branches that Reviewer never sees.
+    """
+    prs = linked_open_prs(repo, issue)
+    if prs:
+        pr = prs[0]
+        head = ((pr.get("head") or {}).get("ref") or "").strip()
+        if head:
+            return head, pr
+    return f"builder/{issue}-{slugify(title)}", None
 
 
 def repo_context(cwd: Path, *, ui: bool = False) -> str:
@@ -268,13 +307,13 @@ def extract_json(text: str) -> dict[str, Any]:
     return data
 
 
-def validate_plan(plan: dict[str, Any]) -> list[dict[str, str]]:
+def validate_plan(plan: dict[str, Any]) -> list[dict[str, Any]]:
     files = plan.get("files")
     if not isinstance(files, list) or not files:
         raise GitHubError("model plan missing non-empty files[]")
     if len(files) > MAX_FILES:
         raise GitHubError(f"model proposed too many files ({len(files)} > {MAX_FILES})")
-    out: list[dict[str, str]] = []
+    out: list[dict[str, Any]] = []
     for item in files:
         if not isinstance(item, dict):
             raise GitHubError("each files[] entry must be an object")
@@ -295,9 +334,19 @@ def validate_plan(plan: dict[str, Any]) -> list[dict[str, str]]:
                 if pad:
                     cleaned = cleaned + ("=" * pad)
                 raw = base64.b64decode(cleaned, validate=False)
-                text = raw.decode("utf-8", errors="replace")
             except Exception as exc:
                 raise GitHubError(f"invalid content_b64 for {path}: {exc}") from exc
+            if is_binary_path(path):
+                if len(raw) > MAX_FILE_CHARS:
+                    raise GitHubError(f"file too large: {path}")
+                out.append({"path": path, "content": raw})
+                continue
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise GitHubError(
+                    f"content_b64 for text path {path} is not valid UTF-8: {exc}"
+                ) from exc
         else:
             text = content if isinstance(content, str) else json.dumps(content, indent=2)
         if len(text) > MAX_FILE_CHARS:
@@ -319,11 +368,14 @@ def ensure_branch(repo: str, branch: str, base_sha: str) -> None:
             raise
 
 
-def put_file(repo: str, branch: str, path: str, content: str, message: str) -> None:
+def put_file(
+    repo: str, branch: str, path: str, content: str | bytes, message: str
+) -> None:
     owner, name = split_repo(repo)
     # Ensure Contents API always has a GitHub token for mutations.
     token()
-    content_b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    raw = content.encode("utf-8") if isinstance(content, str) else content
+    content_b64 = base64.b64encode(raw).decode("ascii")
     put_body: dict[str, Any] = {
         "message": message,
         "content": content_b64,
@@ -475,7 +527,7 @@ def build_with_models(
     default = api("GET", f"/repos/{owner}/{name}").get("default_branch") or "main"
     ref = api("GET", f"/repos/{owner}/{name}/git/ref/heads/{default}")
     base_sha = ref["object"]["sha"]
-    branch = f"builder/{issue}-{slugify(title)}"
+    branch, existing_pr = resolve_builder_branch(repo, issue, title)
 
     system = json_system_prompt(ui=ui)
     # Thin planner child issues often only say "User flow" — pull parent context.
@@ -569,9 +621,8 @@ def build_with_models(
             f"{commit_message} ({item['path']})",
         )
 
-    prs = linked_open_prs(repo, issue)
-    if prs:
-        pr_number = int(prs[0]["number"])
+    if existing_pr:
+        pr_number = int(existing_pr["number"])
         created = False
     else:
         pr = api(

--- a/tests/test_codegen_provider.py
+++ b/tests/test_codegen_provider.py
@@ -4,7 +4,13 @@ import base64
 
 import pytest
 
-from codegen_models import is_ui_design_issue, select_provider, validate_plan
+from codegen_models import (
+    is_binary_path,
+    is_ui_design_issue,
+    resolve_builder_branch,
+    select_provider,
+    validate_plan,
+)
 from github_api import GitHubError
 
 
@@ -22,6 +28,60 @@ def test_validate_plan_accepts_unpadded_content_b64() -> None:
         {"files": [{"path": "site/about.html", "content_b64": unpadded}]}
     )
     assert files == [{"path": "site/about.html", "content": text}]
+
+
+def test_validate_plan_preserves_binary_content_b64() -> None:
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    files = validate_plan(
+        {
+            "files": [
+                {
+                    "path": "site/assets/og-share.png",
+                    "content_b64": base64.b64encode(png).decode(),
+                }
+            ]
+        }
+    )
+    assert files == [{"path": "site/assets/og-share.png", "content": png}]
+    assert files[0]["content"][:4] == b"\x89PNG"
+
+
+def test_is_binary_path() -> None:
+    assert is_binary_path("site/assets/og-share.png")
+    assert not is_binary_path("site/index.html")
+
+
+def test_resolve_builder_branch_reuses_open_pr_head(monkeypatch) -> None:
+    pr = {
+        "number": 76,
+        "title": "builder: P1 — Add Open Graph (#67)",
+        "body": "Closes #67",
+        "head": {"ref": "builder/67-p1-add-open-graph-structured-data-and-sh"},
+    }
+
+    monkeypatch.setattr(
+        "codegen_models.linked_open_prs",
+        lambda repo, issue: [pr],
+    )
+    branch, linked = resolve_builder_branch(
+        "saberistic-team/agent-web",
+        67,
+        "Add Open Graph, structured data, and share-ready metadata",
+    )
+    assert branch == "builder/67-p1-add-open-graph-structured-data-and-sh"
+    assert linked is pr
+
+
+def test_resolve_builder_branch_falls_back_to_slug(monkeypatch) -> None:
+    monkeypatch.setattr("codegen_models.linked_open_prs", lambda repo, issue: [])
+    branch, linked = resolve_builder_branch(
+        "saberistic-team/agent-web",
+        67,
+        "Add Open Graph, structured data, and share-ready metadata",
+    )
+    assert branch.startswith("builder/67-")
+    assert "open-graph" in branch
+    assert linked is None
 
 
 def test_select_provider_prefers_cursor_when_key_set(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Builder now **reuses the open linked PR head branch** instead of inventing a new `builder/{issue}-{slug}` from the current title (that forked #67 onto a ghost branch).
- Binary assets (PNG/JPEG/etc.) are committed as **raw bytes**, not UTF-8-with-replacement (root cause of corrupt `og-share.png`).
- Documented the rule in `AGENTS/builder.md`; added unit tests.

## Context
Issue #67 / PR #76 was looping because Builder kept pushing to `builder/67-add-open-graph-…` while Reviewer watched `builder/67-p1-…`.

## Test plan
- [x] `PYTHONPATH=scripts pytest tests/test_codegen_provider.py tests/test_codegen_cursor.py`
- [ ] After merge, delete any leftover ghost branch and re-run Reviewer on #76 only


Made with [Cursor](https://cursor.com)