### PR TITLE
docs: reset contaminated Builder PR heads after conflict thrash

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -258,6 +258,22 @@ Regressing those surfaces creates screenshot 404/500s and Builder↔Reviewer
 loops on unrelated PRs (learned from #109 / #180 and #110 / #181). Prefer
 surgical edits over rewriting whole `admin_routes.py` / migration files.
 
+## Contaminated PR heads (anti-loop)
+
+When `builder_conflicts` repeatedly returns `broken_after_resolve` after
+cross-issue commit thrash (wrong PR binding) **or** after a reset left the
+PR head identical to `main` (0 commits ahead):
+
+1. **Reset** the existing PR head to current `main` (`force-with-lease` on
+   the same `builder/{issue}-…` branch — never open a second PR).
+2. Re-implement (or clean cherry-pick) the issue on that clean base.
+3. Run full pytest + `scripts/check_coverage.py` before Reviewer handoff.
+4. Dependent PR bodies must not use bare `#earlier` prose (use “issue N” /
+   “PR #M”) so `linked_open_prs` cannot re-bind the wrong head.
+
+Empty PR heads (`ahead_by: 0`) are **not** “done” — they need implementation
+commits. Do not hand off `waiting` forever without new commits.
+
 ## Dependent milestone issues (anti-loop)
 
 When stacked issues share admin/CRM surfaces (LinkedIn import #109→#110→#111),

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -31,6 +31,10 @@ is set. OpenAI and GitHub Models are backups (OpenAI quota is often exhausted).
    **Also smoke mergeable/clean PR heads** before handoff; an already-broken
    remote head can be `mergeable: true` while `admin_router` /
    `CORRELATION_HEADER` are undefined, collection fails, or CI assertions fail.
+   **Pitfall:** after a contaminated head is force-reset to `main`, Builder
+   must still implement the issue (empty PR ≠ done). Repeated
+   `broken_after_resolve` after cross-issue thrash → reset same PR head to
+   `main` and re-implement; do not keep merging the corrupted tip.
    **Pitfall:** Cursor local bridge rejects callback tokens that start with `-`
    (`Missing value for --tool-callback-auth-token`). SDK may mark
    `retryable=False`, but Builder must treat it as `waiting` and patch token


### PR DESCRIPTION
## Summary
- Document anti-loop: when `broken_after_resolve` repeats after cross-issue thrash (or head was reset empty to main), reset the **same** PR head to main and re-implement
- Empty PR (`ahead_by: 0`) is not done

Learned from milestone 4 (#109/#110 / PRs #180/#181).

## Test plan
- [x] Docs-only review


Made with [Cursor](https://cursor.com)