### PR TITLE
fix: requeue Builder on retryable codegen failures

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -119,15 +119,16 @@ jobs:
           )"
               ;;
             waiting)
-              # Unresolved merge conflicts (or similar): stay in the priority queue
-              # so Builder runs again — do not send a dirty PR to Reviewer.
+              # Unresolved conflicts, retryable codegen (timeouts / soft file
+              # budget), or unfinished work: stay in the priority queue so
+              # Builder runs again — never status:blocked for those cases.
               gh issue edit "${ISSUE}" \
                 --repo "${{ github.repository }}" \
                 --add-label "status:queued"
               gh issue comment "${ISSUE}" --repo "${{ github.repository }}" --body "$(cat <<EOF
           ### builder_handoff
           - status: \`status:queued\`
-          - next: dispatcher will re-apply \`agent:builder\` (merge conflicts / unfinished)
+          - next: dispatcher will re-apply \`agent:builder\` (retryable codegen / merge conflicts / unfinished)
           EOF
           )"
               ;;

--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -190,15 +190,26 @@ Hide one with CSS at each breakpoint. Reviewer hard-fails when desktop
 
 Stop, comment `@human-review` with the blocker, add `status:blocked`.
 
-Escalate when Cursor/OpenAI/Models codegen fails **after** shared GitHub API
-retries are exhausted (`scripts/github_api.py` retries 408/429/5xx and network
-timeouts with exponential backoff), or when acceptance criteria cannot be met
-from the issue text. Do **not** escalate on a single transient Contents API
-`500` / timeout — retries absorb those before `@human-review`.
+Escalate only for **non-retryable** failures: acceptance criteria cannot be met
+from the issue text, missing landing scaffold, production smoke failure on a
+verify issue, or Cursor/OpenAI/Models codegen failures that are **not**
+transient (after in-script retries). Shared GitHub API retries cover 408/429/5xx
+and network timeouts (`scripts/github_api.py`). Cursor local SDK retries
+`is_retryable` Bridge/timeouts (`CURSOR_LOCAL_ATTEMPTS`, default 3).
 
-Do **not** escalate for service coverage below threshold, missing tests, failing
-CI assertions, visual readability / mobile overflow, or merge conflicts with
-`main` — fix those (same PR head) and re-run.
+Do **not** escalate / `status:blocked` for:
+
+- Cursor Bridge `ReadTimeout` / `retryable=True` (re-enter `status:queued` via
+  `waiting` handoff — learned from [#104](https://github.com/saberistic-team/agent-web/issues/104))
+- Soft “too many files” budgets after a raise of `CURSOR_MAX_FILES` (requeue;
+  learned from [#105](https://github.com/saberistic-team/agent-web/issues/105))
+- Single transient Contents API `500` / timeout
+- Service coverage below threshold, missing tests, failing CI assertions, visual
+  readability / mobile overflow, or merge conflicts with `main` — fix those
+  (same PR head) and re-run
+
+`scripts/run_agent.py` classifies retryable codegen errors with
+`is_retryable_codegen_failure()` → `waiting` handoff, not `@human-review`.
 
 ## Special case: landing / UI design
 

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -88,7 +88,7 @@ while the issue is in the orchestration pipeline.
 | `status:new` | **Entry point only.** Fresh work that has not been claimed by any agent. Humans (or intake automation) may apply this; **only the Planner may move an issue out of `status:new`.** |
 | `status:queued` | Accepted by the Planner and waiting in the **priority queue**. The dispatcher applies `agent:builder` or `agent:docs` when that agent is free, highest priority first. |
 | `status:in-progress` | An agent is actively working the issue. |
-| `status:blocked` | Work cannot proceed until an external dependency or decision is resolved. |
+| `status:blocked` | Work cannot proceed until an **external** dependency or decision is resolved. Do **not** use for transient Cursor SDK timeouts, soft file-budget overruns, coverage gaps, or merge conflicts — those re-enter `status:queued` (`waiting` handoff). |
 | `status:needs-review` | Implementation is ready for review (pairs with the `review` axis). |
 | `status:done` | Work is complete and accepted; Gate sets this only after a complete `### acceptance_checklist` and close. |
 | `status:failed` | The run failed or was aborted; needs human or Planner intervention. |

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -95,7 +95,16 @@ commit per file, which storms CI and races merges).
 
 Docs: [Cursor Python SDK](https://cursor.com/docs/sdk/python)
 
-## Limits (OpenAI / Models JSON path only)
+## Limits
 
-- Max 12 files per issue
-- Prefer plain JSON `content` strings (not brittle `content_b64`)
+| Path | Limit | Notes |
+|------|-------|--------|
+| Cursor local (`CURSOR_MAX_FILES`) | **60** (was 30) | Override via env; soft overruns requeue Builder (`waiting`), do not `status:blocked` |
+| Cursor local attempts (`CURSOR_LOCAL_ATTEMPTS`) | **3** | Retries `is_retryable` Bridge / read timeouts before failing |
+| OpenAI / Models JSON | 12 files | Prefer plain JSON `content` strings (not brittle `content_b64`) |
+
+Transient Cursor timeouts and soft file-budget hits must **re-enter
+`status:queued`** (`### builder_codegen_retry`), not `@human-review` /
+`status:blocked` — see [AGENTS/builder.md](../AGENTS/builder.md) Escalation
+(learned from [#104](https://github.com/saberistic-team/agent-web/issues/104) /
+[#105](https://github.com/saberistic-team/agent-web/issues/105)).

--- a/scripts/codegen_cursor.py
+++ b/scripts/codegen_cursor.py
@@ -197,7 +197,9 @@ def _collect_changed_files(root: Path) -> list[tuple[str, str | bytes]]:
 
     from codegen_models import MAX_FILE_CHARS, is_binary_path
 
-    max_files = int(os.environ.get("CURSOR_MAX_FILES") or "30")
+    # CRM / admin features routinely touch repos + pages + tests; 30 was
+    # falsely blocking Builder (#105). Override with CURSOR_MAX_FILES if needed.
+    max_files = int(os.environ.get("CURSOR_MAX_FILES") or "60")
     if not unique:
         raise GitHubError("Cursor local agent finished but changed no files")
     if len(unique) > max_files:
@@ -255,22 +257,36 @@ def _build_local(
     )
     agent_id = ""
     run_id = ""
-    try:
-        with Agent.create(
-            model=model,
-            api_key=key,
-            name=f"builder-{issue}",
-            local=LocalAgentOptions(cwd=str(root)),
-        ) as agent:
-            agent_id = str(getattr(agent, "agent_id", "") or "")
-            run = agent.send(prompt)
-            run_id = str(getattr(run, "id", "") or "")
-            result = run.wait()
-    except CursorAgentError as exc:
-        retryable = getattr(exc, "is_retryable", False)
+    result = None
+    attempts = max(1, int(os.environ.get("CURSOR_LOCAL_ATTEMPTS") or "3"))
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            with Agent.create(
+                model=model,
+                api_key=key,
+                name=f"builder-{issue}",
+                local=LocalAgentOptions(cwd=str(root)),
+            ) as agent:
+                agent_id = str(getattr(agent, "agent_id", "") or "")
+                run = agent.send(prompt)
+                run_id = str(getattr(run, "id", "") or "")
+                result = run.wait()
+            last_exc = None
+            break
+        except CursorAgentError as exc:
+            last_exc = exc
+            retryable = bool(getattr(exc, "is_retryable", False))
+            if not retryable or attempt >= attempts:
+                raise GitHubError(
+                    f"Cursor SDK local startup failed (retryable={retryable}): {exc}"
+                ) from exc
+            # Brief pause before Bridge/timeout retry (learned from #104).
+            time.sleep(min(2 ** (attempt - 1), 8))
+    if last_exc is not None or result is None:
         raise GitHubError(
-            f"Cursor SDK local startup failed (retryable={retryable}): {exc}"
-        ) from exc
+            f"Cursor SDK local startup failed (retryable=True): {last_exc}"
+        )
 
     status = getattr(result, "status", None)
     if status != "finished":

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -102,6 +102,36 @@ def escalate(repo: str, issue: int, reason: str, assignee_hint: str | None = Non
     replace_status(repo, issue, "status:blocked")
 
 
+def is_retryable_codegen_failure(exc: BaseException) -> bool:
+    """True when Builder should re-enter ``status:queued`` instead of blocking.
+
+    Learned from [#104](https://github.com/saberistic-team/agent-web/issues/104)
+    (Cursor Bridge ``ReadTimeout``, ``retryable=True`` escalated to
+    ``status:blocked``) and [#105](https://github.com/saberistic-team/agent-web/issues/105)
+    (file-budget overrun → false human-review). Transient SDK/network failures and
+    soft budget hits are operator-retriable by the dispatcher — not external
+    blockers.
+    """
+    text = str(exc).lower()
+    if "retryable=true" in text.replace(" ", ""):
+        return True
+    markers = (
+        "readtimeout",
+        "timed out",
+        "bridge request timed out",
+        "temporarily unavailable",
+        "connection reset",
+        "connection aborted",
+        "connection error",
+        "remoteprotocolerror",
+        "server disconnected",
+        "too many files",
+        "changed too many files",
+        "model proposed too many files",
+    )
+    return any(marker in text for marker in markers)
+
+
 def write_builder_handoff(mode: str) -> None:
     """Tell builder.yml how to advance labels: reviewer | done | blocked | waiting."""
     if mode not in {"reviewer", "done", "blocked", "waiting"}:
@@ -616,20 +646,30 @@ def role_builder(repo: str, issue: int, brief: Path) -> None:
         # After codegen, merge base if dirty; hand off only when mergeable.
         handoff_builder_when_mergeable(repo, issue)
     except Exception as exc:
-        escalate(
-            repo,
-            issue,
-            (
-                "Codegen failed (Cursor SDK / OpenAI / GitHub Models).\n\n"
-                f"`{exc}`\n\n"
-                "Preferred: Cursor Agent SDK via `CURSOR_API_KEY` "
-                "(`CODEGEN_PROVIDER=cursor`, `CURSOR_RUNTIME=local` by default). "
-                "Optional: OpenAI (`OPENAI_API_KEY`) or GitHub Models (`MODELS_TOKEN`). "
-                "See docs/MODELS.md. "
-                "If `git/refs` returns 403 for the Builder App, grant the App "
-                "`contents: write` on this repository."
-            ),
+        detail = (
+            "Codegen failed (Cursor SDK / OpenAI / GitHub Models).\n\n"
+            f"`{exc}`\n\n"
+            "Preferred: Cursor Agent SDK via `CURSOR_API_KEY` "
+            "(`CODEGEN_PROVIDER=cursor`, `CURSOR_RUNTIME=local` by default). "
+            "Optional: OpenAI (`OPENAI_API_KEY`) or GitHub Models (`MODELS_TOKEN`). "
+            "See docs/MODELS.md. "
+            "If `git/refs` returns 403 for the Builder App, grant the App "
+            "`contents: write` on this repository."
         )
+        if is_retryable_codegen_failure(exc):
+            post_issue_comment(
+                repo,
+                issue,
+                (
+                    "### builder_codegen_retry\n"
+                    "- result: `waiting`\n"
+                    "- reason: transient / soft codegen failure (do not `status:blocked`)\n\n"
+                    f"{detail}\n"
+                ),
+            )
+            write_builder_handoff("waiting")
+            return
+        escalate(repo, issue, detail)
         write_builder_handoff("blocked")
 
 

--- a/tests/test_run_agent_codegen_retry.py
+++ b/tests/test_run_agent_codegen_retry.py
@@ -1,0 +1,35 @@
+"""Builder codegen failures must requeue when retryable (not status:blocked)."""
+
+from __future__ import annotations
+
+import pytest
+
+from run_agent import is_retryable_codegen_failure
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Cursor SDK local startup failed (retryable=True): Bridge request timed out: ReadTimeout: timed out",
+        "Cursor changed too many files (32 > 30): app/admin_companies.py, app/contacts.py",
+        "model proposed too many files (15 > 12)",
+        "RemoteProtocolError: Server disconnected",
+        "temporarily unavailable",
+    ],
+)
+def test_retryable_codegen_failures(message: str) -> None:
+    assert is_retryable_codegen_failure(RuntimeError(message))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Cursor SDK local startup failed (retryable=False): permanent auth error",
+        "acceptance criteria cannot be met from the issue text",
+        "Landing scaffold missing (`site/index.html`)",
+    ],
+)
+def test_non_retryable_codegen_failures(message: str) -> None:
+    assert not is_retryable_codegen_failure(RuntimeError(message))


### PR DESCRIPTION
## Summary
- Stop escalating Cursor Bridge `ReadTimeout` / `retryable=True` and soft “too many files” budgets to `status:blocked` (learned from #104 / #105)
- Retry local Cursor SDK startups (`CURSOR_LOCAL_ATTEMPTS`, default 3) and raise `CURSOR_MAX_FILES` default to 60
- Document the `waiting` handoff path in Builder brief, MODELS, LABELS, and builder.yml

## Test plan
- [x] `pytest tests/test_run_agent_codegen_retry.py tests/test_codegen_cursor.py`
- [ ] Confirm a synthetic timeout comment path would land `status:queued` via `waiting` handoff
- [ ] After merge, requeue #104 / #105 so dispatcher can drain them


Made with [Cursor](https://cursor.com)