### PR TITLE
fix: stop Builder↔Reviewer loops (SDK auth token, pre-handoff smoke, acceptance AI)

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -106,6 +106,12 @@ a dirty PR as unfinished Builder work.
    when markers remain or import fails (typical breaks: dropped `admin_router`,
    missing Protocol exports, obsolete Basic-auth imports). Status
    `broken_after_resolve` → `waiting` handoff — never Reviewer.
+   **Pre-handoff smoke (mandatory even when `mergeable: clean`):** Builder also
+   clones the PR head and smoke-imports before writing `reviewer` handoff.
+   Stale heads with `NameError: admin_router` / `CORRELATION_HEADER` are
+   mergeable but still break Reviewer screenshots — that was a Builder↔Reviewer
+   loop on CRM PRs. Known import gaps may be auto-repaired (`repair_main_wiring`)
+   once; persistent smoke failure stays `waiting`.
 4. Comment `### builder_conflict_context` and `### builder_conflict_result` on
    the issue.
 5. **Re-check** `mergeable` / `mergeable_state`. Only when clean → hand off
@@ -200,7 +206,11 @@ and network timeouts (`scripts/github_api.py`). Cursor local SDK retries
 Do **not** escalate / `status:blocked` for:
 
 - Cursor Bridge `ReadTimeout` / `retryable=True` (re-enter `status:queued` via
-  `waiting` handoff — learned from [#104](https://github.com/saberistic-team/agent-web/issues/104))
+  `waiting` handoff — learned from [#104](https://github.com/saberistic-team/agent-web/issues/104)
+  / [#108](https://github.com/saberistic-team/agent-web/issues/108))
+- Bridge argv bug `Missing value for --tool-callback-auth-token` (tokens starting
+  with `-`; SDK may say `retryable=False` but Builder still requeues —
+  `scripts/cursor_sdk_patch.py` patches token minting)
 - Soft “too many files” budgets after a raise of `CURSOR_MAX_FILES` (requeue;
   learned from [#105](https://github.com/saberistic-team/agent-web/issues/105))
 - Single transient Contents API `500` / timeout

--- a/AGENTS/reviewer.md
+++ b/AGENTS/reviewer.md
@@ -101,7 +101,11 @@ Any of these is an automatic request-changes — do not approve:
   `.admin-nav-link` nodes exist but none are visible (common when nav links live
   inside a closed `<details>` without a separate desktop list) — Builder must
   keep the desktop list **outside** `<details>` (`format_admin_nav_hard_fail`)
-- Acceptance checklist incomplete (`all_done: false` or missing)
+- Acceptance checklist incomplete (`all_done: false` or missing) when criteria
+  are product-failed. **Exception:** acceptance AI infra/parse failures
+  (`method: ai-error`, e.g. Cursor returned prose instead of JSON) are **not**
+  Builder work when the AI PR review already `approved` — defer to that verdict
+  and do not `REQUEST_CHANGES` solely for the checklist transport glitch.
 
 Coverage gaps, missing tests, CI assertion failures, visual overflow, empty
 preview shells, invisible desktop admin nav, and **merge conflicts** are

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -23,7 +23,15 @@ is set. OpenAI and GitHub Models are backups (OpenAI quota is often exhausted).
    **Pitfall:** a “resolved” merge that drops imports / router wiring / Protocol
    exports breaks CI (`NameError` / `ImportError`) and also loops — resolution
    must smoke `from app.main import app` before push (`broken_after_resolve`
-   → `waiting`, never Reviewer).
+   → `waiting`, never Reviewer). **Also smoke mergeable/clean PR heads** before
+   handoff; an already-broken remote head can be `mergeable: true` while
+   `admin_router` / `CORRELATION_HEADER` are undefined.
+   **Pitfall:** Cursor local bridge rejects callback tokens that start with `-`
+   (`Missing value for --tool-callback-auth-token`). SDK may mark
+   `retryable=False`, but Builder must treat it as `waiting` and patch token
+   minting (`scripts/cursor_sdk_patch.py`) — never `status:blocked`.
+   **Pitfall:** acceptance checklist AI returning non-JSON must not invent
+   product `not_done` rows that bounce Builder when AI review already approved.
    **Pitfall:** per-file Contents API commits (Builder file loop or Reviewer
    screenshots) storm CI and race other merges — codegen/uploads must use
    `put_files` / `put_file_batch` / batched `upload_to_branch` (one commit).

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -546,13 +546,16 @@ def verify_acceptance(
             try:
                 items.extend(ai_check_remaining(criteria, evidence, items))
             except Exception as exc:
+                # Infra/parse failures must not invent product not_done rows —
+                # that bounced Reviewer↔Builder when AI review already approved
+                # (e.g. Cursor returned prose instead of JSON).
                 for criterion in criteria:
                     if any(i.get("text") == criterion for i in items):
                         continue
                     items.append(
                         {
                             "text": criterion,
-                            "status": "not_done",
+                            "status": "n/a",
                             "evidence": [],
                             "note": f"AI verification unavailable: {exc}",
                             "method": "ai-error",
@@ -581,11 +584,21 @@ def verify_acceptance(
         i for i in items if i.get("text") not in criteria
     ]
 
-    all_done = bool(ordered) and all(
-        i.get("status") in {"done", "n/a"} for i in ordered
+    # Treat AI-infra-only gaps as non-blocking for all_done; product not_done
+    # still fails. Callers that need a strict checklist inspect ai_infra_failed.
+    product_items = [i for i in ordered if i.get("method") != "ai-error"]
+    all_done = bool(product_items) and all(
+        i.get("status") in {"done", "n/a"} for i in product_items
     )
+    if not product_items and ordered and all(
+        i.get("method") == "ai-error" for i in ordered
+    ):
+        # Every criterion was AI-infra-only — inconclusive, not a product fail.
+        all_done = False
+    ai_infra_failed = any(i.get("method") == "ai-error" for i in ordered)
     return {
         "all_done": all_done,
+        "ai_infra_failed": ai_infra_failed,
         "items": ordered,
         "evidence": {
             "pr_url": evidence.get("pr_url"),
@@ -604,6 +617,8 @@ def format_checklist(result: dict[str, Any], *, role: str) -> str:
         f"- role: `{role}`",
         f"- all_done: `{str(bool(result.get('all_done'))).lower()}`",
     ]
+    if result.get("ai_infra_failed"):
+        lines.append("- ai_infra_failed: `true`")
     meta = result.get("evidence") or {}
     if meta.get("pr_url"):
         lines.append(f"- pr: {meta['pr_url']}")

--- a/scripts/builder_conflicts.py
+++ b/scripts/builder_conflicts.py
@@ -30,6 +30,29 @@ MAX_FILE_CHARS = 60_000
 SMOKE_IMPORT = "from app.main import app"
 SMOKE_TIMEOUT_SEC = 90
 
+# Symbols commonly dropped during conflict/codegen that break ``app.main``.
+MAIN_WIRING_IMPORTS: tuple[tuple[str, str], ...] = (
+    (
+        "admin_router",
+        "from app.admin_routes import router as admin_router",
+    ),
+    (
+        "CORRELATION_HEADER",
+        "from app.actor_context import CORRELATION_HEADER",
+    ),
+    (
+        "AdminLoginRequired",
+        "from app.admin_auth import AdminLoginRequired, login_redirect_url",
+    ),
+    (
+        "login_redirect_url",
+        "from app.admin_auth import AdminLoginRequired, login_redirect_url",
+    ),
+)
+_NAMEERROR_RE = re.compile(
+    r"NameError: name '([A-Za-z_][A-Za-z0-9_]*)' is not defined"
+)
+
 
 def linked_open_prs(repo: str, issue: int) -> list[dict[str, Any]]:
     owner, name = split_repo(repo)
@@ -40,6 +63,185 @@ def linked_open_prs(repo: str, issue: int) -> list[dict[str, Any]]:
         for pr in prs
         if needle in (pr.get("title") or "") or needle in (pr.get("body") or "")
     ]
+
+
+def repair_main_wiring(text: str) -> tuple[str, list[str]]:
+    """Ensure known ``app.main`` symbols have their imports. Returns (text, added)."""
+    added: list[str] = []
+    lines = text.splitlines(keepends=True)
+    existing = set(lines)
+    insert_at = 0
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("from ") or stripped.startswith("import "):
+            insert_at = i + 1
+        elif stripped and not stripped.startswith("#") and insert_at:
+            break
+    for symbol, stmt in MAIN_WIRING_IMPORTS:
+        if symbol not in text:
+            continue
+        # Already imported under this name or as ``router as admin_router``.
+        if re.search(rf"\bas {re.escape(symbol)}\b", text) or re.search(
+            rf"^from .+ import .*\b{re.escape(symbol)}\b", text, re.M
+        ):
+            continue
+        if any(stmt in line for line in lines):
+            continue
+        line = stmt + "\n"
+        if line in existing:
+            continue
+        lines.insert(insert_at, line)
+        existing.add(line)
+        insert_at += 1
+        added.append(symbol)
+    return "".join(lines), added
+
+
+def try_repair_main_after_smoke(
+    root: Path, smoke_detail: str
+) -> tuple[bool, str]:
+    """If smoke failed on a known NameError, repair ``app/main.py`` in place."""
+    match = _NAMEERROR_RE.search(smoke_detail or "")
+    if not match:
+        return False, "no NameError to repair"
+    main_path = root / "app" / "main.py"
+    if not main_path.is_file():
+        return False, "app/main.py missing"
+    original = main_path.read_text(encoding="utf-8")
+    fixed, added = repair_main_wiring(original)
+    if not added or fixed == original:
+        return False, f"no wiring repair for {match.group(1)}"
+    main_path.write_text(fixed, encoding="utf-8")
+    return True, f"added imports for: {', '.join(added)}"
+
+
+def smoke_import_app(cwd: Path) -> tuple[bool, str]:
+    """Import ``app.main`` after a merge; return ``(ok, detail)``."""
+    env = {**os.environ, "PYTHONPATH": str(cwd)}
+    # Preview/auth settings are optional for import; avoid requiring secrets.
+    env.setdefault("ADMIN_PREVIEW_MODE", "1")
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", SMOKE_IMPORT],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=SMOKE_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"smoke timed out after {SMOKE_TIMEOUT_SEC}s ({SMOKE_IMPORT})"
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip() or f"exit {proc.returncode}"
+        return False, detail[:800]
+    return True, "ok"
+
+
+def smoke_and_maybe_repair_app(cwd: Path) -> tuple[bool, str, list[str]]:
+    """Smoke ``app.main``; attempt one known-import repair on NameError."""
+    ok, detail = smoke_import_app(cwd)
+    repairs: list[str] = []
+    if ok:
+        return True, detail, repairs
+    repaired, note = try_repair_main_after_smoke(cwd, detail)
+    if not repaired:
+        return False, detail, repairs
+    repairs.append(note)
+    ok2, detail2 = smoke_import_app(cwd)
+    if ok2:
+        return True, detail2, repairs
+    return False, detail2, repairs
+
+
+def clone_pr_head(repo: str, pr: dict[str, Any], *, dest: Path) -> Path:
+    """Shallow-clone the PR head ref into ``dest`` (must not exist)."""
+    owner, name = split_repo(repo)
+    head_ref = (pr.get("head") or {}).get("ref")
+    if not head_ref:
+        raise GitHubError(f"PR #{pr.get('number')} missing head.ref")
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        raise GitHubError("missing GITHUB_TOKEN for PR head smoke clone")
+    clone_url = f"https://x-access-token:{token}@github.com/{owner}/{name}.git"
+    parent = dest.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    _run_git(
+        ["clone", "--branch", head_ref, "--single-branch", clone_url, str(dest)],
+        cwd=parent,
+    )
+    return dest
+
+
+def smoke_pr_head(
+    repo: str,
+    pr: dict[str, Any],
+    *,
+    push_repair: bool = True,
+) -> dict[str, Any]:
+    """Clone PR head and smoke-import ``app.main`` (even when mergeable/clean).
+
+    Optional wiring repair is committed + pushed when smoke recovers, so stale
+    broken heads stop looping Builder↔Reviewer without needing a new conflict.
+    """
+    pr_number = int(pr["number"])
+    head_ref = (pr.get("head") or {}).get("ref") or ""
+    with tempfile.TemporaryDirectory(prefix="builder-smoke-") as tmp:
+        root = Path(tmp) / "repo"
+        clone_pr_head(repo, pr, dest=root)
+        ok, detail, repairs = smoke_and_maybe_repair_app(root)
+        if ok and repairs and push_repair:
+            _run_git(["config", "user.name", "saberistic-agent-web-builder"], cwd=root)
+            _run_git(
+                ["config", "user.email", "builder@users.noreply.github.com"],
+                cwd=root,
+            )
+            _run_git(["add", "--", "app/main.py"], cwd=root)
+            commit = _run_git(
+                [
+                    "commit",
+                    "-m",
+                    f"builder: repair app.main wiring after smoke (#{pr_number})",
+                ],
+                cwd=root,
+                check=False,
+            )
+            if commit.returncode != 0:
+                return {
+                    "status": "smoke_ok",
+                    "pr": pr_number,
+                    "head": head_ref,
+                    "smoke_error": None,
+                    "repairs": repairs,
+                    "pushed": False,
+                    "note": "repair applied locally but commit failed",
+                }
+            _run_git(["push", "origin", f"HEAD:{head_ref}"], cwd=root)
+            return {
+                "status": "smoke_repaired",
+                "pr": pr_number,
+                "head": head_ref,
+                "smoke_error": None,
+                "repairs": repairs,
+                "pushed": True,
+            }
+        if ok:
+            return {
+                "status": "smoke_ok",
+                "pr": pr_number,
+                "head": head_ref,
+                "smoke_error": None,
+                "repairs": repairs,
+                "pushed": False,
+            }
+        return {
+            "status": "smoke_failed",
+            "pr": pr_number,
+            "head": head_ref,
+            "smoke_error": detail,
+            "repairs": repairs,
+            "pushed": False,
+        }
 
 
 def refresh_pr(repo: str, pr_number: int) -> dict[str, Any]:
@@ -283,29 +485,6 @@ def leftover_conflict_markers(cwd: Path, paths: list[str]) -> list[str]:
     return dirty
 
 
-def smoke_import_app(cwd: Path) -> tuple[bool, str]:
-    """Import ``app.main`` after a merge; return ``(ok, detail)``."""
-    env = {**os.environ, "PYTHONPATH": str(cwd)}
-    # Preview/auth settings are optional for import; avoid requiring secrets.
-    env.setdefault("ADMIN_PREVIEW_MODE", "1")
-    try:
-        proc = subprocess.run(
-            [sys.executable, "-c", SMOKE_IMPORT],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=SMOKE_TIMEOUT_SEC,
-            check=False,
-        )
-    except subprocess.TimeoutExpired:
-        return False, f"smoke timed out after {SMOKE_TIMEOUT_SEC}s ({SMOKE_IMPORT})"
-    if proc.returncode != 0:
-        detail = (proc.stderr or proc.stdout or "").strip() or f"exit {proc.returncode}"
-        return False, detail[:800]
-    return True, "ok"
-
-
 def default_resolve_file(
     path: str,
     conflicted_text: str,
@@ -436,6 +615,30 @@ def merge_default_into_pr_branch(
             check=False,
         )
         if merge.returncode == 0:
+            smoke_ok, smoke_detail, repairs = smoke_and_maybe_repair_app(root)
+            if not smoke_ok:
+                return {
+                    "status": "broken_after_resolve",
+                    "pr": pr_number,
+                    "head": head_ref,
+                    "base": base_ref,
+                    "conflicted": [],
+                    "leftover_markers": [],
+                    "smoke_error": smoke_detail,
+                    "repairs": repairs,
+                    "pushed": False,
+                }
+            if repairs:
+                _run_git(["add", "--", "app/main.py"], cwd=root)
+                _run_git(
+                    [
+                        "commit",
+                        "-m",
+                        f"builder: repair app.main wiring after merge (#{pr_number})",
+                    ],
+                    cwd=root,
+                    check=False,
+                )
             if push:
                 _run_git(["push", "origin", f"HEAD:{head_ref}"], cwd=root)
             return {
@@ -444,6 +647,7 @@ def merge_default_into_pr_branch(
                 "head": head_ref,
                 "base": base_ref,
                 "conflicted": [],
+                "repairs": repairs,
             }
 
         conflicted = list_unmerged_paths(root)
@@ -489,7 +693,18 @@ def merge_default_into_pr_branch(
         # Fail closed: do not push or claim ``resolved`` when markers remain or
         # ``app.main`` no longer imports (classic Builder↔Reviewer loop).
         marker_hits = leftover_conflict_markers(root, resolved_paths)
-        smoke_ok, smoke_detail = smoke_import_app(root)
+        smoke_ok, smoke_detail, repairs = smoke_and_maybe_repair_app(root)
+        if repairs:
+            _run_git(["add", "--", "app/main.py"], cwd=root)
+            _run_git(
+                [
+                    "commit",
+                    "-m",
+                    f"builder: repair app.main wiring after conflict resolve (#{pr_number})",
+                ],
+                cwd=root,
+                check=False,
+            )
         if marker_hits or not smoke_ok:
             return {
                 "status": "broken_after_resolve",
@@ -499,6 +714,7 @@ def merge_default_into_pr_branch(
                 "conflicted": resolved_paths,
                 "leftover_markers": marker_hits,
                 "smoke_error": None if smoke_ok else smoke_detail,
+                "repairs": repairs,
                 "pushed": False,
             }
 
@@ -510,6 +726,7 @@ def merge_default_into_pr_branch(
             "head": head_ref,
             "base": base_ref,
             "conflicted": resolved_paths,
+            "repairs": repairs,
         }
 
 

--- a/scripts/codegen_cursor.py
+++ b/scripts/codegen_cursor.py
@@ -539,6 +539,9 @@ def build_with_cursor(
 
     try:
         import cursor_sdk  # noqa: F401
+        from cursor_sdk_patch import patch_callback_auth_tokens
+
+        patch_callback_auth_tokens()
     except ImportError as exc:
         raise GitHubError(
             "cursor-sdk is not installed; pip install -r requirements-agents.txt"

--- a/scripts/cursor_sdk_patch.py
+++ b/scripts/cursor_sdk_patch.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Workarounds for known Cursor Python SDK bridge bugs.
+
+The local bridge rejects callback auth tokens that start with ``-`` (arg parse
+treats them as flags), which surfaces as::
+
+    Missing value for --tool-callback-auth-token
+
+SDK marks that as ``retryable=False``, which previously escalated Builder to
+``status:blocked``. Patch token minting so tokens never start with ``-``, and
+treat residual bridge/token failures as dispatcher-retriable.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+
+def safe_auth_token(nbytes: int = 32) -> str:
+    """``token_urlsafe`` that never starts with ``-`` (bridge argv safe)."""
+    while True:
+        token = secrets.token_urlsafe(nbytes)
+        if not token.startswith("-"):
+            return token
+
+
+def patch_callback_auth_tokens() -> bool:
+    """Monkeypatch SDK token minting. Returns True when a patch was applied."""
+    applied = False
+    for mod_name in ("cursor_sdk._tool_callback", "cursor_sdk._store_callback"):
+        try:
+            mod = __import__(mod_name, fromlist=["_new_auth_token"])
+        except Exception:
+            continue
+        if not hasattr(mod, "_new_auth_token"):
+            continue
+
+        def _token() -> str:
+            return safe_auth_token()
+
+        setattr(mod, "_new_auth_token", _token)
+        applied = True
+    return applied

--- a/scripts/post_deploy_visual.py
+++ b/scripts/post_deploy_visual.py
@@ -206,6 +206,9 @@ def visual_ai_check_cursor(
     model = os.environ.get("CURSOR_MODEL") or DEFAULT_CURSOR_MODEL
     try:
         from cursor_sdk import Agent, AgentOptions, LocalAgentOptions
+        from cursor_sdk_patch import patch_callback_auth_tokens
+
+        patch_callback_auth_tokens()
     except ImportError as exc:
         raise GitHubError(
             "cursor-sdk is not installed; pip install -r requirements-agents.txt"

--- a/scripts/review_models.py
+++ b/scripts/review_models.py
@@ -48,6 +48,9 @@ def chat_cursor(system: str, user: str, model: str | None = None) -> tuple[str, 
     model = model or os.environ.get("CURSOR_MODEL") or DEFAULT_CURSOR_MODEL
     try:
         from cursor_sdk import Agent, AgentOptions, LocalAgentOptions
+        from cursor_sdk_patch import patch_callback_auth_tokens
+
+        patch_callback_auth_tokens()
     except ImportError as exc:
         raise GitHubError(
             "cursor-sdk is not installed; pip install -r requirements-agents.txt"

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -113,7 +113,12 @@ def is_retryable_codegen_failure(exc: BaseException) -> bool:
     blockers.
     """
     text = str(exc).lower()
-    if "retryable=true" in text.replace(" ", ""):
+    compact = text.replace(" ", "")
+    if "retryable=true" in compact:
+        return True
+    # Bridge argv bug: token_urlsafe values starting with "-" → SDK reports
+    # retryable=False, but a requeue (or the token patch) recovers.
+    if "tool-callback-auth-token" in text or "bridge exited before discovery" in text:
         return True
     markers = (
         "readtimeout",
@@ -144,11 +149,15 @@ def handoff_builder_when_mergeable(repo: str, issue: int) -> None:
     """Resolve conflicts if needed; hand off to Reviewer only when the PR is clean.
 
     Unresolved conflicts re-enter the priority queue (``waiting``) so Builder
-    runs again — never send a dirty PR to Reviewer.
+    runs again — never send a dirty PR to Reviewer. Even mergeable/clean heads
+    are smoke-imported so stale NameErrors cannot bounce Reviewer↔Builder.
     """
     from builder_conflicts import (
+        linked_open_prs,
         linked_pr_conflict_status,
         maybe_resolve_pr_conflicts,
+        refresh_pr,
+        smoke_pr_head,
     )
 
     HANDOFF_DIR.mkdir(parents=True, exist_ok=True)
@@ -211,6 +220,56 @@ def handoff_builder_when_mergeable(repo: str, issue: int) -> None:
         )
         write_builder_handoff("waiting")
         return
+
+    # Always smoke the PR head — mergeable/clean heads can still NameError.
+    prs = linked_open_prs(repo, issue)
+    if prs:
+        pr = refresh_pr(repo, int(prs[0]["number"]))
+        try:
+            smoke = smoke_pr_head(repo, pr, push_repair=True)
+        except Exception as smoke_exc:
+            post_issue_comment(
+                repo,
+                issue,
+                (
+                    "### builder_smoke_result\n"
+                    f"- status: `failed`\n"
+                    f"- pr: #{pr.get('number')}\n"
+                    f"- error: `{smoke_exc}`\n"
+                    "- note: re-entering `status:queued` (smoke clone/import failed).\n"
+                ),
+            )
+            write_builder_handoff("waiting")
+            return
+        smoke_status = (smoke.get("status") or "").strip()
+        if smoke_status == "smoke_failed":
+            post_issue_comment(
+                repo,
+                issue,
+                (
+                    "### builder_smoke_result\n"
+                    f"- status: `smoke_failed`\n"
+                    f"- pr: #{smoke.get('pr')}\n"
+                    f"- smoke_error: `{smoke.get('smoke_error')}`\n"
+                    f"- repairs: `{smoke.get('repairs')}`\n"
+                    "- note: not handing off to Reviewer; re-entering "
+                    "`status:queued` until `from app.main import app` succeeds.\n"
+                ),
+            )
+            write_builder_handoff("waiting")
+            return
+        if smoke_status == "smoke_repaired":
+            post_issue_comment(
+                repo,
+                issue,
+                (
+                    "### builder_smoke_result\n"
+                    f"- status: `smoke_repaired`\n"
+                    f"- pr: #{smoke.get('pr')}\n"
+                    f"- repairs: `{smoke.get('repairs')}`\n"
+                    "- note: restored missing ``app.main`` wiring; proceeding to Reviewer.\n"
+                ),
+            )
 
     write_builder_handoff("reviewer")
 
@@ -1001,23 +1060,24 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
 
     # OpenAI / Models AI review (required for approve path).
     ai_block = ""
+    ai_verdict: dict[str, Any] = {}
     try:
         from review_models import ai_review
 
-        verdict = ai_review(repo, issue, pr_number)
+        ai_verdict = ai_review(repo, issue, pr_number)
         ai_block += (
                     f"- ai_provider: `cursor-or-openai-or-models`\n"
-            f"- ai_model: `{verdict.get('model')}`\n"
-            f"- ai_decision: `{verdict.get('decision')}`\n"
-            f"- ai_summary: {verdict.get('summary')}\n"
+            f"- ai_model: `{ai_verdict.get('model')}`\n"
+            f"- ai_decision: `{ai_verdict.get('decision')}`\n"
+            f"- ai_summary: {ai_verdict.get('summary')}\n"
             "- ai_reasons:\n"
-            + "\n".join(f"  - {r}" for r in (verdict.get("reasons") or []))
+            + "\n".join(f"  - {r}" for r in (ai_verdict.get("reasons") or []))
             + "\n"
         )
-        if verdict.get("decision") != "approved":
+        if ai_verdict.get("decision") != "approved":
             hard_fail_reasons.append(
                 "AI reviewer rejected: "
-                + "; ".join(verdict.get("reasons") or ["does not meet acceptance"])
+                + "; ".join(ai_verdict.get("reasons") or ["does not meet acceptance"])
             )
     except Exception as exc:
         hard_fail_reasons.append(f"AI reviewer unavailable: {exc}")
@@ -1029,10 +1089,27 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
         from acceptance import post_checklist, update_issue_checkboxes, verify_acceptance
 
         acceptance = verify_acceptance(repo, issue, pr_number, use_ai=True)
+        product_incomplete = any(
+            i.get("status") not in {"done", "n/a"} and i.get("method") != "ai-error"
+            for i in (acceptance.get("items") or [])
+        )
+        infra_only_gap = bool(acceptance.get("ai_infra_failed")) and not product_incomplete
+        if (
+            infra_only_gap
+            and not acceptance.get("all_done")
+            and ai_verdict.get("decision") == "approved"
+        ):
+            # Defer to AI review so Cursor prose/JSON glitches do not bounce Builder.
+            acceptance = dict(acceptance)
+            acceptance["all_done"] = True
+            acceptance_note += (
+                "- acceptance_ai_infra: `deferred_to_ai_review` "
+                "(checklist AI unavailable; AI review approved)\n"
+            )
         checklist_comment = post_checklist(
             repo, issue, acceptance, role="reviewer"
         )
-        acceptance_note = (
+        acceptance_note += (
             f"- acceptance_all_done: `{str(bool(acceptance.get('all_done'))).lower()}`\n"
             f"- acceptance_checklist: {checklist_comment.get('html_url')}\n"
         )
@@ -1041,6 +1118,16 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
                 update_issue_checkboxes(repo, issue, acceptance)
             except Exception as body_exc:
                 acceptance_note += f"- acceptance_body_update: failed (`{body_exc}`)\n"
+        elif product_incomplete:
+            hard_fail_reasons.append(
+                "acceptance criteria incomplete — see acceptance_checklist comment "
+                + (checklist_comment.get("html_url") or "")
+            )
+        elif infra_only_gap:
+            hard_fail_reasons.append(
+                "acceptance AI unavailable and AI review did not approve — see "
+                + (checklist_comment.get("html_url") or "")
+            )
         else:
             hard_fail_reasons.append(
                 "acceptance criteria incomplete — see acceptance_checklist comment "

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from acceptance import mark_body_checkboxes, parse_criteria
+from acceptance import mark_body_checkboxes, parse_criteria, verify_acceptance
+from github_api import GitHubError
 
 
 def test_parse_criteria_section() -> None:
@@ -28,3 +29,39 @@ def test_mark_body_checkboxes() -> None:
     updated = mark_body_checkboxes(body, ["First thing"])
     assert "- [x] First thing" in updated
     assert "- [ ] Second thing" in updated
+
+
+def test_verify_acceptance_ai_error_is_not_product_not_done(monkeypatch) -> None:
+    """Cursor prose instead of JSON must not invent not_done rows (anti-loop)."""
+
+    def fake_gather(repo, issue, pr_number=None):
+        return {
+            "issue_body": (
+                "## Acceptance criteria\n"
+                "- [ ] Supported stages are X\n"
+                "- [ ] Tests cover transitions\n"
+            ),
+            "issue_title": "pipeline",
+            "issue_url": "https://example.com/i/1",
+            "pr_url": "https://example.com/p/1",
+            "head_sha": "abc",
+            "commits": [],
+            "files": [],
+            "comments": [],
+            "deploy": {},
+        }
+
+    def boom(*_a, **_k):
+        raise GitHubError(
+            "acceptance AI did not return JSON: "
+            "'Gathering PR and codebase evidence against each acceptance criterion.'"
+        )
+
+    monkeypatch.setattr("acceptance.gather_evidence", fake_gather)
+    monkeypatch.setattr("acceptance.ai_check_remaining", boom)
+
+    result = verify_acceptance("o/r", 1, 1, use_ai=True)
+    assert result["ai_infra_failed"] is True
+    assert all(i["method"] == "ai-error" for i in result["items"])
+    assert all(i["status"] == "n/a" for i in result["items"])
+    assert result["all_done"] is False

--- a/tests/test_builder_conflicts.py
+++ b/tests/test_builder_conflicts.py
@@ -200,6 +200,10 @@ def test_merge_fetch_uses_explicit_refspec_for_single_branch_clone(monkeypatch) 
         "builder_conflicts.summarize_recent_closed_work",
         lambda repo, **kwargs: "",
     )
+    monkeypatch.setattr(
+        "builder_conflicts.smoke_and_maybe_repair_app",
+        lambda cwd: (True, "ok", []),
+    )
 
     work_dir = Path("/tmp/builder-conflict-test-repo")
     pr = {
@@ -240,6 +244,27 @@ def test_smoke_import_app_reports_failure(tmp_path) -> None:
     ok, detail = smoke_import_app(tmp_path)
     assert ok is False
     assert detail
+
+
+def test_repair_main_wiring_adds_missing_imports() -> None:
+    from builder_conflicts import repair_main_wiring
+
+    src = (
+        "from fastapi import FastAPI\n"
+        "\n"
+        "app = FastAPI()\n"
+        "app.include_router(admin_router)\n"
+        "hdr = CORRELATION_HEADER\n"
+    )
+    fixed, added = repair_main_wiring(src)
+    assert "admin_router" in added
+    assert "CORRELATION_HEADER" in added
+    assert "from app.admin_routes import router as admin_router" in fixed
+    assert "from app.actor_context import CORRELATION_HEADER" in fixed
+    # Idempotent
+    again, added2 = repair_main_wiring(fixed)
+    assert added2 == []
+    assert again == fixed
 
 
 def test_merge_conflict_resolve_skips_push_when_smoke_fails(monkeypatch, tmp_path) -> None:
@@ -287,8 +312,8 @@ def test_merge_conflict_resolve_skips_push_when_smoke_fails(monkeypatch, tmp_pat
         lambda path, text, brief, chat=None: "from broken import x\n",
     )
     monkeypatch.setattr(
-        "builder_conflicts.smoke_import_app",
-        lambda cwd: (False, "NameError: name 'admin_router' is not defined"),
+        "builder_conflicts.smoke_and_maybe_repair_app",
+        lambda cwd: (False, "NameError: name 'admin_router' is not defined", []),
     )
 
     pr = {
@@ -307,6 +332,17 @@ def test_merge_conflict_resolve_skips_push_when_smoke_fails(monkeypatch, tmp_pat
     assert result["status"] == "broken_after_resolve"
     assert result.get("pushed") is False
     assert "admin_router" in (result.get("smoke_error") or "")
+
+
+def test_is_retryable_includes_bridge_auth_token() -> None:
+    from run_agent import is_retryable_codegen_failure
+
+    assert is_retryable_codegen_failure(
+        RuntimeError(
+            "Cursor SDK local startup failed (retryable=True): "
+            "Bridge request timed out: ReadTimeout: timed out"
+        )
+    )
 
 
 def test_linked_pr_conflict_status_clean(monkeypatch) -> None:

--- a/tests/test_cursor_sdk_patch.py
+++ b/tests/test_cursor_sdk_patch.py
@@ -1,0 +1,27 @@
+"""Unit tests for Cursor SDK bridge auth-token workaround."""
+
+from __future__ import annotations
+
+import pytest
+
+from cursor_sdk_patch import safe_auth_token
+
+
+@pytest.mark.unit
+def test_safe_auth_token_never_starts_with_hyphen() -> None:
+    for _ in range(200):
+        token = safe_auth_token(8)
+        assert token
+        assert not token.startswith("-")
+
+
+@pytest.mark.unit
+def test_tool_callback_auth_token_is_retryable() -> None:
+    from run_agent import is_retryable_codegen_failure
+
+    err = RuntimeError(
+        "Cursor SDK local startup failed (retryable=False): "
+        "Bridge exited before discovery with status 1: cursor-sdk-bridge failed: "
+        "Error: Missing value for --tool-callback-auth-token"
+    )
+    assert is_retryable_codegen_failure(err)

--- a/tests/test_run_agent_codegen_retry.py
+++ b/tests/test_run_agent_codegen_retry.py
@@ -12,6 +12,7 @@ from run_agent import is_retryable_codegen_failure
     "message",
     [
         "Cursor SDK local startup failed (retryable=True): Bridge request timed out: ReadTimeout: timed out",
+        "Cursor SDK local startup failed (retryable=False): Bridge exited before discovery with status 1: Missing value for --tool-callback-auth-token",
         "Cursor changed too many files (32 > 30): app/admin_companies.py, app/contacts.py",
         "model proposed too many files (15 > 12)",
         "RemoteProtocolError: Server disconnected",


### PR DESCRIPTION
## Summary
- Patch Cursor SDK callback tokens so they never start with `-` (fixes false `Missing value for --tool-callback-auth-token` / `retryable=False` blocked handoffs; see [Cursor forum](https://forum.cursor.com/t/python-sdk-launch-bridge-randomly-fails-token-urlsafe-callback-tokens-starting-with-are-rejected-by-the-bridge-arg-parser/163586)). Treat residual bridge-auth failures as dispatcher-retriable.
- Smoke-import `app.main` on **every** Builder→Reviewer handoff (including mergeable/clean heads) and auto-repair known dropped imports (`admin_router`, `CORRELATION_HEADER`, …) so CRM PRs stop bouncing on NameError.
- Acceptance checklist AI infra/parse failures no longer invent product `not_done` rows; when AI review already approved, Reviewer defers instead of `REQUEST_CHANGES`.

Unblocks the agent loop around [#105](https://github.com/saberistic-team/agent-web/issues/105), [#107](https://github.com/saberistic-team/agent-web/issues/107), [#108](https://github.com/saberistic-team/agent-web/issues/108).

## Test plan
- [x] `pytest` anti-loop suite (`test_cursor_sdk_patch`, `test_acceptance`, `test_builder_conflicts`, `test_run_agent_codegen_retry`)
- [ ] After merge: requeue `#105` / `#108` / `#166` from `status:blocked` → `status:queued`
- [ ] Confirm Builder no longer `@human-review`s on tool-callback-auth-token
- [ ] Confirm Reviewer does not bounce on acceptance AI “Gathering…” prose when AI review approved

Made with [Cursor](https://cursor.com)