### PR TITLE
fix: fail closed on broken Builder conflict merges

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -72,6 +72,11 @@ a dirty PR as unfinished Builder work.
    `git merge origin/main` fails with “not something we can merge” and loops
    Builder↔Reviewer. `builder_conflicts.py` must fetch with an explicit refspec:
    `+refs/heads/{base}:refs/remotes/origin/{base}`.
+   **Post-merge smoke (mandatory):** after conflict resolution, `builder_conflicts`
+   must run `from app.main import app` and refuse to push / claim `resolved`
+   when markers remain or import fails (typical breaks: dropped `admin_router`,
+   missing Protocol exports, obsolete Basic-auth imports). Status
+   `broken_after_resolve` → `waiting` handoff — never Reviewer.
 4. Comment `### builder_conflict_context` and `### builder_conflict_result` on
    the issue.
 5. **Re-check** `mergeable` / `mergeable_state`. Only when clean → hand off

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -20,6 +20,10 @@ is set. OpenAI and GitHub Models are backups (OpenAI quota is often exhausted).
    **Pitfall:** the conflict clone uses `--single-branch`; fetching the base
    must use an explicit refspec (`+refs/heads/main:refs/remotes/origin/main`)
    or `git merge origin/main` fails and loops Builder↔Reviewer.
+   **Pitfall:** a “resolved” merge that drops imports / router wiring / Protocol
+   exports breaks CI (`NameError` / `ImportError`) and also loops — resolution
+   must smoke `from app.main import app` before push (`broken_after_resolve`
+   → `waiting`, never Reviewer).
 7. Reviewer (acceptance checklist + screenshots). If the PR is dirty again
    (e.g. another merge landed), Reviewer requests changes and requeues Builder.
 

--- a/scripts/builder_conflicts.py
+++ b/scripts/builder_conflicts.py
@@ -12,6 +12,7 @@ import argparse
 import os
 import re
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Callable
@@ -23,6 +24,11 @@ DEFAULT_RECENT_PRS = 8
 DEFAULT_RECENT_ISSUES = 8
 MAX_BODY_CHARS = 1200
 MAX_FILE_CHARS = 60_000
+# Fast import check after conflict resolution. Broken merges that still claim
+# ``resolved`` were looping Builder↔Reviewer (e.g. dropped ``admin_router``,
+# missing Protocol exports). Fail closed until smoke passes.
+SMOKE_IMPORT = "from app.main import app"
+SMOKE_TIMEOUT_SEC = 90
 
 
 def linked_open_prs(repo: str, issue: int) -> list[dict[str, Any]]:
@@ -261,6 +267,45 @@ def strip_conflict_markers_prefer_head(text: str) -> str:
 ResolveFn = Callable[[str, str, str], str]
 
 
+def leftover_conflict_markers(cwd: Path, paths: list[str]) -> list[str]:
+    """Return relative paths that still contain git conflict markers."""
+    dirty: list[str] = []
+    for rel in paths:
+        path = cwd / rel
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if CONFLICT_MARKER.search(text):
+            dirty.append(rel)
+    return dirty
+
+
+def smoke_import_app(cwd: Path) -> tuple[bool, str]:
+    """Import ``app.main`` after a merge; return ``(ok, detail)``."""
+    env = {**os.environ, "PYTHONPATH": str(cwd)}
+    # Preview/auth settings are optional for import; avoid requiring secrets.
+    env.setdefault("ADMIN_PREVIEW_MODE", "1")
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", SMOKE_IMPORT],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=SMOKE_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"smoke timed out after {SMOKE_TIMEOUT_SEC}s ({SMOKE_IMPORT})"
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip() or f"exit {proc.returncode}"
+        return False, detail[:800]
+    return True, "ok"
+
+
 def default_resolve_file(
     path: str,
     conflicted_text: str,
@@ -276,7 +321,11 @@ def default_resolve_file(
     system = (
         "You resolve git merge conflicts for a product repo. "
         "Return ONLY the full resolved file contents — no markdown fences, "
-        "no explanation. Preserve both feature intent and recently merged work."
+        "no explanation. Preserve both feature intent and recently merged work. "
+        "Never drop imports, router wiring (`admin_router`), Protocol/repository "
+        "exports, cookie/session symbol names, or migration catalog entries that "
+        "either side defines — union both sides when unsure. Prefer keeping "
+        "main's auth/session APIs when they conflict with obsolete Basic-auth tests."
     )
     user = (
         f"{brief}\n\n"
@@ -436,6 +485,23 @@ def merge_default_into_pr_branch(
             ],
             cwd=root,
         )
+
+        # Fail closed: do not push or claim ``resolved`` when markers remain or
+        # ``app.main`` no longer imports (classic Builder↔Reviewer loop).
+        marker_hits = leftover_conflict_markers(root, resolved_paths)
+        smoke_ok, smoke_detail = smoke_import_app(root)
+        if marker_hits or not smoke_ok:
+            return {
+                "status": "broken_after_resolve",
+                "pr": pr_number,
+                "head": head_ref,
+                "base": base_ref,
+                "conflicted": resolved_paths,
+                "leftover_markers": marker_hits,
+                "smoke_error": None if smoke_ok else smoke_detail,
+                "pushed": False,
+            }
+
         if push:
             _run_git(["push", "origin", f"HEAD:{head_ref}"], cwd=root)
         return {
@@ -498,18 +564,29 @@ def maybe_resolve_pr_conflicts(
         recent_brief=recent,
     )
     result["issue"] = issue
-    post_issue_comment(
-        repo,
-        issue,
-        (
-            "### builder_conflict_result\n"
-            f"- status: `{result.get('status')}`\n"
-            f"- pr: #{pr_number}\n"
-            f"- head: `{result.get('head')}`\n"
-            f"- base: `{result.get('base')}`\n"
-            f"- conflicted: {', '.join(f'`{p}`' for p in result.get('conflicted') or []) or '(none)'}\n"
-        ),
-    )
+    lines = [
+        "### builder_conflict_result\n",
+        f"- status: `{result.get('status')}`\n",
+        f"- pr: #{pr_number}\n",
+        f"- head: `{result.get('head')}`\n",
+        f"- base: `{result.get('base')}`\n",
+        f"- conflicted: {', '.join(f'`{p}`' for p in result.get('conflicted') or []) or '(none)'}\n",
+    ]
+    if result.get("status") == "broken_after_resolve":
+        markers = result.get("leftover_markers") or []
+        if markers:
+            lines.append(
+                "- leftover_markers: "
+                + ", ".join(f"`{p}`" for p in markers)
+                + "\n"
+            )
+        if result.get("smoke_error"):
+            lines.append(f"- smoke_error: `{result['smoke_error']}`\n")
+        lines.append(
+            "- note: resolution did **not** push; re-enter Builder (`waiting`) — "
+            "do not hand off to Reviewer until `from app.main import app` succeeds.\n"
+        )
+    post_issue_comment(repo, issue, "".join(lines))
     return result
 
 
@@ -535,7 +612,11 @@ def main(argv: list[str] | None = None) -> int:
         push=not args.no_push,
     )
     print(result)
-    return 0 if result.get("status") in {"clean", "merged_clean", "resolved", "no_pr"} else 1
+    return (
+        0
+        if result.get("status") in {"clean", "merged_clean", "resolved", "no_pr"}
+        else 1
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_builder_conflicts.py
+++ b/tests/test_builder_conflicts.py
@@ -223,6 +223,92 @@ def test_merge_fetch_uses_explicit_refspec_for_single_branch_clone(monkeypatch) 
     assert fetch[2] == "+refs/heads/main:refs/remotes/origin/main"
 
 
+def test_leftover_conflict_markers(tmp_path) -> None:
+    from builder_conflicts import leftover_conflict_markers
+
+    clean = tmp_path / "ok.py"
+    clean.write_text("x = 1\n", encoding="utf-8")
+    dirty = tmp_path / "bad.py"
+    dirty.write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> main\n", encoding="utf-8")
+    assert leftover_conflict_markers(tmp_path, ["ok.py", "bad.py"]) == ["bad.py"]
+
+
+def test_smoke_import_app_reports_failure(tmp_path) -> None:
+    from builder_conflicts import smoke_import_app
+
+    # Empty tree cannot import app.main
+    ok, detail = smoke_import_app(tmp_path)
+    assert ok is False
+    assert detail
+
+
+def test_merge_conflict_resolve_skips_push_when_smoke_fails(monkeypatch, tmp_path) -> None:
+    """Broken conflict merges must not claim resolved / push (anti-loop)."""
+    from pathlib import Path
+
+    from builder_conflicts import merge_default_into_pr_branch
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "app").mkdir()
+    (root / "app" / "main.py").write_text(
+        "<<<<<<< HEAD\nfrom broken import x\n=======\nfrom other import y\n>>>>>>> main\n",
+        encoding="utf-8",
+    )
+
+    def fake_run_git(args: list[str], *, cwd: Path, check: bool = True):
+        class _Proc:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        if args[:1] == ["merge"]:
+            _Proc.returncode = 1
+            return _Proc()
+        if args[:2] == ["diff", "--name-only"]:
+            _Proc.stdout = "app/main.py\n"
+            return _Proc()
+        if args[0] == "push":
+            raise AssertionError("must not push when smoke fails")
+        return _Proc()
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr("builder_conflicts._run_git", fake_run_git)
+    monkeypatch.setattr(
+        "builder_conflicts.summarize_recent_closed_work",
+        lambda repo, **kwargs: "",
+    )
+    monkeypatch.setattr(
+        "builder_conflicts.list_unmerged_paths",
+        lambda cwd: ["app/main.py"],
+    )
+    monkeypatch.setattr(
+        "builder_conflicts.default_resolve_file",
+        lambda path, text, brief, chat=None: "from broken import x\n",
+    )
+    monkeypatch.setattr(
+        "builder_conflicts.smoke_import_app",
+        lambda cwd: (False, "NameError: name 'admin_router' is not defined"),
+    )
+
+    pr = {
+        "number": 135,
+        "title": "builder: contacts (#105)",
+        "body": "Closes #105",
+        "head": {"ref": "builder/105-x"},
+        "base": {"ref": "main"},
+    }
+    result = merge_default_into_pr_branch(
+        "saberistic-team/agent-web",
+        pr,
+        work_dir=root,
+        push=True,
+    )
+    assert result["status"] == "broken_after_resolve"
+    assert result.get("pushed") is False
+    assert "admin_router" in (result.get("smoke_error") or "")
+
+
 def test_linked_pr_conflict_status_clean(monkeypatch) -> None:
     from builder_conflicts import linked_pr_conflict_status
 


### PR DESCRIPTION
## Summary
- Builder↔Reviewer was looping when `builder_conflicts` marked merges `resolved` while dropping `admin_router`, Protocol exports, or session cookie symbols.
- After conflict resolution, smoke `from app.main import app` and refuse to push/`resolved` on leftover markers or import failure (`broken_after_resolve` → waiting handoff).
- Document the anti-loop rule in `AGENTS/builder.md` and `docs/MODELS.md`.

## Test plan
- [x] `PYTHONPATH=scripts pytest tests/test_builder_conflicts.py`
- [ ] Confirm next dirty CRM PR (`#105` / `#106`) re-queues Builder instead of Reviewer when smoke fails


Made with [Cursor](https://cursor.com)