### PR TITLE
fix(agents): GitHub API retries + acceptance PR file pagination

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -136,8 +136,11 @@ must ship test updates on the same PR before re-requesting review.
 
 Stop, comment `@human-review` with the blocker, add `status:blocked`.
 
-Escalate when Cursor/OpenAI/Models codegen fails, or when acceptance criteria
-cannot be met from the issue text.
+Escalate when Cursor/OpenAI/Models codegen fails **after** shared GitHub API
+retries are exhausted (`scripts/github_api.py` retries 408/429/5xx and network
+timeouts with exponential backoff), or when acceptance criteria cannot be met
+from the issue text. Do **not** escalate on a single transient Contents API
+`500` / timeout — retries absorb those before `@human-review`.
 
 Do **not** escalate for service coverage below threshold, missing tests, failing
 CI assertions, visual readability / mobile overflow, or merge conflicts with

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -17,7 +17,14 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-from github_api import GitHubError, api, list_issue_comments, post_issue_comment, split_repo
+from github_api import (
+    GitHubError,
+    api,
+    list_issue_comments,
+    list_pr_files,
+    post_issue_comment,
+    split_repo,
+)
 
 CHECKLIST_MARKER = "### acceptance_checklist"
 CRITERIA_SECTION = re.compile(
@@ -124,7 +131,9 @@ def gather_evidence(repo: str, issue: int, pr_number: int | None) -> dict[str, A
             }
             for c in commits
         ]
-        files = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}/files") or []
+        # Paginate: screenshot-heavy PRs exceed the default 30-file page and
+        # would otherwise hide tests/* from acceptance heuristics (#83).
+        files = list_pr_files(repo, pr_number)
         evidence["files"] = [
             {
                 "filename": f.get("filename"),

--- a/scripts/github_api.py
+++ b/scripts/github_api.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 
 import json
 import os
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Any
+
+# Transient GitHub / network failures Builder (and other roles) hit during codegen.
+# Retry a few times with exponential backoff before escalating to @human-review.
+RETRYABLE_HTTP_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+API_MAX_ATTEMPTS = 5
+API_BACKOFF_BASE_S = 1.0
+API_BACKOFF_CAP_S = 30.0
 
 
 class GitHubError(RuntimeError):
@@ -34,6 +42,16 @@ def split_repo(repo: str) -> tuple[str, str]:
     return owner, name
 
 
+def _retry_delay_s(attempt: int, *, retry_after: str | None = None) -> float:
+    """Exponential backoff: 1s, 2s, 4s, 8s… capped; honor Retry-After when present."""
+    if retry_after:
+        try:
+            return min(float(retry_after.strip()), API_BACKOFF_CAP_S)
+        except ValueError:
+            pass
+    return min(API_BACKOFF_BASE_S * (2**attempt), API_BACKOFF_CAP_S)
+
+
 def api(
     method: str,
     path: str,
@@ -43,27 +61,57 @@ def api(
 ) -> Any:
     url = path if path.startswith("http") else f"https://api.github.com{path}"
     data = None if body is None else json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=data,
-        method=method,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token_override or token()}",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "agent-web",
-            **({"Content-Type": "application/json"} if body is not None else {}),
-        },
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=60) as resp:
-            raw = resp.read()
-            if not raw:
-                return None
-            return json.loads(raw.decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        raise GitHubError(f"{method} {path} -> {exc.code}: {detail}") from exc
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token_override or token()}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "agent-web",
+        **({"Content-Type": "application/json"} if body is not None else {}),
+    }
+    last_error: Exception | None = None
+    for attempt in range(API_MAX_ATTEMPTS):
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                raw = resp.read()
+                if not raw:
+                    return None
+                return json.loads(raw.decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            last_error = GitHubError(f"{method} {path} -> {exc.code}: {detail}")
+            if exc.code not in RETRYABLE_HTTP_STATUS or attempt >= API_MAX_ATTEMPTS - 1:
+                raise last_error from exc
+            delay = _retry_delay_s(
+                attempt, retry_after=exc.headers.get("Retry-After") if exc.headers else None
+            )
+            time.sleep(delay)
+        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+            last_error = GitHubError(f"{method} {path} -> transient: {exc}")
+            if attempt >= API_MAX_ATTEMPTS - 1:
+                raise last_error from exc
+            time.sleep(_retry_delay_s(attempt))
+    raise last_error or GitHubError(f"{method} {path} -> exhausted retries")
+
+
+def list_pr_files(repo: str, pr_number: int) -> list[dict[str, Any]]:
+    """Paginate pull request files (default API page is only 30)."""
+    owner, name = split_repo(repo)
+    files: list[dict[str, Any]] = []
+    page = 1
+    while page <= 20:
+        batch = (
+            api(
+                "GET",
+                f"/repos/{owner}/{name}/pulls/{pr_number}/files?per_page=100&page={page}",
+            )
+            or []
+        )
+        files.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return files
 
 
 def post_issue_comment(repo: str, issue: int, body: str) -> dict[str, Any]:

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import github_api
+
+
+class _FakeHTTPError(Exception):
+    def __init__(self, code: int, body: bytes = b"{}", *, headers: dict | None = None) -> None:
+        self.code = code
+        self._body = body
+        self.headers = headers or {}
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_api_retries_transient_http_500_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr(github_api.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(github_api.urllib.error, "HTTPError", _FakeHTTPError)
+
+    calls = {"n": 0}
+
+    def fake_urlopen(req, timeout=60):  # noqa: ANN001, ARG001
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _FakeHTTPError(500, b'{"message":"server error"}')
+        raw = json.dumps({"ok": True}).encode()
+        resp = MagicMock()
+        resp.read.return_value = raw
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = None
+        return resp
+
+    monkeypatch.setattr(github_api.urllib.request, "urlopen", fake_urlopen)
+    assert github_api.api("GET", "/rate_limit") == {"ok": True}
+    assert calls["n"] == 3
+
+
+def test_api_exhausts_retries_on_persistent_500(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    delays: list[float] = []
+    monkeypatch.setattr(github_api.time, "sleep", delays.append)
+    monkeypatch.setattr(github_api.urllib.error, "HTTPError", _FakeHTTPError)
+
+    def always_500(req, timeout=60):  # noqa: ANN001, ARG001
+        raise _FakeHTTPError(500, b"boom")
+
+    monkeypatch.setattr(github_api.urllib.request, "urlopen", always_500)
+    with pytest.raises(github_api.GitHubError, match="-> 500"):
+        github_api.api("PUT", "/repos/o/n/contents/x")
+    assert len(delays) == github_api.API_MAX_ATTEMPTS - 1
+    assert delays == [1.0, 2.0, 4.0, 8.0]
+
+
+def test_api_does_not_retry_client_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    sleeps: list[float] = []
+    monkeypatch.setattr(github_api.time, "sleep", sleeps.append)
+    monkeypatch.setattr(github_api.urllib.error, "HTTPError", _FakeHTTPError)
+
+    def always_404(req, timeout=60):  # noqa: ANN001, ARG001
+        raise _FakeHTTPError(404, b"missing")
+
+    monkeypatch.setattr(github_api.urllib.request, "urlopen", always_404)
+    with pytest.raises(github_api.GitHubError, match="-> 404"):
+        github_api.api("GET", "/repos/o/n")
+    assert sleeps == []
+
+
+def test_list_pr_files_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
+    pages: dict[int, list[dict[str, Any]]] = {
+        1: [{"filename": f"f{i}.png"} for i in range(100)],
+        2: [{"filename": "tests/test_seo.py"}],
+    }
+
+    def fake_api(method: str, path: str, **_kwargs: Any) -> Any:
+        assert method == "GET"
+        assert "per_page=100" in path
+        page = 1
+        if "page=" in path:
+            page = int(path.rsplit("page=", 1)[-1])
+        return pages.get(page, [])
+
+    monkeypatch.setattr(github_api, "api", fake_api)
+    files = github_api.list_pr_files("o/n", 89)
+    assert len(files) == 101
+    assert files[-1]["filename"] == "tests/test_seo.py"
+
+
+def test_retry_delay_honors_retry_after() -> None:
+    assert github_api._retry_delay_s(0, retry_after="3") == 3.0
+    assert github_api._retry_delay_s(0, retry_after="999") == github_api.API_BACKOFF_CAP_S


### PR DESCRIPTION
## Summary
- Retry transient GitHub API failures (408/429/5xx, timeouts) with exponential backoff before Builder escalates to human review.
- Paginate PR files (`per_page=100`) so acceptance can see `tests/*` on screenshot-heavy PRs.
- Document the retry policy in `AGENTS/builder.md`.

Unblocks Reviewer false-negatives of the form “No test files in PR evidence” when screenshot artifacts dominate the first files page.

## Test plan
- [x] `tests/test_github_api.py` covers retry success, exhaust, no-retry on 404, and pagination
- [x] Existing `tests/test_acceptance.py` still pass


Made with [Cursor](https://cursor.com)