### PR TITLE
feat: auto-freeze shipped migration digests after deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
       github.event_name != 'push' ||
       (
         !startsWith(github.event.head_commit.message, 'review: record') &&
-        !startsWith(github.event.head_commit.message, 'deploy: record')
+        !startsWith(github.event.head_commit.message, 'deploy: record') &&
+        !startsWith(github.event.head_commit.message, 'deploy: freeze')
       )
     runs-on: ubuntu-latest
     services:
@@ -51,7 +52,8 @@ jobs:
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       !startsWith(github.event.head_commit.message, 'review: record') &&
-      !startsWith(github.event.head_commit.message, 'deploy: record')
+      !startsWith(github.event.head_commit.message, 'deploy: record') &&
+      !startsWith(github.event.head_commit.message, 'deploy: freeze')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Render deploy hook
@@ -74,7 +76,8 @@ jobs:
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       !startsWith(github.event.head_commit.message, 'review: record') &&
-      !startsWith(github.event.head_commit.message, 'deploy: record')
+      !startsWith(github.event.head_commit.message, 'deploy: record') &&
+      !startsWith(github.event.head_commit.message, 'deploy: freeze')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/app/migrations/definitions.py
+++ b/app/migrations/definitions.py
@@ -27,8 +27,9 @@ def migration_content_digest(migration: Migration) -> str:
 
 
 # Digests for versions that must never be silently redefined (#210).
-# When adding a new migration, leave prior entries unchanged and freeze the
-# new version only after it has shipped to production.
+# When adding a new migration, leave prior entries unchanged. Post-deploy
+# (scripts/freeze_shipped_migrations.py) freezes new versions after a healthy
+# production deploy — do not hand-edit shipped digests.
 FROZEN_MIGRATION_DIGESTS: dict[str, str] = {
     "001": "b25d23a80d13aca9fab1449d4ce7b50513b747a6bd6d00e234ea0ff21c0877f6",
     "002": "a74155b616b65ecb04f14cae1f2f33cf4e6a316d23c9452a6e4e3ac1161d6ed6",
@@ -44,6 +45,7 @@ FROZEN_MIGRATION_DIGESTS: dict[str, str] = {
     "012": "256322500ee7ac616de8f575a6b0a7c652c78924b9b1a3ca1007897626e88ef7",
     "013": "677757b25f70e5e1b8dea6aa244d458b276ddad8e751a837c9bceb84cd9b6308",
     "014": "9bb2a99e936e5ab77f75d1f94556715667cb97bff7dc185007ccdfe32f28f050",
+    "015": "014080f78e50242cb2e5518567634f7522f844bd55d7c4dcba4c970df73d07b0",
 }
 
 

--- a/docs/CRM_SCHEMA.md
+++ b/docs/CRM_SCHEMA.md
@@ -306,8 +306,12 @@ revision reused version `013` for the canonical
 `pipeline_owner` / `expected_value_cents` / `pipeline_loss_reason` /
 `pipeline_nurture_reason` and `pipeline_stage_history`. The runner keys pending
 work by version, so migration `015` performs the additive reconciliation.
-Versions `001`–`014` are frozen via `FROZEN_MIGRATION_DIGESTS` so an existing
-migration cannot be silently redefined again.
+Versions that have shipped to production are frozen via
+`FROZEN_MIGRATION_DIGESTS` so an existing migration cannot be silently
+redefined again. After each healthy production deploy, post-deploy runs
+`scripts/freeze_shipped_migrations.py` and commits any still-unfrozen digests
+with a `deploy: freeze …` meta commit (skipped by the Deploy job so Render is
+not retriggered).
 
 Applied versions are recorded in `schema_migrations`. Steps are **idempotent**
 (`IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, conditional legacy backfills) so

--- a/docs/HELLO_API.md
+++ b/docs/HELLO_API.md
@@ -60,6 +60,6 @@ On every push/merge to `main`, [`.github/workflows/ci.yml`](../.github/workflows
    ([SCREENSHOTS.md](SCREENSHOTS.md))
 
 CI skips push jobs whose commit message starts with `review: record` or
-`deploy: record` (screenshot/health recorder commits).
+`deploy: record` / `deploy: freeze` (screenshot/health/migration-freeze recorder commits).
 
 Never commit the deploy hook URL; keep it in GitHub Actions secrets only.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,6 +29,9 @@ Optional overrides:
 - **Live Postgres (optional locally, required in CI):** schema reconcile tests in
   `tests/test_pipeline_schema_reconcile.py` use `TEST_DATABASE_URL`. CI sets
   `REQUIRE_TEST_DATABASE=1` so those tests fail closed when the URL is missing.
+- **Migration digest freeze:** after a healthy production deploy, post-deploy runs
+  `scripts/freeze_shipped_migrations.py` and commits any unfrozen digests with
+  `deploy: freeze …` (skipped by Deploy so Render is not retriggered).
 - Agent/orchestration scripts under `scripts/` are **not** measured by these
   gates (they have their own tests without `app/` coverage requirements).
 

--- a/scripts/freeze_shipped_migrations.py
+++ b/scripts/freeze_shipped_migrations.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Freeze digests for migrations that have shipped to production.
+
+After deploy health succeeds, post-deploy calls ``maybe_commit_freeze`` so any
+migration still missing from ``FROZEN_MIGRATION_DIGESTS`` is recorded on
+``main`` with a meta commit (``deploy: freeze …``) that does not re-trigger
+Render. New migrations stay editable until the next healthy production deploy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+COMMIT_PREFIX = "deploy: freeze migrations"
+
+_DEFINITIONS = Path("app/migrations/definitions.py")
+_FROZEN_DICT_RE = re.compile(
+    r"(FROZEN_MIGRATION_DIGESTS: dict\[str, str\] = \{\n)(.*?)(\n\})",
+    re.DOTALL,
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def load_definitions(root: Path | None = None) -> Any:
+    """Load definitions.py without importing ``app.migrations`` (avoids psycopg)."""
+    path = (root or repo_root()) / _DEFINITIONS
+    spec = importlib.util.spec_from_file_location("migration_definitions_freeze", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    # dataclasses reads sys.modules[cls.__module__] while processing the class.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def missing_frozen_digests(root: Path | None = None) -> dict[str, str]:
+    """Return version→digest for registry entries not yet in FROZEN_MIGRATION_DIGESTS."""
+    mod = load_definitions(root)
+    frozen: dict[str, str] = dict(mod.FROZEN_MIGRATION_DIGESTS)
+    missing: dict[str, str] = {}
+    for migration in mod.MIGRATIONS:
+        if migration.version in frozen:
+            continue
+        missing[migration.version] = mod.migration_content_digest(migration)
+    return missing
+
+
+def format_frozen_block(digests: dict[str, str]) -> str:
+    lines = [f'    "{version}": "{digest}",' for version, digest in digests.items()]
+    return "\n".join(lines)
+
+
+def merged_frozen_digests(root: Path | None = None) -> dict[str, str]:
+    """Existing frozen digests plus any still-unfrozen registry versions."""
+    mod = load_definitions(root)
+    merged = dict(mod.FROZEN_MIGRATION_DIGESTS)
+    for migration in mod.MIGRATIONS:
+        if migration.version not in merged:
+            merged[migration.version] = mod.migration_content_digest(migration)
+    return {
+        migration.version: merged[migration.version]
+        for migration in mod.MIGRATIONS
+        if migration.version in merged
+    }
+
+
+def apply_freeze_to_definitions(text: str, digests: dict[str, str]) -> str:
+    """Rewrite the FROZEN_MIGRATION_DIGESTS literal in definitions.py source."""
+    block = format_frozen_block(digests)
+    match = _FROZEN_DICT_RE.search(text)
+    if match is None:
+        raise RuntimeError("FROZEN_MIGRATION_DIGESTS block not found in definitions.py")
+    updated = _FROZEN_DICT_RE.sub(rf"\1{block}\3", text, count=1)
+    updated = updated.replace(
+        "# When adding a new migration, leave prior entries unchanged and freeze the\n"
+        "# new version only after it has shipped to production.\n",
+        "# When adding a new migration, leave prior entries unchanged. Post-deploy\n"
+        "# (scripts/freeze_shipped_migrations.py) freezes new versions after a healthy\n"
+        "# production deploy — do not hand-edit shipped digests.\n",
+    )
+    return updated
+
+
+def build_freeze_files_at(root: Path) -> list[tuple[str, bytes]]:
+    missing = missing_frozen_digests(root)
+    if not missing:
+        return []
+    merged = merged_frozen_digests(root)
+    path = root / _DEFINITIONS
+    rel = _DEFINITIONS.as_posix()
+    new_text = apply_freeze_to_definitions(path.read_text(encoding="utf-8"), merged)
+    return [(rel, new_text.encode("utf-8"))]
+
+
+def commit_message(versions: list[str]) -> str:
+    joined = ", ".join(versions)
+    return f"{COMMIT_PREFIX} ({joined})"
+
+
+def maybe_commit_freeze(repo: str, branch: str, *, root: Path | None = None) -> dict[str, Any]:
+    """Commit newly shipped digests to ``branch`` when any are missing.
+
+    Returns a result dict with ``frozen`` (versions added) and optional ``sha``.
+    No-op when everything is already frozen.
+    """
+    base = root or repo_root()
+    missing = missing_frozen_digests(base)
+    if not missing:
+        print("freeze_migrations: nothing to freeze")
+        return {"frozen": [], "sha": None}
+
+    files = build_freeze_files_at(base)
+    from github_api import put_files
+
+    versions = list(missing.keys())
+    message = commit_message(versions)
+    sha = put_files(repo, branch, files, message)
+    print(f"freeze_migrations: froze {', '.join(versions)} -> {sha}")
+    return {"frozen": versions, "sha": sha, "message": message}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Print missing versions; exit 1 if any are unfrozen",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Rewrite local definitions.py (no git push)",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Commit freeze to GitHub (requires --repo)",
+    )
+    parser.add_argument("--repo", default="", help="owner/name for --commit")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Repo root (default: parent of scripts/)",
+    )
+    args = parser.parse_args(argv)
+    root = (args.root or repo_root()).resolve()
+
+    missing = missing_frozen_digests(root)
+    if args.check:
+        if missing:
+            print("missing:", ", ".join(missing))
+            for version, digest in missing.items():
+                print(f'  "{version}": "{digest}",')
+            return 1
+        print("ok: all migrations frozen")
+        return 0
+
+    if args.write:
+        files = build_freeze_files_at(root)
+        if not files:
+            print("nothing to write")
+            return 0
+        for rel, content in files:
+            (root / rel).write_bytes(content)
+            print(f"wrote {rel}")
+        return 0
+
+    if args.commit:
+        repo = (args.repo or "").strip()
+        if not repo:
+            print("FAIL: --repo required with --commit", file=sys.stderr)
+            return 1
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        maybe_commit_freeze(repo, args.branch, root=root)
+        return 0
+
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/post_deploy_visual.py
+++ b/scripts/post_deploy_visual.py
@@ -414,6 +414,22 @@ def main(argv: list[str] | None = None) -> int:
             health=health,
         )
 
+        # After production accepts this SHA, freeze any still-unfrozen migration
+        # digests so shipped SQL cannot be silently redefined (#210).
+        try:
+            from freeze_shipped_migrations import maybe_commit_freeze
+
+            freeze_result = maybe_commit_freeze(args.repo, default)
+            if freeze_result.get("frozen"):
+                print(
+                    "freeze_migrations_versions="
+                    + ",".join(str(v) for v in freeze_result["frozen"])
+                )
+        except Exception as freeze_exc:
+            # Health already recorded; do not fail the deploy visual path if the
+            # meta freeze commit races. Operators can re-run --commit manually.
+            print(f"freeze_migrations_error={freeze_exc}", file=sys.stderr)
+
         out = Path("trace/screenshots-post")
         short = (args.sha or "local")[:12]
         changed: list[str] | None = None

--- a/tests/test_freeze_shipped_migrations.py
+++ b/tests/test_freeze_shipped_migrations.py
@@ -1,0 +1,157 @@
+"""Unit tests for post-deploy migration digest freezing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from freeze_shipped_migrations import (
+    apply_freeze_to_definitions,
+    build_freeze_files_at,
+    commit_message,
+    format_frozen_block,
+    load_definitions,
+    maybe_commit_freeze,
+    missing_frozen_digests,
+)
+
+
+@pytest.mark.unit
+def test_missing_reports_only_unfrozen_versions() -> None:
+    missing = missing_frozen_digests()
+    frozen = load_definitions().FROZEN_MIGRATION_DIGESTS
+    for version, digest in missing.items():
+        assert version not in frozen
+        assert len(digest) == 64
+
+
+@pytest.mark.unit
+def test_format_and_apply_freeze_round_trip(tmp_path: Path) -> None:
+    definitions = tmp_path / "app" / "migrations"
+    definitions.mkdir(parents=True)
+    source = '''"""Ordered migrations."""
+from __future__ import annotations
+import hashlib
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Migration:
+    version: str
+    name: str
+    up_sql: str
+
+def migration_content_digest(migration: Migration) -> str:
+    payload = f"{migration.version}\\0{migration.name}\\0{migration.up_sql}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+# When adding a new migration, leave prior entries unchanged and freeze the
+# new version only after it has shipped to production.
+FROZEN_MIGRATION_DIGESTS: dict[str, str] = {
+    "001": "aaa",
+}
+
+MIGRATIONS: tuple[Migration, ...] = (
+    Migration(version="001", name="one", up_sql="CREATE 1"),
+    Migration(version="002", name="two", up_sql="CREATE 2"),
+)
+'''
+    path = definitions / "definitions.py"
+    path.write_text(source, encoding="utf-8")
+
+    missing = missing_frozen_digests(tmp_path)
+    assert list(missing) == ["002"]
+    files = build_freeze_files_at(tmp_path)
+    assert len(files) == 1
+    rel, content = files[0]
+    assert rel == "app/migrations/definitions.py"
+    text = content.decode("utf-8")
+    assert '"002"' in text
+    assert "Post-deploy" in text
+    assert "freeze_shipped_migrations.py" in text
+
+    path.write_bytes(content)
+    assert missing_frozen_digests(tmp_path) == {}
+    assert build_freeze_files_at(tmp_path) == []
+
+
+@pytest.mark.unit
+def test_apply_freeze_preserves_existing_digest() -> None:
+    text = (
+        "FROZEN_MIGRATION_DIGESTS: dict[str, str] = {\n"
+        '    "001": "keep-me",\n'
+        "}\n"
+    )
+    updated = apply_freeze_to_definitions(
+        text,
+        {"001": "keep-me", "002": "new-digest"},
+    )
+    assert '"001": "keep-me"' in updated
+    assert '"002": "new-digest"' in updated
+    assert format_frozen_block({"001": "a"}) == '    "001": "a",'
+
+
+@pytest.mark.unit
+def test_maybe_commit_freeze_noop_when_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "freeze_shipped_migrations.missing_frozen_digests",
+        lambda root=None: {},
+    )
+    with patch("github_api.put_files") as put:
+        result = maybe_commit_freeze("o/r", "main")
+    assert result == {"frozen": [], "sha": None}
+    put.assert_not_called()
+
+
+@pytest.mark.unit
+def test_maybe_commit_freeze_pushes_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hashlib
+
+    definitions = tmp_path / "app" / "migrations"
+    definitions.mkdir(parents=True)
+    digest_001 = hashlib.sha256(b"001\0one\0A").hexdigest()
+    digest_002 = hashlib.sha256(b"002\0two\0B").hexdigest()
+    (definitions / "definitions.py").write_text(
+        f'''from __future__ import annotations
+import hashlib
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Migration:
+    version: str
+    name: str
+    up_sql: str
+
+def migration_content_digest(migration: Migration) -> str:
+    payload = f"{{migration.version}}\\0{{migration.name}}\\0{{migration.up_sql}}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+# When adding a new migration, leave prior entries unchanged and freeze the
+# new version only after it has shipped to production.
+FROZEN_MIGRATION_DIGESTS: dict[str, str] = {{
+    "001": "{digest_001}",
+}}
+
+MIGRATIONS = (
+    Migration("001", "one", "A"),
+    Migration("002", "two", "B"),
+)
+''',
+        encoding="utf-8",
+    )
+
+    with patch("github_api.put_files", return_value="newsha") as put:
+        result = maybe_commit_freeze("o/r", "main", root=tmp_path)
+    assert result["frozen"] == ["002"]
+    assert result["sha"] == "newsha"
+    assert result["message"] == commit_message(["002"])
+    put.assert_called_once()
+    args = put.call_args.args
+    assert args[0] == "o/r"
+    assert args[1] == "main"
+    assert args[3] == commit_message(["002"])
+    written = args[2][0][1].decode("utf-8")
+    assert digest_002 in written

--- a/tests/test_pipeline_schema_reconcile.py
+++ b/tests/test_pipeline_schema_reconcile.py
@@ -308,13 +308,20 @@ def _seed_legacy_pipeline_data(conn: psycopg.Connection) -> dict[str, Any]:
 
 
 @pytest.mark.unit
-def test_frozen_migration_digests_cover_shipped_versions() -> None:
+def test_frozen_migration_digests_match_and_form_prefix() -> None:
+    """Frozen digests must match SQL and be a contiguous prefix of the registry.
+
+    Newest versions may remain unfrozen until post-deploy freezes them.
+    """
+    versions = [m.version for m in MIGRATIONS]
     by_version = {m.version: m for m in MIGRATIONS}
-    assert set(FROZEN_MIGRATION_DIGESTS) == {
-        "001", "002", "003", "004", "005", "006", "007", "008", "009",
-        "010", "011", "012", "013", "014",
-    }
-    for version, expected in FROZEN_MIGRATION_DIGESTS.items():
+    frozen = FROZEN_MIGRATION_DIGESTS
+    assert frozen
+    assert set(frozen).issubset(by_version)
+    frozen_in_order = [version for version in versions if version in frozen]
+    assert frozen_in_order == versions[: len(frozen_in_order)]
+    assert set(frozen_in_order) == set(frozen)
+    for version, expected in frozen.items():
         assert migration_content_digest(by_version[version]) == expected
 
 


### PR DESCRIPTION
## Summary
- Add `scripts/freeze_shipped_migrations.py` to append digests for any migration not yet in `FROZEN_MIGRATION_DIGESTS`
- Run it from post-deploy after `/health` succeeds; commit with `deploy: freeze …` (CI skips redeploy, same pattern as `deploy: record`)
- Freeze `015` now (already healthy on production) and soften the freeze-set unit assert to allow a contiguous unfrozen suffix

## Test plan
- [x] `python scripts/freeze_shipped_migrations.py --check` → ok
- [x] `pytest tests/test_freeze_shipped_migrations.py tests/test_crm_migrations_unit.py -q`
- [ ] After merge, confirm next real deploy no-ops freeze (already frozen) and a future `016` freezes automatically post-health


Made with [Cursor](https://cursor.com)