### PR TITLE
fix: stop Builder closing product issues as verify-deploy

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -163,7 +163,10 @@ GitHub still says clean).
   default in Actions, `cloud` optional). Optional OpenAI / GitHub Models
   backup — [docs/MODELS.md](../docs/MODELS.md), [docs/DESIGN.md](../docs/DESIGN.md).
 - Verify/smoke issues may complete via `scripts/smoke_deploy.py` without a
-  model call; landing scaffolds may also skip codegen.
+  model call; landing scaffolds may also skip codegen. The verify-deploy
+  shortcut requires a deploy-intent **title** (or `smoke_deploy.py`) plus a
+  live target (`onrender.com` or `/health`+`/hello`) — acceptance bullets that
+  merely say “verify …” / “ready to deploy” must still produce a PR (#210).
 - Branch / PR must reference `#issue` (`Closes #N`); follow-ups stay on that
   same PR head (see **Branch and PR reuse**).
 - Tests relevant to the change are added or updated when behavior changes.

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -309,10 +309,32 @@ def handoff_builder_when_mergeable(repo: str, issue: int) -> None:
 
 
 def is_verify_deploy_issue(title: str, body: str) -> bool:
-    text = f"{title}\n{body}".lower()
-    if not re.search(r"\bverify\b|\bsmoke\b", text):
+    """True only for ops smoke checks against a live deploy.
+
+    Must not match product issues that merely say "verify …" or "ready to
+    deploy" in acceptance criteria (learned from #210).
+    """
+    title_l = (title or "").lower()
+    body_l = (body or "").lower()
+    text = f"{title_l}\n{body_l}"
+
+    # Explicit smoke script is an unambiguous ops signal.
+    if re.search(r"smoke_deploy\.py", text):
+        return True
+
+    # Require the *title* to be about verifying/smoking a deploy — not AC
+    # bullets that say "Verify X" while also mentioning deploy readiness.
+    title_is_verify_deploy = bool(
+        re.search(r"\b(verify|smoke)\b", title_l)
+        and re.search(r"\b(deploy|render|production)\b", title_l)
+    )
+    if not title_is_verify_deploy:
         return False
-    return bool(re.search(r"\brender\b|\bdeploy\b|onrender\.com|/health|/hello", text))
+
+    return bool(
+        re.search(r"onrender\.com", text)
+        or (re.search(r"/health", text) and re.search(r"/hello", text))
+    )
 
 
 def close_linked_open_prs(repo: str, issue: int, reason: str) -> None:

--- a/tests/test_verify_deploy_issue.py
+++ b/tests/test_verify_deploy_issue.py
@@ -1,0 +1,71 @@
+"""Builder must not treat product ACs as verify-deploy ops shortcuts (#210)."""
+
+from __future__ import annotations
+
+import pytest
+
+from run_agent import is_verify_deploy_issue
+
+
+@pytest.mark.unit
+def test_real_render_smoke_issue_matches() -> None:
+    assert is_verify_deploy_issue(
+        "Verify production Render deploy (agent-web-hello)",
+        (
+            "## Verify production Render deploy\n\n"
+            "**Production URL:** https://agent-web-hello.onrender.com\n\n"
+            "### Acceptance\n"
+            "- `GET /health` → `{\"status\":\"ok\"}`\n"
+            "- `GET /hello` → `{\"message\":\"hello world\"}`\n\n"
+            "Prefer running:\n\n"
+            "```bash\npython scripts/smoke_deploy.py\n```\n"
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_smoke_deploy_script_mentions_match() -> None:
+    assert is_verify_deploy_issue(
+        "Ops: check production after cutover",
+        "Run `python scripts/smoke_deploy.py` against https://saberistic.com",
+    )
+
+
+@pytest.mark.unit
+def test_migration_issue_with_verify_and_deploy_ac_does_not_match() -> None:
+    """Regression: #210 was closed as done after a false verify-deploy match."""
+    assert not is_verify_deploy_issue(
+        "Reconcile legacy migration 013 with the canonical pipeline schema",
+        (
+            "## Summary\n"
+            "Add a forward-only migration that reconciles databases…\n\n"
+            "## Acceptance criteria\n"
+            "- A database representing the earlier applied `013` state upgrades…\n"
+            "- The change is ready to deploy in the PR\n\n"
+            "## Verification expectations\n"
+            "- Verify canonical history row counts and values after legacy "
+            "reconciliation.\n"
+            "- Verify pipeline mutations and rollback behavior.\n"
+            "- Confirm the application no longer encounters missing canonical "
+            "pipeline relations or columns.\n"
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_backup_verify_issue_with_render_mention_does_not_match() -> None:
+    assert not is_verify_deploy_issue(
+        "Verify CRM and analytics backup and restore procedures",
+        (
+            "- Document which Render Postgres backups exist and their retention\n"
+            "- Verify migrations can advance a restored database safely\n"
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_title_verify_deploy_without_live_target_does_not_match() -> None:
+    assert not is_verify_deploy_issue(
+        "Verify production deploy checklist",
+        "Write the runbook; do not hit live endpoints yet.",
+    )


### PR DESCRIPTION
## Summary
- Tighten `is_verify_deploy_issue` so acceptance bullets ("Verify …", "ready to deploy") no longer take the ops smoke shortcut
- Add regression tests for #210-style bodies and real Render smoke issues (#25)
- Document the rule in `AGENTS/builder.md`

## Why
Builder falsely closed [#210](https://github.com/saberistic-team/agent-web/issues/210) and [#197](https://github.com/saberistic-team/agent-web/issues/197) after `GET /health` passed, with no PR.

## Test plan
- [x] `pytest tests/test_verify_deploy_issue.py -q`
- [ ] After merge, reopen/requeue #210 and #197 and confirm Builder opens a PR instead of `builder_verify` → `status:done`


Made with [Cursor](https://cursor.com)