### PR TITLE
fix: route docs PRs through Reviewer with objective checklist

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,12 @@ jobs:
   docs:
     if: github.event.label.name == 'agent:docs'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: write
       issues: write
       pull-requests: write
+      models: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,11 +24,21 @@ jobs:
         with:
           app-id: ${{ secrets.DOCS_APP_ID }}
           private-key: ${{ secrets.DOCS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Install agent dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-agents.txt
 
       - name: Mark in progress
         env:
@@ -48,6 +60,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.docs.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          CURSOR_MODEL: ${{ vars.CURSOR_MODEL }}
+          CURSOR_RUNTIME: ${{ vars.CURSOR_RUNTIME }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+          MODELS_TOKEN: ${{ secrets.MODELS_TOKEN || github.token }}
+          GITHUB_MODELS_MODEL: ${{ vars.GITHUB_MODELS_MODEL }}
+          CODEGEN_PROVIDER: ${{ vars.CODEGEN_PROVIDER }}
         run: |
           python scripts/run_agent.py \
             --role docs \
@@ -60,18 +80,59 @@ jobs:
         run: |
           set -euo pipefail
           ISSUE="${{ github.event.issue.number }}"
-          for label in status:new status:queued status:in-progress status:blocked status:needs-review status:failed; do
+          HANDOFF="reviewer"
+          if [[ -f trace/docs-handoff.txt ]]; then
+            HANDOFF="$(tr -d '[:space:]' < trace/docs-handoff.txt)"
+          fi
+          for label in status:new status:queued status:in-progress status:blocked status:done status:failed status:needs-review; do
             gh issue edit "${ISSUE}" --repo "${{ github.repository }}" --remove-label "${label}" 2>/dev/null || true
           done
-          gh issue edit "${ISSUE}" \
-            --repo "${{ github.repository }}" \
-            --add-label "status:done" \
-            --remove-label "agent:docs"
-          gh issue comment "${ISSUE}" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          for label in review:needs-review review:approved review:changes-requested agent:reviewer agent:builder agent:docs agent:planner; do
+            gh issue edit "${ISSUE}" --repo "${{ github.repository }}" --remove-label "${label}" 2>/dev/null || true
+          done
+
+          case "${HANDOFF}" in
+            blocked)
+              gh issue edit "${ISSUE}" \
+                --repo "${{ github.repository }}" \
+                --add-label "status:blocked"
+              gh issue comment "${ISSUE}" --repo "${{ github.repository }}" --body "$(cat <<EOF
           ### docs_handoff
-          - status: \`status:done\`
+          - status: \`status:blocked\`
+          - next: \`@human-review\`
           EOF
           )"
+              ;;
+            waiting)
+              gh issue edit "${ISSUE}" \
+                --repo "${{ github.repository }}" \
+                --add-label "status:queued"
+              gh issue comment "${ISSUE}" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          ### docs_handoff
+          - status: \`status:queued\`
+          - next: dispatcher will re-apply \`agent:docs\` (retryable codegen / unfinished)
+          EOF
+          )"
+              ;;
+            reviewer|*)
+              gh issue edit "${ISSUE}" \
+                --repo "${{ github.repository }}" \
+                --add-label "status:needs-review" \
+                --add-label "review:needs-review" \
+                --add-label "agent:reviewer"
+              GITHUB_TOKEN="${GH_TOKEN}" python scripts/pr_labels.py \
+                --repo "${{ github.repository }}" \
+                --issue "${ISSUE}" \
+                --review review:needs-review || true
+              gh issue comment "${ISSUE}" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          ### docs_handoff
+          - status: \`status:needs-review\`
+          - next: \`agent:reviewer\` (docs checklist — objectives / acceptance)
+          - pr_labels: mirrored \`type:*\` \`priority:*\` \`review:needs-review\`
+          EOF
+          )"
+              ;;
+          esac
 
       - name: Dispatch next queued work
         if: always()
@@ -101,5 +162,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: agent-trace-docs-${{ github.event.issue.number }}-${{ github.run_id }}
-          path: trace/agent-trace.jsonl
+          path: |
+            trace/agent-trace.jsonl
+            trace/docs-handoff.txt
+            trace/docs-model.txt
           if-no-files-found: ignore

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -161,7 +161,8 @@ jobs:
               for label in status:new status:in-progress status:blocked status:needs-review status:done status:failed agent:builder agent:docs agent:reviewer agent:planner; do
                 gh issue edit "${ISSUE}" --repo "${{ github.repository }}" --remove-label "${label}" 2>/dev/null || true
               done
-              # Re-enter priority queue; dispatcher applies agent:builder when free.
+              # Re-enter priority queue; dispatcher applies agent:builder or
+              # agent:docs from type:* when free.
               gh issue edit "${ISSUE}" \
                 --repo "${{ github.repository }}" \
                 --add-label "review:changes-requested" \
@@ -174,7 +175,7 @@ jobs:
               gh issue comment "${ISSUE}" --repo "${{ github.repository }}" --body "$(cat <<EOF
           ### reviewer_labels
           - decision: \`changes-requested\` (from GitHub PR review API + Cursor/OpenAI/Models)
-          - next: \`status:queued\` (dispatcher will apply \`agent:builder\` by priority)
+          - next: \`status:queued\` (dispatcher will apply \`agent:builder\` or \`agent:docs\` from \`type:*\` by priority)
           - pr_labels: mirrored \`review:changes-requested\`
           EOF
           )"

--- a/AGENTS/docs.md
+++ b/AGENTS/docs.md
@@ -16,31 +16,48 @@ In-scope paths:
 - documentation for **areas the Builder changed in the linked PR** (keep
   prose accurate to that diff; do not expand into unrelated subsystems)
 
-Workflow moves you `status:in-progress` → `status:done` after you finish.
+Workflow moves you `status:in-progress` → hand off with
+`status:needs-review`, `review:needs-review`, and `agent:reviewer` — same
+orchestration path as Builder, but Reviewer applies a **docs review**
+checklist (objectives / acceptance criteria), not product screenshot or
+coverage gates. Project board Status / Priority / Review sync from those
+labels ([docs/LABELS.md](../docs/LABELS.md)).
 
 ## Definition of done
 
 - Docs reflect current behavior/labels/identities/workflows as required by
   the issue (edit the real files under `docs/`, `README.md`, `AGENTS/` — not
   only a stub).
+- Required deliverables named in the issue (paths, sections, decisions) are
+  present on the PR head — a `docs/agent-updates/<issue>.md` stub alone is
+  **not** done.
 - Changes are on a **non-default branch** via PR when Contents writes are
   needed: `docs/<issue-number>-<short-slug>`  
   Example: `docs/7-label-taxonomy`
 - On create/reuse of that PR, mirror `type:*` and `priority:*` from the issue
-  onto the PR. Do **not** add `review:*`, `agent:*`, or `status:*` (Docs
-  usually completes without Reviewer) — [docs/LABELS.md](../docs/LABELS.md).
+  onto the PR, set `review:needs-review`, and copy the issue’s **milestone**
+  onto the PR — [docs/LABELS.md](../docs/LABELS.md). Do **not** put
+  `agent:*` or `status:*` on the PR.
 - Links and role/label names match `docs/LABELS.md` and
   `docs/IDENTITIES.md` when those are in scope.
 - No open questions left in the doc that the issue already answered.
+- You hand off to Reviewer; you do **not** set `status:done` yourself
+  (Gate does after merge + complete acceptance checklist).
 
 ### Automated App behavior (current)
 
-`scripts/run_agent.py` `role_docs` opens/reuses that branch and PR, then writes
-a stub at `docs/agent-updates/<issue>.md` so a visible PR exists. That stub is
-**not** the finished documentation — expand or replace it with authoritative
-updates for the issue scope before treating the work as done. Opening the PR
-requires `pull_requests: write` on the Docs App (see
-[docs/IDENTITIES.md](../docs/IDENTITIES.md)).
+`scripts/run_agent.py` `role_docs` opens/reuses that branch and PR, writes a
+stub at `docs/agent-updates/<issue>.md`, then runs codegen against the Docs
+brief so authoritative files land on the same head. Opening the PR requires
+`pull_requests: write` on the Docs App (see
+[docs/IDENTITIES.md](../docs/IDENTITIES.md)). The workflow then labels
+`status:needs-review` + `agent:reviewer`.
+
+## Branch and PR reuse (mandatory)
+
+**One issue → one open PR → one head branch.** Prefer the open linked PR’s
+current head after `review:changes-requested` requeues Docs (dispatcher
+applies `agent:docs` again for `type:docs`). Do not open a second PR.
 
 ## Constraints
 

--- a/AGENTS/planner.md
+++ b/AGENTS/planner.md
@@ -76,7 +76,8 @@ without re-planning. The parent is then marked done by the workflow.
   exists. You only label issues.
 - Do not assign `agent:reviewer` as the first owner of new work; route to
   `builder` or `docs` via the dispatcher (keep `agent:planner` only while
-  still planning).
+  still planning). Both Builder and Docs hand off to Reviewer after their
+  PR is ready (`type:docs` uses the docs checklist, not screenshots/coverage).
 - Do not apply `status:queued` until the gate (`release-plan`) has passed
   (single-issue path). Children may be created already queued.
 - Prefer an existing human-set `priority:*` (including `priority:medium`);

--- a/AGENTS/reviewer.md
+++ b/AGENTS/reviewer.md
@@ -7,14 +7,20 @@ You run when an issue is labeled `agent:reviewer` (usually with
 **GitHub pull request review APIs** (approve or request changes), then
 record the orchestration decision.
 
+**Route by issue `type:*`:** `type:docs` uses the **Docs review** path below
+(objectives / acceptance only). Other types use the **Builder / product**
+path (screenshots, coverage, visual gates). Both still validate against the
+issue’s original acceptance criteria before `review:approved`.
+
 Before approving you must:
 
 1. Confirm the linked PR **merges cleanly** into its base (`mergeable` /
    `mergeable_state` not dirty). If GitHub reports conflicts (e.g. another
-   branch merged after Builder handed off), **request changes immediately** and
-   return the issue to Builder — do not approve or spend the rest of the review
-   budget on a conflicted PR. Merge conflicts are always Builder work on the
-   same PR head.
+   branch merged after Builder/Docs handed off), **request changes immediately**
+   and return the issue to the implementing agent (`agent:builder` or
+   `agent:docs` via the priority queue — dispatcher uses `type:*`) — do not
+   approve or spend the rest of the review budget on a conflicted PR. Merge
+   conflicts are always implementing-agent work on the same PR head.
 2. Capture **headless Chromium screenshots** via Actions Playwright
    (`scripts/screenshot_deploy.py`, preferring the **PR-head** copy under
    `COVERAGE_ROOT` when present — see [docs/SCREENSHOTS.md](../docs/SCREENSHOTS.md))
@@ -52,7 +58,39 @@ refs for the same issue number (ghost branches are not in scope). If Builder
 appears to be committing off-PR, request changes citing the wrong branch rather
 than reviewing stale ghost commits.
 
+## Docs review (`type:docs`)
+
+Docs PRs still go through Reviewer + Gate. Skip product evidence that does
+not apply; **do** enforce objectives.
+
+**Do (required):**
+
+1. Mergeability + CI green (same as product PRs).
+2. Run AI review + post `### acceptance_checklist` against the issue body —
+   every acceptance criterion and named deliverable path must be evidenceable
+   on the PR head (commits / files), not only the issue prose.
+3. Reject stub-only heads: if the PR is only `docs/agent-updates/<n>.md` (or
+   equivalent placeholder) without the deliverable files the issue required,
+   `REQUEST_CHANGES` citing “return to Docs”.
+4. Reject product-scoped changes on a docs issue (`app/`, routes, DB,
+   migrations, public marketing routes) — `REQUEST_CHANGES` / escalate to
+   Planner unless the issue explicitly allowed them.
+5. Reject invented APIs or behavior that the repo does not implement when the
+   issue asked to document current/research decisions only.
+
+**Skip for docs (do not hard-fail):**
+
+- Deploy / PR-branch screenshots and visual readability
+- Admin preview mock-data / nav visibility
+- Service coverage gates and “code change without tests”
+- Builder scaffold-sync heuristics aimed at product implementation PRs
+
+On `changes-requested`, labels return to `status:queued`; dispatcher applies
+`agent:docs` for `type:docs` (not Builder). Preserve `priority:*`.
+
 ## Definition of done
+
+### Product / Builder PRs
 
 - Desktop + mobile **PR-branch** screenshots for **PR-affected** pages
   (public + all admin nav pages under `ADMIN_PREVIEW_MODE` when admin files
@@ -63,14 +101,19 @@ than reviewing stale ghost commits.
   mobile out-of-frame overflow)
 - Admin preview data pages show **mock rows** when capture ran (no empty
   “no records yet” / placeholder shells under `ADMIN_PREVIEW_MODE`)
+
+### All PRs (including docs)
+
 - AI review is recorded in the PR review body
 - `### acceptance_checklist` is posted with `all_done: true` and evidence links
+  (criteria map to the **original issue objectives**)
 - Matching issue-body checkboxes are flipped to `[x]` when verified
 - You submitted a GitHub PR review (approve **or** request changes)
 - Labels then move to either:
   - `review:approved` (gate merges + closes only if checklist complete), or
   - `review:changes-requested` + `status:queued` (dispatcher re-applies
-    `agent:builder` by `priority:*`; preserve existing priority)
+    `agent:builder` or `agent:docs` from `type:*` by `priority:*`; preserve
+    existing priority)
 - Project board Status / Review fields track those labels automatically
   ([docs/LABELS.md](../docs/LABELS.md) — Project board)
 - The linked PR’s mirror labels stay in sync: `review:approved` or
@@ -83,15 +126,28 @@ Any of these is an automatic request-changes — do not approve:
 
 - **Merge conflicts** with the PR base (`mergeable: false` /
   `mergeable_state: dirty`) — including races where other PRs merged after
-  Builder handed off
+  Builder/Docs handed off
 - Failing required tests / CI
+- AI reviewer says acceptance criteria are unmet
+- Acceptance checklist incomplete (`all_done: false` or missing) when criteria
+  are product- or docs-failed. **Exception:** acceptance AI infra/parse failures
+  (`method: ai-error`, e.g. Cursor returned prose instead of JSON) are **not**
+  implementing-agent work when the AI PR review already `approved` — defer to
+  that verdict and do not `REQUEST_CHANGES` solely for the checklist transport
+  glitch.
+- **Docs stub-only** (`type:docs`): PR lacks the issue’s required deliverable
+  files (only `docs/agent-updates/` placeholder) — return to Docs
+- **Docs out-of-scope product code** (`type:docs`): unexpected `app/` / route /
+  migration changes — return to Docs or escalate
+
+### Product / Builder-only hard fails
+
 - **Service coverage below gates** on `app/`: unit **≥90%**, integration **≥70%**
   ([docs/TESTING.md](../docs/TESTING.md), `scripts/check_coverage.py`)
 - Failing security audits or high/critical findings introduced by the PR
 - Behavior change with **missing tests** that should cover it
 - Builder **scaffold sync** PRs (`builder(#N): sync …` only) that do not
   implement the issue
-- AI reviewer says acceptance criteria are unmet
 - Required deploy screenshots failed (when `SCREENSHOTS_REQUIRED=true`)
 - **Visual readability fail:** text clipped or overflowing the mobile viewport
   (out of frame) on any **captured** PR-branch screenshot (`h1`, `.lede`,
@@ -104,16 +160,12 @@ Any of these is an automatic request-changes — do not approve:
   `.admin-nav-link` nodes exist but none are visible (common when nav links live
   inside a closed `<details>` without a separate desktop list) — Builder must
   keep the desktop list **outside** `<details>` (`format_admin_nav_hard_fail`)
-- Acceptance checklist incomplete (`all_done: false` or missing) when criteria
-  are product-failed. **Exception:** acceptance AI infra/parse failures
-  (`method: ai-error`, e.g. Cursor returned prose instead of JSON) are **not**
-  Builder work when the AI PR review already `approved` — defer to that verdict
-  and do not `REQUEST_CHANGES` solely for the checklist transport glitch.
 
 Coverage gaps, missing tests, CI assertion failures, visual overflow, empty
-preview shells, invisible desktop admin nav, and **merge conflicts** are
-**Builder work** — request changes so dispatcher requeues `agent:builder`
-(Builder resolves on the same PR head).
+preview shells, invisible desktop admin nav, docs deliverable gaps, and
+**merge conflicts** are **implementing-agent work** — request changes so
+dispatcher requeues `agent:builder` or `agent:docs` from `type:*` (resolve
+on the same PR head).
 Do **not** treat them as terminal `@human-review` / `status:blocked` (see
 `scripts/review_decision.py`). Do **not** resolve conflicts yourself.
 

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -170,11 +170,11 @@ at intake; otherwise the Planner infers or defaults to `priority:normal`.
 - Within the same priority, older issue numbers run first (FIFO).
 - Reviewer `changes-requested` re-enters `status:queued` (same priority) and
   waits for the dispatcher — it does not skip the queue by re-applying
-  `agent:builder` immediately. Merge conflicts are always Builder-fixable
-  (including when another PR merges after handoff).
-- Builder that cannot leave a clean PR (still `mergeable_state: dirty` after
-  conflict resolution) uses the `waiting` handoff → `status:queued` and does
-  **not** apply `agent:reviewer` until the PR merges cleanly.
+  `agent:builder` / `agent:docs` immediately. Merge conflicts are always
+  implementing-agent fixable (including when another PR merges after handoff).
+- Builder/Docs that cannot leave a clean PR (still `mergeable_state: dirty`
+  after conflict resolution) use the `waiting` handoff → `status:queued` and
+  do **not** apply `agent:reviewer` until the PR merges cleanly.
 - Manual `agent:builder` / `agent:docs` still starts a run immediately
   (emergency override); prefer the queue for normal work.
 
@@ -218,7 +218,7 @@ typically used when `status:needs-review` (or after a review cycle).
 |-------|---------|
 | `review:needs-review` | Awaiting a review decision. |
 | `review:approved` | Review passed; ready to merge or mark done. |
-| `review:changes-requested` | Review found required changes; return to builder via the priority queue. |
+| `review:changes-requested` | Review found required changes; return to the implementing agent (`agent:builder` or `agent:docs` from `type:*`) via the priority queue. |
 
 ---
 
@@ -232,13 +232,13 @@ PRs — those are issue ownership / pipeline state and runtime triggers.
 |-----------|--------|-------|
 | `type:*` | Copied from the linked issue | Set when Builder/Docs open (or refresh) the PR |
 | `priority:*` | Copied from the linked issue | Preserved across review cycles |
-| `review:*` | Kept in sync with the issue review axis | Builder → `needs-review`; Reviewer/Gate update on decision/merge |
+| `review:*` | Kept in sync with the issue review axis | Builder/Docs → `needs-review`; Reviewer/Gate update on decision/merge |
 | Milestone | Copied from the linked issue | Same GitHub milestone as the issue when set; skipped for critical/no-milestone work |
 | `agent:*` | **Never on PRs** | Issue-only |
 | `status:*` | **Never on PRs** | Issue-only |
 
-Implementation: `scripts/pr_labels.py` (also invoked from Builder / Reviewer /
-Gate workflows). Label mutations use the Issues Labels API
+Implementation: `scripts/pr_labels.py` (also invoked from Builder / Docs /
+Reviewer / Gate workflows). Label mutations use the Issues Labels API
 (`POST/DELETE .../issues/{number}/labels`), which works for PR numbers.
 Milestone assignment uses `PATCH .../issues/{number}` with `milestone` (also
 works for PR numbers).
@@ -249,7 +249,7 @@ works for PR numbers).
 |------|------------------|
 | **Planner** | None. Labels the **issue** only (`type:*`, `priority:*`, `status:queued`) and sets an open milestone. No `pull_requests` scope; no PR exists yet for new work. |
 | **Builder** | On create/reuse of a code PR: mirror `type:*` + `priority:*`, set `review:needs-review`, and copy the issue milestone onto the PR. On handoff to Reviewer, workflows re-apply the same mirror. |
-| **Docs** | On create/reuse: mirror `type:*` + `priority:*` and the issue milestone (Docs usually skips Reviewer, so no `review:*`). |
+| **Docs** | On create/reuse: mirror `type:*` + `priority:*`, set `review:needs-review`, and copy the issue milestone onto the PR (same review handoff as Builder; Reviewer uses the docs checklist). |
 | **Reviewer** | After the PR review API decision, set the matching `review:*` on the PR (`approved` / `changes-requested`) while updating the issue. |
 | **Gate** | On squash merge (`review-approved`): ensure the PR has `review:approved`. Issue still receives `status:done` + `review:approved`. |
 

--- a/scripts/builder_conflicts.py
+++ b/scripts/builder_conflicts.py
@@ -355,13 +355,16 @@ def linked_pr_conflict_status(repo: str, issue: int) -> dict[str, Any]:
     }
 
 
-def format_merge_conflict_hard_fail(status: dict[str, Any]) -> str:
+def format_merge_conflict_hard_fail(
+    status: dict[str, Any], *, implementer: str = "Builder"
+) -> str:
     """Reviewer hard-fail line for a conflicted linked PR."""
+    who = implementer if implementer in {"Builder", "Docs"} else "Builder"
     return (
         "PR has merge conflicts with base "
         f"(mergeable=`{status.get('mergeable')}`, "
         f"mergeable_state=`{status.get('mergeable_state')}`) — "
-        "return to Builder to resolve on the same PR head"
+        f"return to {who} to resolve on the same PR head"
     )
 
 

--- a/scripts/review_decision.py
+++ b/scripts/review_decision.py
@@ -23,7 +23,8 @@ _FIXABLE_RE = re.compile(
     r"overflow|clipped|pytest|test_|"
     r"admin preview empty data|empty shell|mock rows|ADMIN_PREVIEW|"
     r"admin desktop nav invisible|admin-nav-desktop|admin-nav-link|"
-    r"merge conflict|mergeable|mergeability|return to Builder",
+    r"merge conflict|mergeable|mergeability|return to Builder|"
+    r"return to Docs|agent-updates stub|docs PR|type:docs PR",
     re.I,
 )
 _TERMINAL_RE = re.compile(r"terminal:\s*true|worklog-only", re.I)

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -43,6 +43,7 @@ from priority import (
 
 HANDOFF_DIR = Path("trace")
 BUILDER_HANDOFF = HANDOFF_DIR / "builder-handoff.txt"
+DOCS_HANDOFF = HANDOFF_DIR / "docs-handoff.txt"
 
 
 def load_screenshot_deploy() -> ModuleType:
@@ -175,6 +176,14 @@ def write_builder_handoff(mode: str) -> None:
         raise GitHubError(f"invalid builder handoff mode: {mode!r}")
     HANDOFF_DIR.mkdir(parents=True, exist_ok=True)
     BUILDER_HANDOFF.write_text(mode + "\n", encoding="utf-8")
+
+
+def write_docs_handoff(mode: str) -> None:
+    """Tell docs.yml how to advance labels: reviewer | blocked | waiting."""
+    if mode not in {"reviewer", "blocked", "waiting"}:
+        raise GitHubError(f"invalid docs handoff mode: {mode!r}")
+    HANDOFF_DIR.mkdir(parents=True, exist_ok=True)
+    DOCS_HANDOFF.write_text(mode + "\n", encoding="utf-8")
 
 
 def handoff_builder_when_mergeable(repo: str, issue: int) -> None:
@@ -792,7 +801,13 @@ def role_docs(repo: str, issue: int, brief: Path) -> None:
     data = get_issue(repo, issue)
     title = data.get("title") or f"issue-{issue}"
     body = data.get("body") or ""
-    branch = f"docs/{issue}-{slugify(title)}"
+    # Prefer existing linked PR head (including after review:changes-requested).
+    prs = linked_open_prs(repo, issue)
+    if prs:
+        head = ((prs[0].get("head") or {}).get("ref") or "").strip()
+        branch = head or f"docs/{issue}-{slugify(title)}"
+    else:
+        branch = f"docs/{issue}-{slugify(title)}"
     owner, name = split_repo(repo)
     default = api("GET", f"/repos/{owner}/{name}").get("default_branch") or "main"
     ref = api("GET", f"/repos/{owner}/{name}/git/ref/heads/{default}")
@@ -850,8 +865,9 @@ def role_docs(repo: str, issue: int, brief: Path) -> None:
             },
         )
         pr_number = int(pr["number"])
-        # Docs skips Reviewer; mirror type/priority only (no review:*).
-        apply_pr_mirror(repo, issue, pr_number, default_review=None)
+        apply_pr_mirror(
+            repo, issue, pr_number, default_review="review:needs-review"
+        )
         post_issue_comment(
             repo,
             issue,
@@ -859,12 +875,61 @@ def role_docs(repo: str, issue: int, brief: Path) -> None:
         )
     else:
         pr_number = int(prs[0]["number"])
-        apply_pr_mirror(repo, issue, pr_number, default_review=None)
+        apply_pr_mirror(
+            repo, issue, pr_number, default_review="review:needs-review"
+        )
         post_issue_comment(
             repo,
             issue,
             f"### docs_result\n- branch: `{branch}`\n- existing_pr: #{pr_number}\n",
         )
+
+    # Authoritative docs via codegen on the same head, then hand off to Reviewer.
+    try:
+        from codegen_models import build_with_models
+
+        result = build_with_models(
+            repo,
+            issue,
+            title=title,
+            body=body,
+            brief=brief,
+        )
+        HANDOFF_DIR.mkdir(parents=True, exist_ok=True)
+        (HANDOFF_DIR / "docs-model.txt").write_text(
+            f"{result.get('provider')}:{result.get('model')}\n",
+            encoding="utf-8",
+        )
+        apply_pr_mirror(
+            repo,
+            issue,
+            int(result.get("pr") or pr_number),
+            default_review="review:needs-review",
+        )
+        write_docs_handoff("reviewer")
+    except Exception as exc:
+        detail = (
+            "Docs codegen failed (Cursor SDK / OpenAI / GitHub Models).\n\n"
+            f"`{exc}`\n\n"
+            "Preferred: Cursor Agent SDK via `CURSOR_API_KEY` "
+            "(`CODEGEN_PROVIDER=cursor`). See docs/MODELS.md."
+        )
+        if is_retryable_codegen_failure(exc):
+            post_issue_comment(
+                repo,
+                issue,
+                (
+                    "### docs_codegen_retry\n"
+                    "- result: `waiting`\n"
+                    "- reason: transient / soft codegen failure "
+                    "(do not `status:blocked`)\n\n"
+                    f"{detail}\n"
+                ),
+            )
+            write_docs_handoff("waiting")
+            return
+        escalate(repo, issue, detail)
+        write_docs_handoff("blocked")
 
 
 def role_reviewer(repo: str, issue: int, brief: Path) -> None:
@@ -877,8 +942,14 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
     pr_number = pr["number"]
 
     hard_fail_reasons: list[str] = []
+    issue_data_early = api("GET", f"/repos/{owner}/{name}/issues/{issue}") or {}
+    issue_labels = {
+        label["name"] for label in (issue_data_early.get("labels") or [])
+    }
+    is_docs_issue = "type:docs" in issue_labels
+    implementer = "Docs" if is_docs_issue else "Builder"
 
-    # Merge conflicts first — return to Builder; skip the rest of the budget.
+    # Merge conflicts first — return to implementing agent; skip the rest.
     try:
         from builder_conflicts import (
             format_merge_conflict_hard_fail,
@@ -887,14 +958,18 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
 
         conflict_status = linked_pr_conflict_status(repo, issue)
         if conflict_status.get("status") == "dirty":
-            hard_fail_reasons.append(format_merge_conflict_hard_fail(conflict_status))
+            hard_fail_reasons.append(
+                format_merge_conflict_hard_fail(
+                    conflict_status, implementer=implementer
+                )
+            )
         elif conflict_status.get("pr_payload"):
             pr = conflict_status["pr_payload"]
             pr_number = int(pr["number"])
     except Exception as conflict_exc:
         hard_fail_reasons.append(
             f"mergeability check failed: {conflict_exc} — "
-            "treat as conflict and return to Builder"
+            f"treat as conflict and return to {implementer}"
         )
 
     if hard_fail_reasons:
@@ -976,12 +1051,35 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
 
     commits = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}/commits") or []
     commit_msgs = [c.get("commit", {}).get("message", "") for c in commits]
-    issue_data = api("GET", f"/repos/{owner}/{name}/issues/{issue}")
+    issue_data = issue_data_early
     issue_blob = f"{issue_data.get('title')}\n{issue_data.get('body')}".lower()
     infra_issue = bool(
         re.search(r"screenshot|headless|playwright|visual (check|evidence)", issue_blob)
     )
-    if (
+    if is_docs_issue:
+        stub_only = bool(filenames) and all(
+            name.startswith("docs/agent-updates/") for name in filenames
+        )
+        if stub_only or not filenames:
+            hard_fail_reasons.append(
+                "docs PR is agent-updates stub only — required deliverable "
+                "files missing; return to Docs"
+            )
+        product_paths = [
+            name
+            for name in filenames
+            if name.startswith(("app/", "site/", "migrations/"))
+            or (
+                name.endswith((".py", ".ts", ".js"))
+                and not name.startswith(("docs/", "AGENTS/", "scripts/", "tests/"))
+            )
+        ]
+        if product_paths:
+            hard_fail_reasons.append(
+                "type:docs PR includes product code paths "
+                f"({', '.join(product_paths[:8])}); return to Docs or escalate"
+            )
+    elif (
         commit_msgs
         and all(re.search(r"\bsync\b", m or "", re.I) for m in commit_msgs)
         and not infra_issue
@@ -1000,30 +1098,37 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
         "test" in f["filename"].lower() or f["filename"].startswith("tests/")
         for f in files
     )
-    if code_touched and not tests_touched and any(
-        f["filename"].endswith((".py", ".ts", ".js", ".go", ".rs")) for f in files
+    if (
+        not is_docs_issue
+        and code_touched
+        and not tests_touched
+        and any(
+            f["filename"].endswith((".py", ".ts", ".js", ".go", ".rs")) for f in files
+        )
     ):
         hard_fail_reasons.append("behavior/code change without test file updates")
 
     # Service coverage gates: unit ≥90% / integration ≥70% of app/
+    # Docs reviews skip coverage hard-fails (objectives checklist is enough).
     coverage_note = ""
     app_touched = any(
         f["filename"].startswith("app/") and f["filename"].endswith(".py")
         for f in files
     )
-    for run in checks.get("check_runs") or []:
-        name_l = (run.get("name") or "").lower()
-        conclusion = (run.get("conclusion") or "").lower()
-        if "coverage" in name_l and conclusion in {
-            "failure",
-            "timed_out",
-            "cancelled",
-        }:
-            hard_fail_reasons.append(
-                "service coverage check failed "
-                "(unit ≥90% / integration ≥70% of app/ required)"
-            )
-    if app_touched:
+    if not is_docs_issue:
+        for run in checks.get("check_runs") or []:
+            name_l = (run.get("name") or "").lower()
+            conclusion = (run.get("conclusion") or "").lower()
+            if "coverage" in name_l and conclusion in {
+                "failure",
+                "timed_out",
+                "cancelled",
+            }:
+                hard_fail_reasons.append(
+                    "service coverage check failed "
+                    "(unit ≥90% / integration ≥70% of app/ required)"
+                )
+    if app_touched and not is_docs_issue:
         cov_root = (os.environ.get("COVERAGE_ROOT") or "").strip()
         cov_cmd = [sys.executable, "scripts/check_coverage.py"]
         if cov_root:
@@ -1050,96 +1155,119 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
         except Exception as exc:
             hard_fail_reasons.append(f"service coverage check failed to run: {exc}")
             coverage_note = f"- coverage: failed (`{exc}`)\n"
+    elif is_docs_issue:
+        coverage_note = "- coverage: skipped (docs review)\n"
     else:
         coverage_note = "- coverage: skipped (PR does not touch app/*.py)\n"
 
     # Pre-merge screenshots: PR-head only (incl. admin via ADMIN_PREVIEW_MODE).
-    # saberistic.com shots are post-deploy only.
+    # saberistic.com shots are post-deploy only. Docs reviews skip capture.
     screenshot_note = ""
-    try:
-        screenshot_deploy = load_screenshot_deploy()
-        comment_markdown_pre_dual = screenshot_deploy.comment_markdown_pre_dual
-        comment_on_issue_or_pr = screenshot_deploy.comment_on_issue_or_pr
-        capture_pre_dual = screenshot_deploy.capture_pre_dual
-        fetch_pr_changed_paths = screenshot_deploy.fetch_pr_changed_paths
-        format_admin_nav_hard_fail = screenshot_deploy.format_admin_nav_hard_fail
-        format_empty_data_hard_fail = screenshot_deploy.format_empty_data_hard_fail
-        format_overflow_hard_fail = screenshot_deploy.format_overflow_hard_fail
-        resolve_screenshot_routes = screenshot_deploy.resolve_screenshot_routes
-        format_screenshot_targets = screenshot_deploy.format_screenshot_targets
-        upload_to_branch = screenshot_deploy.upload_to_branch
-
-        out_dir = Path("trace/screenshots")
-        changed = fetch_pr_changed_paths(repo, pr_number)
-        routes = resolve_screenshot_routes(
-            changed_files=changed, include_admin=True
+    if is_docs_issue:
+        body_shots = (
+            "### reviewer_screenshots_pre\n"
+            "- note: docs review — screenshots skipped; "
+            "acceptance checklist validates issue objectives\n"
         )
-        branch = pr["head"]["ref"]
-        prefix = f".agent/screenshots/pr-{pr_number}"
-        if not routes:
-            body_shots = (
-                "### reviewer_screenshots_pre\n"
-                "- production: skipped pre-merge "
-                "(saberistic.com shots are post-deploy only)\n"
-                "- routes (PR-affected): (none)\n"
-                "- note: no pages affected by this PR "
-                "(tests/docs/scripts only); screenshots skipped\n"
+        post_issue_comment(repo, issue, body_shots)
+        post_issue_comment(repo, pr_number, body_shots)
+        screenshot_note = (
+            "- screenshots_pre: skipped (docs review)\n"
+            "- visual_readability: `n/a`\n"
+        )
+    else:
+        try:
+            screenshot_deploy = load_screenshot_deploy()
+            comment_markdown_pre_dual = screenshot_deploy.comment_markdown_pre_dual
+            comment_on_issue_or_pr = screenshot_deploy.comment_on_issue_or_pr
+            capture_pre_dual = screenshot_deploy.capture_pre_dual
+            fetch_pr_changed_paths = screenshot_deploy.fetch_pr_changed_paths
+            format_admin_nav_hard_fail = screenshot_deploy.format_admin_nav_hard_fail
+            format_empty_data_hard_fail = screenshot_deploy.format_empty_data_hard_fail
+            format_overflow_hard_fail = screenshot_deploy.format_overflow_hard_fail
+            resolve_screenshot_routes = screenshot_deploy.resolve_screenshot_routes
+            format_screenshot_targets = screenshot_deploy.format_screenshot_targets
+            upload_to_branch = screenshot_deploy.upload_to_branch
+
+            out_dir = Path("trace/screenshots")
+            changed = fetch_pr_changed_paths(repo, pr_number)
+            routes = resolve_screenshot_routes(
+                changed_files=changed, include_admin=True
             )
-            comment_on_issue_or_pr(repo, pr_number, body_shots)
-            comment_on_issue_or_pr(repo, issue, body_shots)
-            screenshot_note = (
-                "- screenshots_pre: skipped (no pages affected)\n"
-                "- visual_readability: `n/a`\n"
-            )
-        else:
-            dual = capture_pre_dual(out_dir, routes=routes)
-            branch_urls = upload_to_branch(repo, branch, dual.branch_paths, prefix)
-            body_shots = comment_markdown_pre_dual(
-                branch_url=dual.branch_url,
-                branch_urls=branch_urls,
-                targets=routes,
-            )
-            comment_on_issue_or_pr(repo, pr_number, body_shots)
-            comment_on_issue_or_pr(repo, issue, body_shots)
-            screenshot_note = (
-                f"- screenshots_pre: {len(branch_urls)} branch posted on PR + issue "
-                "(no saberistic.com pre-merge shots)\n"
-                f"- screenshots_routes: {format_screenshot_targets(routes)}\n"
-                f"- screenshots_branch: `{dual.branch_url}`\n"
-            )
-            overflow_fail = format_overflow_hard_fail(dual.overflows)
-            if overflow_fail:
-                hard_fail_reasons.append(overflow_fail)
-                screenshot_note += (
-                    f"- visual_readability: `fail` ({len(dual.overflows)} overflow(s) "
-                    "on PR branch)\n"
+            branch = pr["head"]["ref"]
+            prefix = f".agent/screenshots/pr-{pr_number}"
+            if not routes:
+                body_shots = (
+                    "### reviewer_screenshots_pre\n"
+                    "- production: skipped pre-merge "
+                    "(saberistic.com shots are post-deploy only)\n"
+                    "- routes (PR-affected): (none)\n"
+                    "- note: no pages affected by this PR "
+                    "(tests/docs/scripts only); screenshots skipped\n"
+                )
+                comment_on_issue_or_pr(repo, pr_number, body_shots)
+                comment_on_issue_or_pr(repo, issue, body_shots)
+                screenshot_note = (
+                    "- screenshots_pre: skipped (no pages affected)\n"
+                    "- visual_readability: `n/a`\n"
                 )
             else:
-                screenshot_note += "- visual_readability: `ok` (PR branch)\n"
-            empty_fail = format_empty_data_hard_fail(dual.empty_pages)
-            if empty_fail:
-                hard_fail_reasons.append(empty_fail)
-                screenshot_note += (
-                    f"- preview_mock_data: `fail` ({len(dual.empty_pages)} empty "
-                    "shell finding(s) on PR branch)\n"
+                dual = capture_pre_dual(out_dir, routes=routes)
+                branch_urls = upload_to_branch(repo, branch, dual.branch_paths, prefix)
+                body_shots = comment_markdown_pre_dual(
+                    branch_url=dual.branch_url,
+                    branch_urls=branch_urls,
+                    targets=routes,
                 )
-            else:
-                screenshot_note += "- preview_mock_data: `ok` (PR branch)\n"
-            nav_fail = format_admin_nav_hard_fail(dual.nav_failures)
-            if nav_fail:
-                hard_fail_reasons.append(nav_fail)
-                screenshot_note += (
-                    f"- admin_nav_visible: `fail` ({len(dual.nav_failures)} "
-                    "desktop finding(s) on PR branch)\n"
+                comment_on_issue_or_pr(repo, pr_number, body_shots)
+                comment_on_issue_or_pr(repo, issue, body_shots)
+                screenshot_note = (
+                    f"- screenshots_pre: {len(branch_urls)} branch posted on PR + issue "
+                    "(no saberistic.com pre-merge shots)\n"
+                    f"- screenshots_routes: {format_screenshot_targets(routes)}\n"
+                    f"- screenshots_branch: `{dual.branch_url}`\n"
                 )
-            else:
-                screenshot_note += "- admin_nav_visible: `ok` (PR branch)\n"
-        pr = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}")
-        sha = pr["head"]["sha"]
-    except Exception as exc:
-        screenshot_note = f"- screenshots_pre: failed (`{exc}`)\n"
-        if os.environ.get("SCREENSHOTS_REQUIRED", "true").lower() in {"1", "true", "yes"}:
-            hard_fail_reasons.append(f"required deploy screenshots failed: {exc}")
+                overflow_fail = format_overflow_hard_fail(dual.overflows)
+                if overflow_fail:
+                    hard_fail_reasons.append(overflow_fail)
+                    screenshot_note += (
+                        f"- visual_readability: `fail` "
+                        f"({len(dual.overflows)} overflow(s) on PR branch)\n"
+                    )
+                else:
+                    screenshot_note += "- visual_readability: `ok` (PR branch)\n"
+                empty_fail = format_empty_data_hard_fail(dual.empty_pages)
+                if empty_fail:
+                    hard_fail_reasons.append(empty_fail)
+                    screenshot_note += (
+                        f"- preview_mock_data: `fail` "
+                        f"({len(dual.empty_pages)} empty shell finding(s) "
+                        "on PR branch)\n"
+                    )
+                else:
+                    screenshot_note += "- preview_mock_data: `ok` (PR branch)\n"
+                nav_fail = format_admin_nav_hard_fail(dual.nav_failures)
+                if nav_fail:
+                    hard_fail_reasons.append(nav_fail)
+                    screenshot_note += (
+                        f"- admin_nav_visible: `fail` "
+                        f"({len(dual.nav_failures)} desktop finding(s) "
+                        "on PR branch)\n"
+                    )
+                else:
+                    screenshot_note += "- admin_nav_visible: `ok` (PR branch)\n"
+            pr = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}")
+            sha = pr["head"]["sha"]
+        except Exception as exc:
+            screenshot_note = f"- screenshots_pre: failed (`{exc}`)\n"
+            if os.environ.get("SCREENSHOTS_REQUIRED", "true").lower() in {
+                "1",
+                "true",
+                "yes",
+            }:
+                hard_fail_reasons.append(
+                    f"required deploy screenshots failed: {exc}"
+                )
 
     # OpenAI / Models AI review (required for approve path).
     # Transport/parse glitches (Cursor returning prose) must not start a

--- a/tests/test_builder_conflicts.py
+++ b/tests/test_builder_conflicts.py
@@ -161,6 +161,9 @@ def test_linked_pr_conflict_status_dirty(monkeypatch) -> None:
     assert status["status"] == "dirty"
     assert status["pr"] == 80
     assert "return to Builder" in format_merge_conflict_hard_fail(status)
+    assert "return to Docs" in format_merge_conflict_hard_fail(
+        status, implementer="Docs"
+    )
 
 
 def test_merge_fetch_uses_explicit_refspec_for_single_branch_clone(monkeypatch) -> None:

--- a/tests/test_pr_labels.py
+++ b/tests/test_pr_labels.py
@@ -46,7 +46,15 @@ def test_desired_pr_labels_review_override() -> None:
 
 
 @pytest.mark.unit
-def test_desired_pr_labels_docs_skips_review_by_default() -> None:
+def test_desired_pr_labels_docs_gets_needs_review_by_default() -> None:
+    assert desired_pr_labels(
+        {"type:docs", "priority:normal"},
+        default_review="review:needs-review",
+    ) == ["type:docs", "priority:normal", "review:needs-review"]
+
+
+@pytest.mark.unit
+def test_desired_pr_labels_omits_review_when_default_none() -> None:
     assert desired_pr_labels(
         {"type:docs", "priority:normal"},
         default_review=None,

--- a/tests/test_review_decision.py
+++ b/tests/test_review_decision.py
@@ -73,6 +73,24 @@ def test_fixable_includes_merge_conflicts() -> None:
     )
 
 
+def test_fixable_includes_docs_stub_gaps() -> None:
+    body = (
+        "### reviewer_decision\n"
+        "- hard_fails:\n"
+        "  - docs PR is agent-updates stub only — required deliverable "
+        "files missing; return to Docs\n"
+    )
+    assert is_fixable_changes_requested(body)
+    assert (
+        resolve_decision(
+            latest_state="CHANGES_REQUESTED",
+            latest_body=body,
+            prior_changes_requested=4,
+        )
+        == "changes-requested"
+    )
+
+
 def test_terminal_worklog_not_fixable() -> None:
     body = "PR is builder worklog-only (terminal: true — do not requeue builder)"
     assert not is_fixable_changes_requested(body)


### PR DESCRIPTION
## Summary
- Docs no longer jumps to `status:done` after stub PRs; it hands off like Builder (`status:needs-review` + `agent:reviewer`).
- Reviewer uses a separate docs checklist (issue objectives / acceptance) and skips product screenshot/coverage gates; `changes-requested` requeues `agent:docs` via `type:docs`.
- Docs workflow runs codegen so requeued runs can produce real deliverables instead of leaving open stub PRs (#208 / #198).

## Test plan
- [x] Unit tests: `test_pr_labels`, `test_review_decision`, `test_builder_conflicts`
- [x] After merge: reopen #198, queue Docs, confirm handoff to Reviewer on #208

Made with [Cursor](https://cursor.com)