### PR TITLE
fix(agents): paginate issue comments for acceptance Gate

### DIFF
--- a/scripts/github_api.py
+++ b/scripts/github_api.py
@@ -143,5 +143,20 @@ def delete_label(repo: str, issue: int, label: str) -> None:
 
 
 def list_issue_comments(repo: str, issue: int) -> list[dict[str, Any]]:
+    """Paginate issue comments (default page is 30; busy issues exceed one page)."""
     owner, name = split_repo(repo)
-    return api("GET", f"/repos/{owner}/{name}/issues/{issue}/comments?per_page=100") or []
+    comments: list[dict[str, Any]] = []
+    page = 1
+    while page <= 50:
+        batch = (
+            api(
+                "GET",
+                f"/repos/{owner}/{name}/issues/{issue}/comments?per_page=100&page={page}",
+            )
+            or []
+        )
+        comments.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return comments

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -100,3 +100,23 @@ def test_list_pr_files_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_retry_delay_honors_retry_after() -> None:
     assert github_api._retry_delay_s(0, retry_after="3") == 3.0
     assert github_api._retry_delay_s(0, retry_after="999") == github_api.API_BACKOFF_CAP_S
+
+
+def test_list_issue_comments_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
+    pages = {
+        1: [{"id": i, "body": f"c{i}"} for i in range(100)],
+        2: [{"id": 100, "body": "### acceptance_checklist\n- all_done: `true`"}],
+    }
+
+    def fake_api(method: str, path: str, **_kwargs: Any) -> Any:
+        assert method == "GET"
+        assert "per_page=100" in path
+        page = 1
+        if "page=" in path:
+            page = int(path.rsplit("page=", 1)[-1])
+        return pages.get(page, [])
+
+    monkeypatch.setattr(github_api, "api", fake_api)
+    comments = github_api.list_issue_comments("o/n", 83)
+    assert len(comments) == 101
+    assert "all_done" in comments[-1]["body"]


### PR DESCRIPTION
## Summary
- Paginate `list_issue_comments` so Gate/Reviewer see the newest `### acceptance_checklist` on comment-heavy issues.
- Without this, `require_checklist_complete` can treat an old incomplete checklist as latest and block merge after Reviewer has already posted `all_done: true`.

## Test plan
- [x] Unit test for comment pagination
- [x] Existing github_api retry tests pass


Made with [Cursor](https://cursor.com)