### PR TITLE
fix(builder): single-branch fetch refspec stops conflict loop

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -65,12 +65,19 @@ a dirty PR as unfinished Builder work.
 3. Merge the PR base into the PR head; resolve text conflicts preferring both
    intents (this feature + recently landed work). Prefer base (`theirs` during
    that merge) for conflicted binaries.
+   **Single-branch clone pitfall:** conflict merges clone the PR head with
+   `--single-branch`. A plain `git fetch origin main` updates `FETCH_HEAD` only
+   — it does **not** create `refs/remotes/origin/main`, so
+   `git merge origin/main` fails with “not something we can merge” and loops
+   Builder↔Reviewer. `builder_conflicts.py` must fetch with an explicit refspec:
+   `+refs/heads/{base}:refs/remotes/origin/{base}`.
 4. Comment `### builder_conflict_context` and `### builder_conflict_result` on
    the issue.
 5. **Re-check** `mergeable` / `mergeable_state`. Only when clean → hand off
    (`status:needs-review` / `agent:reviewer`). If still dirty or resolution
-   failed → re-enter `status:queued` (`waiting` handoff) so you run again;
-   never send a conflicted PR to Reviewer.
+   failed → re-enter `status:queued` (`waiting` handoff in
+   `trace/builder-handoff.txt`) so you run again; **never** send a conflicted or
+   unresolved PR to Reviewer.
 
 If Reviewer returns the issue with merge-conflict hard fails (e.g. another
 branch merged after your handoff), resolve on the **same** PR head and

--- a/AGENTS/planner.md
+++ b/AGENTS/planner.md
@@ -43,6 +43,10 @@ The parent is then marked done by the workflow.
 - Decomposition matches the one-commit-per-child rule when children exist.
 - Acceptance criteria / scope notes are on the issue (or each child) so the
   owning agent can execute without re-planning.
+- Acceptance criteria avoid requiring **live production URLs** for features not
+  yet merged. Phrase deploy-dependent outcomes as “published in the PR / ready
+  to deploy” (e.g. routes + editorial review doc on the PR head) so Reviewer
+  can approve pre-merge without waiting for Gate + Render.
 - You did not push commits, open implementation PRs, or edit product code.
 
 ## Constraints

--- a/AGENTS/reviewer.md
+++ b/AGENTS/reviewer.md
@@ -13,7 +13,8 @@ Before approving you must:
    `mergeable_state` not dirty). If GitHub reports conflicts (e.g. another
    branch merged after Builder handed off), **request changes immediately** and
    return the issue to Builder — do not approve or spend the rest of the review
-   budget on a conflicted PR
+   budget on a conflicted PR. Merge conflicts are always Builder work on the
+   same PR head.
 2. Capture **headless Chromium screenshots** via Actions Playwright
    (`scripts/screenshot_deploy.py`) at **desktop and mobile** viewports:
    - **PR branch** — local uvicorn on the PR head checkout (`branch-*.png`)
@@ -28,7 +29,12 @@ Before approving you must:
    — prefers Cursor when `CURSOR_API_KEY` is set
 5. Enforce **service coverage** on `app/`: unit ≥90%, integration ≥70%
 6. Post an **`### acceptance_checklist`** that marks each acceptance criterion
-   done/not_done with links to evidence (PR, commits, files, screenshots)
+   done/not_done with links to evidence (PR, commits, files, screenshots).
+   **Pre-merge “published” criteria** (e.g. launch articles live on `/insights`)
+   are satisfied by **PR-head evidence** — code routes, `LAUNCH_REVIEW.md` /
+   editorial sign-off, branch screenshots, and tests — **not** by production
+   URLs that only exist after Gate merges and deploys. Do **not** fail approval
+   because production still 404s a route the PR adds.
 
 Review **only the linked PR’s head SHA**. Ignore any other `builder/{issue}-…`
 refs for the same issue number (ghost branches are not in scope). If Builder

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -53,3 +53,8 @@ and posted evidence.
 - Put criteria under `## Acceptance criteria`
 - Prefer checkbox bullets: `- [ ] …`
 - Builder commits should include `(#N)` so post-deploy and close can link evidence
+- Do **not** require production deploy evidence for pre-merge Reviewer approval.
+  New routes/features are verified on the **PR branch** (code, tests, branch
+  screenshots, editorial review docs such as `LAUNCH_REVIEW.md`). Production
+  live URLs are post-deploy evidence (Gate merge + Render), not a Reviewer
+  blocker while the PR is still open.

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -16,6 +16,9 @@ is set. OpenAI and GitHub Models are backups (OpenAI quota is often exhausted).
    into the PR head using recently closed issues/PRs as resolution context
    ([AGENTS/builder.md](../AGENTS/builder.md) — Merge conflicts). Builder only
    hands off when the PR is clean; otherwise it re-enters `status:queued`.
+   **Pitfall:** the conflict clone uses `--single-branch`; fetching the base
+   must use an explicit refspec (`+refs/heads/main:refs/remotes/origin/main`)
+   or `git merge origin/main` fails and loops Builder↔Reviewer.
 7. Reviewer (acceptance checklist + screenshots). If the PR is dirty again
    (e.g. another merge landed), Reviewer requests changes and requeues Builder.
 

--- a/scripts/builder_conflicts.py
+++ b/scripts/builder_conflicts.py
@@ -369,7 +369,18 @@ def merge_default_into_pr_branch(
             ["config", "user.email", "builder@users.noreply.github.com"],
             cwd=root,
         )
-        _run_git(["fetch", "origin", base_ref], cwd=root)
+        # --single-branch clones only track the PR head refspec. A plain
+        # `git fetch origin main` updates FETCH_HEAD but does NOT create
+        # refs/remotes/origin/main, so `merge origin/main` fails with
+        # "not something we can merge" and loops Builder↔Reviewer forever.
+        _run_git(
+            [
+                "fetch",
+                "origin",
+                f"+refs/heads/{base_ref}:refs/remotes/origin/{base_ref}",
+            ],
+            cwd=root,
+        )
         merge = _run_git(
             ["merge", f"origin/{base_ref}", "--no-edit"],
             cwd=root,

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -110,12 +110,29 @@ def handoff_builder_when_mergeable(repo: str, issue: int) -> None:
     )
 
     HANDOFF_DIR.mkdir(parents=True, exist_ok=True)
+    _CONFLICT_OK = frozenset({"clean", "merged_clean", "resolved", "no_pr"})
+
     try:
         conflict = maybe_resolve_pr_conflicts(repo, issue)
+        conflict_status = (conflict.get("status") or "").strip()
         (HANDOFF_DIR / "builder-conflict.txt").write_text(
-            f"{conflict.get('status')}\n",
+            f"{conflict_status}\n",
             encoding="utf-8",
         )
+        if conflict_status and conflict_status not in _CONFLICT_OK:
+            post_issue_comment(
+                repo,
+                issue,
+                (
+                    "### builder_conflict_result\n"
+                    f"- status: `{conflict_status}`\n"
+                    f"- pr: #{conflict.get('pr')}\n"
+                    "- note: conflict resolution did not finish cleanly; "
+                    "re-entering `status:queued` (not handing off to Reviewer).\n"
+                ),
+            )
+            write_builder_handoff("waiting")
+            return
     except Exception as conflict_exc:
         post_issue_comment(
             repo,

--- a/tests/test_builder_conflicts.py
+++ b/tests/test_builder_conflicts.py
@@ -163,6 +163,66 @@ def test_linked_pr_conflict_status_dirty(monkeypatch) -> None:
     assert "return to Builder" in format_merge_conflict_hard_fail(status)
 
 
+def test_merge_fetch_uses_explicit_refspec_for_single_branch_clone(monkeypatch) -> None:
+    """--single-branch clones need refspec fetch so origin/main is mergeable."""
+    from pathlib import Path
+
+    from builder_conflicts import merge_default_into_pr_branch
+
+    git_calls: list[list[str]] = []
+
+    def fake_run_git(args: list[str], *, cwd: Path, check: bool = True):
+        git_calls.append(list(args))
+        if args[:2] == ["merge", "origin/main"]:
+            class _Proc:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Proc()
+        if args[:2] == ["push", "origin"]:
+            class _Proc:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _Proc()
+        class _Proc:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Proc()
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr("builder_conflicts._run_git", fake_run_git)
+    monkeypatch.setattr(
+        "builder_conflicts.summarize_recent_closed_work",
+        lambda repo, **kwargs: "",
+    )
+
+    work_dir = Path("/tmp/builder-conflict-test-repo")
+    pr = {
+        "number": 74,
+        "title": "builder: insights (#69)",
+        "body": "Closes #69",
+        "head": {"ref": "builder/69-p1-build-an-authority-content-system-for"},
+        "base": {"ref": "main"},
+    }
+    merge_default_into_pr_branch(
+        "saberistic-team/agent-web",
+        pr,
+        work_dir=work_dir,
+        push=False,
+    )
+
+    fetch_calls = [c for c in git_calls if c and c[0] == "fetch"]
+    assert fetch_calls, "expected a git fetch before merge"
+    fetch = fetch_calls[0]
+    assert fetch[1] == "origin"
+    assert fetch[2] == "+refs/heads/main:refs/remotes/origin/main"
+
+
 def test_linked_pr_conflict_status_clean(monkeypatch) -> None:
     from builder_conflicts import linked_pr_conflict_status
 


### PR DESCRIPTION
## Summary
- Fix `builder_conflicts.py` to fetch the PR base with an explicit refspec after `--single-branch` clone so `git merge origin/main` works.
- Harden `handoff_builder_when_mergeable` to requeue (`waiting` → `status:queued`) when conflict resolution returns a non-success status.
- Add unit test asserting the refspec fetch; update Builder/Reviewer/Planner briefs and docs to prevent Builder↔Reviewer loops.

## Test plan
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_builder_conflicts.py -q`


Made with [Cursor](https://cursor.com)