### PR TITLE
fix: document circular admin router include anti-pattern

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -112,6 +112,9 @@ a dirty PR as unfinished Builder work.
    mergeable but still break Reviewer screenshots — that was a Builder↔Reviewer
    loop on CRM PRs. Known import gaps may be auto-repaired (`repair_main_wiring`)
    once; persistent smoke failure stays `waiting`.
+   **Circular routers:** mount feature routers from `app.main` only — never
+   `include_router` a module that imports `require_admin_session` from
+   `admin_routes` back into `admin_routes` (ImportError loop on #107).
 4. Comment `### builder_conflict_context` and `### builder_conflict_result` on
    the issue.
 5. **Re-check** `mergeable` / `mergeable_state`. Only when clean → hand off

--- a/scripts/builder_conflicts.py
+++ b/scripts/builder_conflicts.py
@@ -504,7 +504,7 @@ def default_resolve_file(
         "Never drop imports, router wiring (`admin_router`), Protocol/repository "
         "exports, cookie/session symbol names, or migration catalog entries that "
         "either side defines — union both sides when unsure. Prefer keeping "
-        "main's auth/session APIs when they conflict with obsolete Basic-auth tests."
+        "main's auth/session APIs when they conflict with obsolete Basic-auth tests. Never create circular imports between `app.admin_routes` and feature routers (`admin_pipeline_routes`, etc.): mount feature routers from `app.main` only — do not `include_router` them at the bottom of admin_routes."
     )
     user = (
         f"{brief}\n\n"


### PR DESCRIPTION
## Summary
- Conflict-resolve prompt + Builder brief: mount feature routers from \`app.main\` only; never nest them inside \`admin_routes\` when they import back (ImportError loop on #107).

## Test plan
- [x] Prompt updated in \`scripts/builder_conflicts.py\`
- [ ] No product behavior change

Made with [Cursor](https://cursor.com)