### PR TITLE
feat(builder): resolve PR merge conflicts from recent closed work

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -51,6 +51,25 @@ rewrite them through UTF-8 text (`errors=replace` turns `0x89` into `U+FFFD`
 and corrupts Open Graph / share images). Codegen `put_file` accepts `bytes` for
 binary paths.
 
+## Merge conflicts (mandatory)
+
+If the linked PR is behind `main` or GitHub reports `mergeable: false` /
+`mergeable_state: dirty`, **resolve on that same PR head** — never open a
+replacement branch.
+
+1. Call `scripts/builder_conflicts.py` (wired after codegen in `role_builder`).
+2. Review **recently merged PRs** and **recently closed issues** for intent and
+   overlapping files (`summarize_recent_closed_work`).
+3. Merge the PR base into the PR head; resolve text conflicts preferring both
+   intents (this feature + recently landed work). Prefer base (`theirs` during
+   that merge) for conflicted binaries.
+4. Comment `### builder_conflict_context` and `### builder_conflict_result` on
+   the issue, then hand off to Reviewer.
+
+CLI: `python scripts/builder_conflicts.py --repo owner/name --issue N`
+(`--context-only` prints the recent-work brief; `--force` merges even when
+GitHub still says clean).
+
 ## Definition of done
 
 - Implementation matches the issue scope (bug fix or feature as labeled).

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -12,7 +12,10 @@ is set. OpenAI and GitHub Models are backups (OpenAI quota is often exhausted).
 4. **Cursor agent** implements the change (`CURSOR_RUNTIME=local` by default)
 5. Thin child issues that say `Parent: #N` also pull the parent issue body into
    the prompt
-6. Reviewer (acceptance checklist + screenshots)
+6. If the linked PR conflicts with its base, **`builder_conflicts`** merges base
+   into the PR head using recently closed issues/PRs as resolution context
+   ([AGENTS/builder.md](../AGENTS/builder.md) — Merge conflicts)
+7. Reviewer (acceptance checklist + screenshots)
 
 ### Branch / PR binding (no stray branches)
 

--- a/scripts/builder_conflicts.py
+++ b/scripts/builder_conflicts.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Builder helpers: detect and resolve PR merge conflicts using recent work.
+
+When an open Builder PR falls behind ``main`` (often after other issues merge),
+Builder reviews recently **merged PRs** and **closed issues**, then rebases /
+merges the PR head and resolves text conflicts with that context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+from github_api import GitHubError, api, post_issue_comment, split_repo
+
+CONFLICT_MARKER = re.compile(r"^<<<<<<< ", re.M)
+DEFAULT_RECENT_PRS = 8
+DEFAULT_RECENT_ISSUES = 8
+MAX_BODY_CHARS = 1200
+MAX_FILE_CHARS = 60_000
+
+
+def linked_open_prs(repo: str, issue: int) -> list[dict[str, Any]]:
+    owner, name = split_repo(repo)
+    prs = api("GET", f"/repos/{owner}/{name}/pulls?state=open&per_page=100") or []
+    needle = f"#{issue}"
+    return [
+        pr
+        for pr in prs
+        if needle in (pr.get("title") or "") or needle in (pr.get("body") or "")
+    ]
+
+
+def refresh_pr(repo: str, pr_number: int) -> dict[str, Any]:
+    """Return a fresh PR payload (mergeable fields are computed asynchronously)."""
+    owner, name = split_repo(repo)
+    return api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}")
+
+
+def pr_needs_conflict_resolution(pr: dict[str, Any]) -> bool:
+    """True when GitHub reports the PR cannot merge cleanly into its base."""
+    if pr.get("merged") or pr.get("state") == "closed":
+        return False
+    mergeable = pr.get("mergeable")
+    state = (pr.get("mergeable_state") or "").lower()
+    if mergeable is False:
+        return True
+    if state in {"dirty", "draft"}:
+        return True
+    return False
+
+
+def list_recent_merged_prs(repo: str, *, limit: int = DEFAULT_RECENT_PRS) -> list[dict[str, Any]]:
+    owner, name = split_repo(repo)
+    prs = (
+        api(
+            "GET",
+            f"/repos/{owner}/{name}/pulls?state=closed&sort=updated&direction=desc&per_page={limit}",
+        )
+        or []
+    )
+    return [pr for pr in prs if pr.get("merged_at")][:limit]
+
+
+def list_recent_closed_issues(
+    repo: str, *, limit: int = DEFAULT_RECENT_ISSUES
+) -> list[dict[str, Any]]:
+    owner, name = split_repo(repo)
+    issues = (
+        api(
+            "GET",
+            f"/repos/{owner}/{name}/issues?state=closed&sort=updated&direction=desc"
+            f"&per_page={max(limit * 3, 30)}",
+        )
+        or []
+    )
+    # Issues API includes PRs; keep true issues only.
+    out: list[dict[str, Any]] = []
+    for item in issues:
+        if item.get("pull_request"):
+            continue
+        out.append(item)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def pr_changed_paths(repo: str, pr_number: int) -> list[str]:
+    owner, name = split_repo(repo)
+    files = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}/files?per_page=100") or []
+    paths: list[str] = []
+    for item in files:
+        path = (item.get("filename") or "").strip()
+        if path:
+            paths.append(path)
+    return paths
+
+
+def _clip(text: str, limit: int = MAX_BODY_CHARS) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def summarize_recent_closed_work(
+    repo: str,
+    *,
+    pr_limit: int = DEFAULT_RECENT_PRS,
+    issue_limit: int = DEFAULT_RECENT_ISSUES,
+) -> str:
+    """Markdown brief of recently merged PRs and closed issues for conflict resolution."""
+    lines = [
+        "## Recently merged PRs (preserve their intent when resolving conflicts)",
+    ]
+    merged = list_recent_merged_prs(repo, limit=pr_limit)
+    if not merged:
+        lines.append("- (none)")
+    for pr in merged:
+        number = pr.get("number")
+        title = pr.get("title") or ""
+        paths = pr_changed_paths(repo, int(number)) if number else []
+        path_note = ", ".join(f"`{p}`" for p in paths[:12])
+        if len(paths) > 12:
+            path_note += ", …"
+        lines.append(f"- #{number}: {title}")
+        if path_note:
+            lines.append(f"  - files: {path_note}")
+        body = _clip(pr.get("body") or "")
+        if body:
+            lines.append(f"  - summary: {body.splitlines()[0][:200]}")
+
+    lines.append("")
+    lines.append("## Recently closed issues (do not regress acceptance)")
+    closed = list_recent_closed_issues(repo, limit=issue_limit)
+    if not closed:
+        lines.append("- (none)")
+    for issue in closed:
+        number = issue.get("number")
+        title = issue.get("title") or ""
+        lines.append(f"- #{number}: {title}")
+        body = _clip(issue.get("body") or "", 400)
+        if body:
+            first = next((ln for ln in body.splitlines() if ln.strip()), "")
+            if first:
+                lines.append(f"  - note: {first[:200]}")
+    return "\n".join(lines)
+
+
+def format_conflict_resolution_brief(
+    repo: str,
+    issue: int,
+    pr: dict[str, Any],
+    *,
+    conflicted_paths: list[str] | None = None,
+) -> str:
+    """Prompt / comment body for resolving conflicts on a Builder PR."""
+    head = ((pr.get("head") or {}).get("ref")) or "?"
+    base = ((pr.get("base") or {}).get("ref")) or "main"
+    number = pr.get("number")
+    paths = conflicted_paths or []
+    recent = summarize_recent_closed_work(repo)
+    path_lines = "\n".join(f"- `{p}`" for p in paths) or "- (unknown until merge runs)"
+    return (
+        f"Resolve merge conflicts for issue #{issue} on PR #{number}.\n"
+        f"Head branch `{head}` must merge cleanly into `{base}`.\n\n"
+        "Rules:\n"
+        "- Prefer keeping both intents when possible (feature + recently merged work).\n"
+        "- Never invent a second Builder branch; stay on this PR head.\n"
+        "- Do not drop technical SEO / tests / routes from recently merged PRs.\n"
+        "- Binary files: keep valid bytes; do not UTF-8-corrupt PNG/JPEG.\n"
+        "- Output full resolved file contents for each conflicted path.\n\n"
+        f"### Conflicted paths\n{path_lines}\n\n"
+        f"{recent}\n"
+    )
+
+
+def _run_git(args: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and proc.returncode != 0:
+        raise GitHubError(
+            f"git {' '.join(args)} failed ({proc.returncode}): "
+            f"{(proc.stderr or proc.stdout or '').strip()}"
+        )
+    return proc
+
+
+def list_unmerged_paths(cwd: Path) -> list[str]:
+    proc = _run_git(["diff", "--name-only", "--diff-filter=U"], cwd=cwd, check=False)
+    paths = [ln.strip() for ln in (proc.stdout or "").splitlines() if ln.strip()]
+    return paths
+
+
+def strip_conflict_markers_prefer_head(text: str) -> str:
+    """Naive fallback: keep 'ours' (PR head) side of conflict markers."""
+    if not CONFLICT_MARKER.search(text):
+        return text
+    out: list[str] = []
+    mode = "keep"  # keep | skip
+    for line in text.splitlines(keepends=True):
+        if line.startswith("<<<<<<< "):
+            mode = "keep"
+            continue
+        if line.startswith("======="):
+            mode = "skip"
+            continue
+        if line.startswith(">>>>>>> "):
+            mode = "keep"
+            continue
+        if mode == "keep":
+            out.append(line)
+    return "".join(out)
+
+
+ResolveFn = Callable[[str, str, str], str]
+
+
+def default_resolve_file(
+    path: str,
+    conflicted_text: str,
+    brief: str,
+    *,
+    chat: ResolveFn | None = None,
+) -> str:
+    """Resolve one conflicted text file; optional chat(system, user) -> content."""
+    if chat is None or path.lower().endswith(
+        (".png", ".jpg", ".jpeg", ".webp", ".gif", ".ico", ".pdf")
+    ):
+        return strip_conflict_markers_prefer_head(conflicted_text)
+    system = (
+        "You resolve git merge conflicts for a product repo. "
+        "Return ONLY the full resolved file contents — no markdown fences, "
+        "no explanation. Preserve both feature intent and recently merged work."
+    )
+    user = (
+        f"{brief}\n\n"
+        f"### Conflicted file `{path}`\n"
+        f"```\n{conflicted_text[:MAX_FILE_CHARS]}\n```\n"
+    )
+    try:
+        resolved = chat(system, user).strip()
+    except Exception:
+        return strip_conflict_markers_prefer_head(conflicted_text)
+    if not resolved or CONFLICT_MARKER.search(resolved):
+        return strip_conflict_markers_prefer_head(conflicted_text)
+    if resolved.startswith("```"):
+        resolved = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", resolved)
+        resolved = re.sub(r"\n?```$", "", resolved)
+    return resolved
+
+
+def _optional_chat() -> ResolveFn | None:
+    """Use OpenAI / Models chat when configured; otherwise None (marker strip)."""
+    try:
+        from codegen_models import chat_completion, select_provider
+    except Exception:
+        return None
+
+    def _chat(system: str, user: str) -> str:
+        provider, model = select_provider("merge conflict", "resolve conflicts")
+        if provider == "cursor":
+            # Cursor SDK path is agent-based; fall back to OpenAI/Models JSON chat.
+            provider, model = "openai", os.environ.get("OPENAI_MODEL") or "gpt-4o-mini"
+            if not (os.environ.get("OPENAI_API_KEY") or "").strip():
+                provider, model = (
+                    "github-models",
+                    os.environ.get("GITHUB_MODELS_MODEL") or "openai/gpt-4o-mini",
+                )
+        return chat_completion(provider=provider, model=model, system=system, user=user)
+
+    return _chat
+
+
+def merge_default_into_pr_branch(
+    repo: str,
+    pr: dict[str, Any],
+    *,
+    work_dir: Path | None = None,
+    push: bool = True,
+    chat: ResolveFn | None = None,
+    recent_brief: str | None = None,
+) -> dict[str, Any]:
+    """Merge the PR base branch into the PR head and resolve text conflicts.
+
+    Uses a temporary clone so Actions (checked out on ``main``) can still update
+    the Builder PR head without inventing a second branch.
+    """
+    owner, name = split_repo(repo)
+    pr_number = int(pr["number"])
+    head_ref = (pr.get("head") or {}).get("ref")
+    base_ref = (pr.get("base") or {}).get("ref") or "main"
+    if not head_ref:
+        raise GitHubError(f"PR #{pr_number} missing head.ref")
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        raise GitHubError("missing GITHUB_TOKEN for conflict merge clone")
+
+    brief = recent_brief or summarize_recent_closed_work(repo)
+    issue_hint = 0
+    title = pr.get("title") or ""
+    m = re.search(r"#(\d+)", title) or re.search(r"#(\d+)", pr.get("body") or "")
+    if m:
+        issue_hint = int(m.group(1))
+    resolution_brief = format_conflict_resolution_brief(
+        repo, issue_hint or pr_number, pr
+    )
+    if brief:
+        resolution_brief = f"{resolution_brief}\n{brief}"
+
+    chat_fn = chat if chat is not None else _optional_chat()
+    clone_url = f"https://x-access-token:{token}@github.com/{owner}/{name}.git"
+
+    with tempfile.TemporaryDirectory(prefix="builder-conflict-") as tmp:
+        root = Path(work_dir) if work_dir else Path(tmp) / "repo"
+        if work_dir is None:
+            _run_git(
+                ["clone", "--branch", head_ref, "--single-branch", clone_url, str(root)],
+                cwd=Path(tmp),
+            )
+        _run_git(["config", "user.name", "saberistic-agent-web-builder"], cwd=root)
+        _run_git(
+            ["config", "user.email", "builder@users.noreply.github.com"],
+            cwd=root,
+        )
+        _run_git(["fetch", "origin", base_ref], cwd=root)
+        merge = _run_git(
+            ["merge", f"origin/{base_ref}", "--no-edit"],
+            cwd=root,
+            check=False,
+        )
+        if merge.returncode == 0:
+            if push:
+                _run_git(["push", "origin", f"HEAD:{head_ref}"], cwd=root)
+            return {
+                "status": "merged_clean",
+                "pr": pr_number,
+                "head": head_ref,
+                "base": base_ref,
+                "conflicted": [],
+            }
+
+        conflicted = list_unmerged_paths(root)
+        if not conflicted:
+            raise GitHubError(
+                f"merge failed without conflict list: {(merge.stderr or merge.stdout or '')[:500]}"
+            )
+
+        resolved_paths: list[str] = []
+        for rel in conflicted:
+            path = root / rel
+            if not path.is_file():
+                _run_git(["checkout", "--theirs", "--", rel], cwd=root, check=False)
+                _run_git(["add", "--", rel], cwd=root, check=False)
+                resolved_paths.append(rel)
+                continue
+            raw = path.read_bytes()
+            if b"\0" in raw[:8000] or rel.lower().endswith(
+                (".png", ".jpg", ".jpeg", ".webp", ".gif", ".ico")
+            ):
+                # Prefer base (recently merged) for binaries when both changed.
+                _run_git(["checkout", "--theirs", "--", rel], cwd=root, check=False)
+                _run_git(["add", "--", rel], cwd=root)
+                resolved_paths.append(rel)
+                continue
+            text = raw.decode("utf-8", errors="replace")
+            fixed = default_resolve_file(
+                rel, text, resolution_brief, chat=chat_fn
+            )
+            path.write_text(fixed, encoding="utf-8")
+            _run_git(["add", "--", rel], cwd=root)
+            resolved_paths.append(rel)
+
+        _run_git(
+            [
+                "commit",
+                "-m",
+                f"builder: merge origin/{base_ref} and resolve conflicts for #{pr_number}",
+            ],
+            cwd=root,
+        )
+        if push:
+            _run_git(["push", "origin", f"HEAD:{head_ref}"], cwd=root)
+        return {
+            "status": "resolved",
+            "pr": pr_number,
+            "head": head_ref,
+            "base": base_ref,
+            "conflicted": resolved_paths,
+        }
+
+
+def maybe_resolve_pr_conflicts(
+    repo: str,
+    issue: int,
+    *,
+    force: bool = False,
+    push: bool = True,
+    chat: ResolveFn | None = None,
+) -> dict[str, Any]:
+    """If the linked open PR conflicts with its base, merge + resolve using recent work."""
+    prs = linked_open_prs(repo, issue)
+    if not prs:
+        return {"status": "no_pr", "issue": issue}
+
+    pr_number = int(prs[0]["number"])
+    pr = refresh_pr(repo, pr_number)
+    # mergeable is null until GitHub computes it — one refresh helps.
+    if pr.get("mergeable") is None:
+        pr = refresh_pr(repo, pr_number)
+
+    needs = pr_needs_conflict_resolution(pr)
+    if not needs and not force:
+        return {
+            "status": "clean",
+            "issue": issue,
+            "pr": pr_number,
+            "mergeable": pr.get("mergeable"),
+            "mergeable_state": pr.get("mergeable_state"),
+        }
+
+    recent = summarize_recent_closed_work(repo)
+    post_issue_comment(
+        repo,
+        issue,
+        (
+            "### builder_conflict_context\n"
+            f"- pr: #{pr_number}\n"
+            f"- mergeable: `{pr.get('mergeable')}`\n"
+            f"- mergeable_state: `{pr.get('mergeable_state')}`\n"
+            f"- head: `{(pr.get('head') or {}).get('ref')}`\n\n"
+            f"{recent}\n"
+        ),
+    )
+
+    result = merge_default_into_pr_branch(
+        repo,
+        pr,
+        push=push,
+        chat=chat,
+        recent_brief=recent,
+    )
+    result["issue"] = issue
+    post_issue_comment(
+        repo,
+        issue,
+        (
+            "### builder_conflict_result\n"
+            f"- status: `{result.get('status')}`\n"
+            f"- pr: #{pr_number}\n"
+            f"- head: `{result.get('head')}`\n"
+            f"- base: `{result.get('base')}`\n"
+            f"- conflicted: {', '.join(f'`{p}`' for p in result.get('conflicted') or []) or '(none)'}\n"
+        ),
+    )
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--issue", type=int, required=True)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--no-push", action="store_true")
+    parser.add_argument("--context-only", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.repo:
+        raise SystemExit("--repo or GITHUB_REPOSITORY required")
+
+    if args.context_only:
+        print(summarize_recent_closed_work(args.repo))
+        return 0
+
+    result = maybe_resolve_pr_conflicts(
+        args.repo,
+        args.issue,
+        force=args.force,
+        push=not args.no_push,
+    )
+    print(result)
+    return 0 if result.get("status") in {"clean", "merged_clean", "resolved", "no_pr"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -494,6 +494,28 @@ def role_builder(repo: str, issue: int, brief: Path) -> None:
             f"{result.get('provider')}:{result.get('model')}\n",
             encoding="utf-8",
         )
+        # After codegen, rebase/merge the PR onto latest base if GitHub reports
+        # conflicts — using recently closed issues/PRs as resolution context.
+        try:
+            from builder_conflicts import maybe_resolve_pr_conflicts
+
+            conflict = maybe_resolve_pr_conflicts(repo, issue)
+            (HANDOFF_DIR / "builder-conflict.txt").write_text(
+                f"{conflict.get('status')}\n",
+                encoding="utf-8",
+            )
+        except Exception as conflict_exc:
+            post_issue_comment(
+                repo,
+                issue,
+                (
+                    "### builder_conflict_result\n"
+                    f"- status: `failed`\n"
+                    f"- error: `{conflict_exc}`\n"
+                    "- note: codegen succeeded; resolve merge conflicts on the "
+                    "existing PR head before Reviewer (do not open a second branch).\n"
+                ),
+            )
         write_builder_handoff("reviewer")
     except Exception as exc:
         escalate(

--- a/tests/test_builder_conflicts.py
+++ b/tests/test_builder_conflicts.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Unit tests for Builder conflict-resolution helpers."""
+
+from __future__ import annotations
+
+from builder_conflicts import (
+    default_resolve_file,
+    format_conflict_resolution_brief,
+    pr_needs_conflict_resolution,
+    strip_conflict_markers_prefer_head,
+    summarize_recent_closed_work,
+)
+
+
+def test_pr_needs_conflict_resolution_dirty() -> None:
+    assert pr_needs_conflict_resolution(
+        {"mergeable": False, "mergeable_state": "dirty", "state": "open"}
+    )
+    assert pr_needs_conflict_resolution(
+        {"mergeable": True, "mergeable_state": "dirty", "state": "open"}
+    )
+    assert not pr_needs_conflict_resolution(
+        {"mergeable": True, "mergeable_state": "clean", "state": "open"}
+    )
+    assert not pr_needs_conflict_resolution(
+        {"mergeable": True, "mergeable_state": "clean", "merged": True}
+    )
+
+
+def test_strip_conflict_markers_prefer_head() -> None:
+    text = (
+        "line1\n"
+        "<<<<<<< HEAD\n"
+        "ours\n"
+        "=======\n"
+        "theirs\n"
+        ">>>>>>> main\n"
+        "line2\n"
+    )
+    assert strip_conflict_markers_prefer_head(text) == "line1\nours\nline2\n"
+
+
+def test_default_resolve_file_uses_chat_when_clean(monkeypatch) -> None:
+    conflicted = (
+        "<<<<<<< HEAD\nfeature\n=======\nseo\n>>>>>>> main\n"
+    )
+
+    def chat(system: str, user: str) -> str:
+        assert "Conflicted file" in user
+        return "feature\nseo\n"
+
+    assert default_resolve_file("site/index.html", conflicted, "brief", chat=chat) == (
+        "feature\nseo"
+    )
+
+
+def test_default_resolve_file_falls_back_when_chat_returns_markers() -> None:
+    conflicted = "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> main\n"
+
+    def chat(system: str, user: str) -> str:
+        return conflicted
+
+    assert default_resolve_file("app/main.py", conflicted, "brief", chat=chat) == "ours\n"
+
+
+def test_summarize_recent_closed_work(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "builder_conflicts.list_recent_merged_prs",
+        lambda repo, limit=8: [
+            {
+                "number": 73,
+                "title": "Repair technical SEO (#68)",
+                "body": "Closes #68\n\nCanonical + robots.",
+                "merged_at": "2026-07-13T00:00:00Z",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "builder_conflicts.pr_changed_paths",
+        lambda repo, pr: ["app/seo.py", "site/index.html"],
+    )
+    monkeypatch.setattr(
+        "builder_conflicts.list_recent_closed_issues",
+        lambda repo, limit=8: [
+            {"number": 68, "title": "Repair technical SEO", "body": "## Goal\nFix SEO."}
+        ],
+    )
+    text = summarize_recent_closed_work("saberistic-team/agent-web")
+    assert "#73" in text
+    assert "`app/seo.py`" in text
+    assert "#68" in text
+    assert "Recently closed issues" in text
+
+
+def test_format_conflict_resolution_brief(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "builder_conflicts.summarize_recent_closed_work",
+        lambda repo, **kwargs: "## Recently merged PRs\n- #73: SEO",
+    )
+    pr = {
+        "number": 76,
+        "title": "builder: OG (#67)",
+        "body": "Closes #67",
+        "head": {"ref": "builder/67-p1"},
+        "base": {"ref": "main"},
+    }
+    brief = format_conflict_resolution_brief(
+        "saberistic-team/agent-web",
+        67,
+        pr,
+        conflicted_paths=["site/index.html"],
+    )
+    assert "issue #67" in brief
+    assert "PR #76" in brief
+    assert "`site/index.html`" in brief
+    assert "#73" in brief
+
+
+def test_maybe_resolve_pr_conflicts_skips_clean(monkeypatch) -> None:
+    from builder_conflicts import maybe_resolve_pr_conflicts
+
+    monkeypatch.setattr(
+        "builder_conflicts.linked_open_prs",
+        lambda repo, issue: [{"number": 76, "title": "x (#67)", "body": "Closes #67"}],
+    )
+    monkeypatch.setattr(
+        "builder_conflicts.refresh_pr",
+        lambda repo, n: {
+            "number": 76,
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "state": "open",
+            "head": {"ref": "builder/67-p1"},
+            "base": {"ref": "main"},
+        },
+    )
+    result = maybe_resolve_pr_conflicts("saberistic-team/agent-web", 67)
+    assert result["status"] == "clean"
+    assert result["pr"] == 76


### PR DESCRIPTION
## Summary
- Add \`scripts/builder_conflicts.py\` so Builder can detect a dirty linked PR, pull context from **recently merged PRs** + **closed issues**, merge the base into the **same PR head**, and resolve text conflicts (optional model chat; binary prefers base).
- Wire \`maybe_resolve_pr_conflicts\` into \`role_builder\` after codegen (comments \`builder_conflict_context\` / \`builder_conflict_result\`).
- Document in \`AGENTS/builder.md\` and \`docs/MODELS.md\`.
- Unit tests in \`tests/test_builder_conflicts.py\`.

## Why
\#67 / \#76 looped partly because Builder did not rebase onto newly merged SEO work and sometimes forked a stray branch instead.

## Test plan
- [x] \`pytest tests/test_builder_conflicts.py\`
- [ ] Dry-run: \`python scripts/builder_conflicts.py --repo saberistic-team/agent-web --issue 67 --context-only\`

Made with [Cursor](https://cursor.com)