### PR TITLE
fix: wait for Render deploy to finish; fail CI if migrations fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,18 +56,30 @@ jobs:
       !startsWith(github.event.head_commit.message, 'deploy: freeze')
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Render deploy hook
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Trigger Render deploy and wait until live
         env:
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+          DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL }}
         run: |
           set -euo pipefail
           if [[ -z "${RENDER_DEPLOY_HOOK_URL:-}" ]]; then
             echo "::error::Missing repo secret RENDER_DEPLOY_HOOK_URL"
             exit 1
           fi
-          curl --fail --silent --show-error -X POST "$RENDER_DEPLOY_HOOK_URL"
-          echo
-          echo "Triggered Render deploy for https://saberistic.com"
+          if [[ -z "${RENDER_API_KEY:-}" ]]; then
+            echo "::error::Missing repo secret RENDER_API_KEY (needed to wait for deploy completion)"
+            exit 1
+          fi
+          # Waits until Render marks the deploy live. Migrations run in app
+          # startup — if they fail, Render status is update_failed and this
+          # step exits non-zero. Also requires /health.schema_version to match.
+          python scripts/render_deploy.py --ref "${{ github.sha }}"
 
   freeze-migrations:
     name: Freeze shipped migrations
@@ -92,14 +104,14 @@ jobs:
         with:
           app-id: ${{ secrets.BUILDER_APP_ID }}
           private-key: ${{ secrets.BUILDER_PRIVATE_KEY }}
-      - name: Wait for healthy deploy and freeze digests
+      - name: Freeze digests after live deploy
         env:
           GITHUB_TOKEN: ${{ steps.builder.outputs.token }}
           DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL }}
         run: |
           set -euo pipefail
-          # Allow Render a moment after the deploy hook before health polling.
-          sleep 20
+          # Deploy job already waited for live + schema; --wait-healthy is a
+          # cheap confirm before writing freeze commits.
           python scripts/freeze_shipped_migrations.py \
             --commit \
             --wait-healthy \
@@ -148,8 +160,9 @@ jobs:
           DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL }}
         run: |
           set -euo pipefail
-          # Allow Render a moment after hook before health polling starts.
-          sleep 20
+          # Deploy job already waited for Render to go live; short pause then
+          # re-check health before screenshots.
+          sleep 5
           python scripts/post_deploy_visual.py \
             --repo "${{ github.repository }}" \
             --sha "${{ github.sha }}" \

--- a/app/db.py
+++ b/app/db.py
@@ -19,6 +19,24 @@ def init_db(database_url: str) -> None:
         apply_migrations(conn)
 
 
+def latest_schema_version(database_url: str) -> str | None:
+    """Return the highest applied ``schema_migrations.version``, or None."""
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT version
+                FROM schema_migrations
+                ORDER BY version DESC
+                LIMIT 1
+                """
+            )
+            row = cur.fetchone()
+    if row is None:
+        return None
+    return str(row[0])
+
+
 @contextmanager
 def db_connection(database_url: str) -> Generator[psycopg.Connection, None, None]:
     with psycopg.connect(database_url, row_factory=dict_row) as conn:

--- a/app/main.py
+++ b/app/main.py
@@ -108,8 +108,26 @@ def sitemap() -> Response:
 
 
 @app.get("/health")
-def health() -> dict[str, str]:
-    return {"status": "ok"}
+def health() -> dict:
+    """Liveness/readiness. Includes ``schema_version`` when the DB is configured.
+
+    Migrations run at startup; if they fail the process never serves /health, so
+    Render marks the deploy failed. When the DB is up, ``schema_version`` is the
+    latest applied migration for post-deploy verification.
+    """
+    payload: dict = {"status": "ok"}
+    settings = get_settings()
+    if not settings.database_configured:
+        return payload
+    try:
+        version = db.latest_schema_version(settings.database_url)
+    except Exception:
+        logger.exception("health: failed to read schema_migrations")
+        raise HTTPException(status_code=503, detail="schema not ready") from None
+    if version is None:
+        raise HTTPException(status_code=503, detail="schema not ready")
+    payload["schema_version"] = version
+    return payload
 
 
 @app.get("/hello")

--- a/docs/HELLO_API.md
+++ b/docs/HELLO_API.md
@@ -42,9 +42,10 @@ python scripts/check_coverage.py
 1. Service exists as Blueprint from [`render.yaml`](../render.yaml); custom domain
    **saberistic.com** points at service **agent-web-hello**.
 2. In Render → **agent-web-hello** → **Settings** → **Deploy Hook**, copy the URL.
-3. In GitHub → repo **Settings** → **Secrets and variables** → **Actions**, add secret:
-   - Name: `RENDER_DEPLOY_HOOK_URL`
-   - Value: the deploy hook URL
+3. In GitHub → repo **Settings** → **Secrets and variables** → **Actions**, add:
+   - Secret `RENDER_DEPLOY_HOOK_URL` = deploy hook URL
+   - Secret `RENDER_API_KEY` = Render API key (Account Settings → API Keys)
+   - Secret `RENDER_SERVICE_ID` = `srv-…` (optional if the hook URL contains it)
 4. Set Actions variable `DEPLOY_BASE_URL` = `https://saberistic.com` (optional if
    code default matches).
 5. In Render → **Settings** → **Auto-Deploy**, prefer **Off** or **After CI Checks Pass** so deploys are gated by GitHub Actions tests (avoids double-deploy with the hook).
@@ -55,9 +56,13 @@ On every push/merge to `main`, [`.github/workflows/ci.yml`](../.github/workflows
 
 1. Runs `pytest -q`
 2. Runs `python scripts/check_coverage.py` (unit ≥90% / integration ≥70% on `app/`)
-3. If both pass, `POST`s the Render deploy hook
-4. `post-deploy-visual` polls `/health` (JSON) and captures production screenshots
-   ([SCREENSHOTS.md](SCREENSHOTS.md))
+3. If both pass, `scripts/render_deploy.py` triggers the deploy hook for that
+   commit SHA and **polls the Render API until the deploy is `live`** (or fails).
+   Schema migrations run in app startup (`db.init_db`); a migration failure marks
+   the Render deploy `update_failed` and fails this CI job. After live, CI also
+   requires `/health` `schema_version` to match the latest migration in the tree.
+4. `Freeze shipped migrations` and `post-deploy-visual` run after a successful
+   deploy (screenshots + digest freeze)
 
 CI skips push jobs whose commit message starts with `review: record` or
 `deploy: record` / `deploy: freeze` (screenshot/health/migration-freeze recorder commits).

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -138,6 +138,8 @@ until merged.
 | `SCREENSHOTS_REQUIRED` | variable | default true for Reviewer when pages are affected |
 | `CURSOR_API_KEY` | secret | Preferred visual / review |
 | `RENDER_DEPLOY_HOOK_URL` | secret | deploy trigger |
+| `RENDER_API_KEY` | secret | poll deploy status until live/failed |
+| `RENDER_SERVICE_ID` | secret | optional `srv-…` if not parseable from the hook URL |
 
 ## Scripts / workflows
 

--- a/scripts/render_deploy.py
+++ b/scripts/render_deploy.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Trigger a Render deploy hook and wait until that deploy finishes.
+
+Migrations run in the web process lifespan (``db.init_db``). If they fail, the
+new instance never becomes healthy and Render marks the deploy failed — this
+script exits non-zero so the CI **Deploy to Render** job fails.
+
+Requires:
+  RENDER_DEPLOY_HOOK_URL
+  RENDER_API_KEY
+Optional:
+  RENDER_SERVICE_ID  (parsed from the deploy hook URL when omitted)
+  DEPLOY_BASE_URL    (default https://saberistic.com) for post-live /health check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+DEFAULT_BASE = "https://saberistic.com"
+HOOK_SERVICE_RE = re.compile(r"/deploy/(srv-[a-zA-Z0-9]+)")
+
+# Render deploy.status values
+SUCCESS = frozenset({"live"})
+FAILURE = frozenset(
+    {
+        "build_failed",
+        "update_failed",
+        "canceled",
+        "deactivated",
+    }
+)
+# Anything else is treated as in-progress until timeout.
+
+
+class RenderDeployError(RuntimeError):
+    """Deploy trigger or wait failed."""
+
+
+def _env(name: str) -> str:
+    return (os.environ.get(name) or "").strip()
+
+
+def service_id_from_hook(hook_url: str) -> str | None:
+    match = HOOK_SERVICE_RE.search(hook_url)
+    return match.group(1) if match else None
+
+
+def resolve_service_id(hook_url: str, explicit: str | None = None) -> str:
+    service_id = (explicit or _env("RENDER_SERVICE_ID") or "").strip()
+    if not service_id:
+        service_id = service_id_from_hook(hook_url) or ""
+    if not service_id:
+        raise RenderDeployError(
+            "RENDER_SERVICE_ID missing and could not parse srv-… from deploy hook URL"
+        )
+    return service_id
+
+
+def _http_json(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    timeout: float = 30,
+) -> tuple[int, Any]:
+    req = urllib.request.Request(url, method=method, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            status = int(resp.status)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        status = int(exc.code)
+        if status >= 400:
+            raise RenderDeployError(f"{method} {url} -> {status}: {raw[:500]}") from exc
+    except urllib.error.URLError as exc:
+        raise RenderDeployError(f"{method} {url} failed: {exc}") from exc
+
+    if not raw.strip():
+        return status, None
+    try:
+        return status, json.loads(raw)
+    except json.JSONDecodeError:
+        return status, {"raw": raw[:500]}
+
+
+def trigger_deploy(hook_url: str, *, ref: str | None = None) -> dict[str, Any]:
+    """POST the deploy hook; optionally pin ``ref`` (commit SHA)."""
+    url = hook_url.strip()
+    if ref:
+        parts = urllib.parse.urlsplit(url)
+        query = dict(urllib.parse.parse_qsl(parts.query, keep_blank_values=True))
+        query["ref"] = ref
+        url = urllib.parse.urlunsplit(
+            (
+                parts.scheme,
+                parts.netloc,
+                parts.path,
+                urllib.parse.urlencode(query),
+                parts.fragment,
+            )
+        )
+    status, body = _http_json(url, method="POST")
+    if status not in {200, 202}:
+        raise RenderDeployError(f"deploy hook returned {status}: {body!r}")
+    deploy_id = None
+    if isinstance(body, dict):
+        deploy_id = body.get("deployId") or body.get("id") or body.get("deploy_id")
+    return {
+        "http_status": status,
+        "deploy_id": str(deploy_id) if deploy_id else None,
+        "body": body,
+    }
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+
+
+def fetch_deploy(api_key: str, service_id: str, deploy_id: str) -> dict[str, Any]:
+    url = f"https://api.render.com/v1/services/{service_id}/deploys/{deploy_id}"
+    _status, body = _http_json(url, headers=_auth_headers(api_key))
+    if not isinstance(body, dict):
+        raise RenderDeployError(f"unexpected deploy payload: {body!r}")
+    # Render may wrap as {"deploy": {...}} or return the deploy object.
+    deploy = body.get("deploy") if isinstance(body.get("deploy"), dict) else body
+    return deploy
+
+
+def list_deploys(api_key: str, service_id: str, *, limit: int = 20) -> list[dict[str, Any]]:
+    url = (
+        f"https://api.render.com/v1/services/{service_id}/deploys"
+        f"?limit={int(limit)}"
+    )
+    _status, body = _http_json(url, headers=_auth_headers(api_key))
+    if not isinstance(body, list):
+        raise RenderDeployError(f"unexpected deploys list: {body!r}")
+    deploys: list[dict[str, Any]] = []
+    for item in body:
+        if isinstance(item, dict) and isinstance(item.get("deploy"), dict):
+            deploys.append(item["deploy"])
+        elif isinstance(item, dict):
+            deploys.append(item)
+    return deploys
+
+
+def find_deploy_for_commit(
+    deploys: list[dict[str, Any]], commit: str
+) -> dict[str, Any] | None:
+    short = commit[:7]
+    for deploy in deploys:
+        commit_obj = deploy.get("commit") or {}
+        sha = ""
+        if isinstance(commit_obj, dict):
+            sha = str(commit_obj.get("id") or commit_obj.get("sha") or "")
+        elif isinstance(commit_obj, str):
+            sha = commit_obj
+        if sha == commit or (sha and sha.startswith(short)):
+            return deploy
+    return None
+
+
+def resolve_deploy_id(
+    *,
+    api_key: str,
+    service_id: str,
+    triggered: dict[str, Any],
+    ref: str | None,
+) -> str:
+    deploy_id = triggered.get("deploy_id")
+    if deploy_id:
+        return str(deploy_id)
+    # 202 Accepted (overlap) or missing id: pick newest matching commit / newest.
+    deploys = list_deploys(api_key, service_id)
+    if ref:
+        matched = find_deploy_for_commit(deploys, ref)
+        if matched and matched.get("id"):
+            return str(matched["id"])
+    if deploys and deploys[0].get("id"):
+        return str(deploys[0]["id"])
+    raise RenderDeployError(
+        "deploy hook did not return a deploy id and no recent deploys were found"
+    )
+
+
+def wait_for_deploy(
+    api_key: str,
+    service_id: str,
+    deploy_id: str,
+    *,
+    timeout_seconds: float = 900,
+    poll_seconds: float = 10,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_status = ""
+    while True:
+        deploy = fetch_deploy(api_key, service_id, deploy_id)
+        status = str(deploy.get("status") or "")
+        if status != last_status:
+            print(f"render_deploy: status={status} id={deploy_id}")
+            last_status = status
+        if status in SUCCESS:
+            return deploy
+        if status in FAILURE:
+            raise RenderDeployError(
+                f"Render deploy {deploy_id} failed with status={status!r}. "
+                "If this followed a schema migration, check Render logs for "
+                "``db.init_db`` / ``apply_migrations`` errors during startup."
+            )
+        if time.monotonic() >= deadline:
+            raise RenderDeployError(
+                f"Timed out after {timeout_seconds:.0f}s waiting for deploy "
+                f"{deploy_id} (last status={status!r})"
+            )
+        time.sleep(poll_seconds)
+
+
+def verify_health(base_url: str, *, expected_schema_version: str | None = None) -> dict[str, Any]:
+    health_url = urllib.parse.urljoin(base_url.rstrip("/") + "/", "health")
+    _status, body = _http_json(health_url)
+    if not isinstance(body, dict) or body.get("status") != "ok":
+        raise RenderDeployError(f"production /health not ok: {body!r}")
+    if expected_schema_version:
+        got = body.get("schema_version")
+        if got != expected_schema_version:
+            raise RenderDeployError(
+                f"schema_version mismatch after deploy: got {got!r}, "
+                f"expected {expected_schema_version!r} "
+                "(migrations may have failed or not applied)"
+            )
+    return body
+
+
+def expected_schema_version_from_repo() -> str | None:
+    """Latest migration version in the checked-out tree, if importable."""
+    try:
+        scripts = os.path.dirname(os.path.abspath(__file__))
+        root = os.path.dirname(scripts)
+        if root not in sys.path:
+            sys.path.insert(0, root)
+        from app.migrations.definitions import MIGRATIONS  # noqa: WPS433
+
+        if not MIGRATIONS:
+            return None
+        return str(MIGRATIONS[-1].version)
+    except Exception as exc:  # noqa: BLE001
+        print(f"render_deploy: could not load MIGRATIONS ({exc})")
+        return None
+
+
+def run_deploy(
+    *,
+    hook_url: str,
+    api_key: str,
+    service_id: str | None = None,
+    ref: str | None = None,
+    base_url: str | None = None,
+    timeout_seconds: float = 900,
+    poll_seconds: float = 10,
+    verify_schema: bool = True,
+) -> dict[str, Any]:
+    resolved_service = resolve_service_id(hook_url, service_id)
+    print(f"render_deploy: triggering hook for {resolved_service} ref={ref or '(default)'}")
+    triggered = trigger_deploy(hook_url, ref=ref)
+    print(f"render_deploy: hook http={triggered['http_status']} deploy_id={triggered.get('deploy_id')}")
+    deploy_id = resolve_deploy_id(
+        api_key=api_key,
+        service_id=resolved_service,
+        triggered=triggered,
+        ref=ref,
+    )
+    deploy = wait_for_deploy(
+        api_key,
+        resolved_service,
+        deploy_id,
+        timeout_seconds=timeout_seconds,
+        poll_seconds=poll_seconds,
+    )
+    origin = (base_url or _env("DEPLOY_BASE_URL") or DEFAULT_BASE).rstrip("/")
+    expected = expected_schema_version_from_repo() if verify_schema else None
+    health = verify_health(origin, expected_schema_version=expected)
+    print(f"render_deploy: live + healthy {health}")
+    return {"deploy": deploy, "health": health, "service_id": resolved_service}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hook-url", default="", help="Defaults to RENDER_DEPLOY_HOOK_URL")
+    parser.add_argument("--api-key", default="", help="Defaults to RENDER_API_KEY")
+    parser.add_argument("--service-id", default="", help="Defaults to RENDER_SERVICE_ID / hook parse")
+    parser.add_argument("--ref", default="", help="Commit SHA to deploy (recommended)")
+    parser.add_argument("--base-url", default="", help="Production origin for /health")
+    parser.add_argument("--timeout-seconds", type=float, default=900)
+    parser.add_argument("--poll-seconds", type=float, default=10)
+    parser.add_argument(
+        "--skip-schema-check",
+        action="store_true",
+        help="Do not require /health.schema_version to match latest migration",
+    )
+    args = parser.parse_args(argv)
+
+    hook = (args.hook_url or _env("RENDER_DEPLOY_HOOK_URL")).strip()
+    api_key = (args.api_key or _env("RENDER_API_KEY")).strip()
+    if not hook:
+        print("FAIL: RENDER_DEPLOY_HOOK_URL / --hook-url required", file=sys.stderr)
+        return 1
+    if not api_key:
+        print("FAIL: RENDER_API_KEY / --api-key required", file=sys.stderr)
+        return 1
+
+    try:
+        run_deploy(
+            hook_url=hook,
+            api_key=api_key,
+            service_id=(args.service_id or None),
+            ref=(args.ref or None) or None,
+            base_url=(args.base_url or None) or None,
+            timeout_seconds=args.timeout_seconds,
+            poll_seconds=args.poll_seconds,
+            verify_schema=not args.skip_schema_check,
+        )
+    except RenderDeployError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_deploy.py
+++ b/scripts/smoke_deploy.py
@@ -26,18 +26,18 @@ def main(argv: list[str] | None = None) -> int:
     base = args.base_url.rstrip("/")
 
     checks = [
-        ("/health", {"status": "ok"}),
-        ("/hello", {"message": "hello world"}),
+        ("/health", "status", "ok"),
+        ("/hello", "message", "hello world"),
     ]
-    for path, expected in checks:
+    for path, key, expected in checks:
         url = f"{base}{path}"
         try:
             payload = get_json(url)
         except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
             print(f"FAIL {url}: {exc}", file=sys.stderr)
             return 1
-        if payload != expected:
-            print(f"FAIL {url}: got {payload!r}, expected {expected!r}", file=sys.stderr)
+        if not isinstance(payload, dict) or payload.get(key) != expected:
+            print(f"FAIL {url}: got {payload!r}, expected {key}={expected!r}", file=sys.stderr)
             return 1
         print(f"PASS {url} → {payload}")
     return 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ client = TestClient(app)
 
 @pytest.mark.unit
 def test_health_handler_unit() -> None:
-    assert health() == {"status": "ok"}
+    assert health()["status"] == "ok"
 
 
 @pytest.mark.unit
@@ -57,7 +57,7 @@ def test_brief_handlers_return_pages(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_health() -> None:
     response = client.get("/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.json()["status"] == "ok"
 
 
 @pytest.mark.unit

--- a/tests/test_render_deploy.py
+++ b/tests/test_render_deploy.py
@@ -1,0 +1,105 @@
+"""Unit tests for Render deploy trigger + wait."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from render_deploy import (
+    RenderDeployError,
+    find_deploy_for_commit,
+    resolve_deploy_id,
+    resolve_service_id,
+    service_id_from_hook,
+    trigger_deploy,
+    verify_health,
+    wait_for_deploy,
+)
+
+
+@pytest.mark.unit
+def test_service_id_from_hook() -> None:
+    url = "https://api.render.com/deploy/srv-abc123?key=secret"
+    assert service_id_from_hook(url) == "srv-abc123"
+    assert resolve_service_id(url) == "srv-abc123"
+
+
+@pytest.mark.unit
+def test_trigger_deploy_appends_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_http(url: str, **kwargs):  # noqa: ANN003
+        seen["url"] = url
+        return 200, {"deployId": "dep-1"}
+
+    monkeypatch.setattr("render_deploy._http_json", fake_http)
+    result = trigger_deploy(
+        "https://api.render.com/deploy/srv-abc?key=k",
+        ref="abcdef0123456789",
+    )
+    assert result["deploy_id"] == "dep-1"
+    assert "ref=abcdef0123456789" in seen["url"]
+
+
+@pytest.mark.unit
+def test_wait_for_deploy_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    states = iter(
+        [
+            {"id": "dep-1", "status": "build_in_progress"},
+            {"id": "dep-1", "status": "live"},
+        ]
+    )
+    monkeypatch.setattr("render_deploy.fetch_deploy", lambda *a, **k: next(states))
+    monkeypatch.setattr("render_deploy.time.sleep", lambda _s: None)
+    deploy = wait_for_deploy("key", "srv-1", "dep-1", poll_seconds=0)
+    assert deploy["status"] == "live"
+
+
+@pytest.mark.unit
+def test_wait_for_deploy_fails_on_update_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "render_deploy.fetch_deploy",
+        lambda *a, **k: {"id": "dep-1", "status": "update_failed"},
+    )
+    monkeypatch.setattr("render_deploy.time.sleep", lambda _s: None)
+    with pytest.raises(RenderDeployError, match="update_failed"):
+        wait_for_deploy("key", "srv-1", "dep-1", poll_seconds=0)
+
+
+@pytest.mark.unit
+def test_resolve_deploy_id_from_list_when_hook_omits_id() -> None:
+    with patch(
+        "render_deploy.list_deploys",
+        return_value=[
+            {"id": "dep-9", "commit": {"id": "aaaaaaaa"}},
+            {"id": "dep-8", "commit": {"id": "bbbbbbbb"}},
+        ],
+    ):
+        deploy_id = resolve_deploy_id(
+            api_key="k",
+            service_id="srv-1",
+            triggered={"deploy_id": None, "http_status": 202},
+            ref="aaaaaaaa",
+        )
+    assert deploy_id == "dep-9"
+
+
+@pytest.mark.unit
+def test_find_deploy_for_commit_short_sha() -> None:
+    deploy = find_deploy_for_commit(
+        [{"id": "1", "commit": {"id": "abcdef012345"}}],
+        "abcdef0",
+    )
+    assert deploy is not None
+    assert deploy["id"] == "1"
+
+
+@pytest.mark.unit
+def test_verify_health_schema_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "render_deploy._http_json",
+        lambda *a, **k: (200, {"status": "ok", "schema_version": "014"}),
+    )
+    with pytest.raises(RenderDeployError, match="schema_version mismatch"):
+        verify_health("https://example.com", expected_schema_version="015")

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -204,7 +204,7 @@ def test_json_accept_on_unknown_path_returns_json_404() -> None:
 
 @pytest.mark.unit
 def test_health_and_hello_remain_json() -> None:
-    assert client.get("/health").json() == {"status": "ok"}
+    assert client.get("/health").json()["status"] == "ok"
     assert client.get("/hello").json() == {"message": "hello world"}
 
 


### PR DESCRIPTION
## Summary
- **Deploy to Render** now runs `scripts/render_deploy.py --ref $SHA`: trigger hook, poll Render deploy status until `live`, fail on `update_failed` / `build_failed` / etc.
- Migrations run in app lifespan; a migration failure prevents the new instance from starting → Render `update_failed` → CI Deploy fails
- `/health` includes `schema_version` when DB is configured; post-live check requires it to match the latest migration in the tree
- Docs: add required secret `RENDER_API_KEY` (and optional `RENDER_SERVICE_ID`)

## Required secrets (before merge to main)
- [ ] `RENDER_API_KEY` — Render Account → API Keys
- [ ] `RENDER_SERVICE_ID` — optional if the deploy hook URL already contains `srv-…`
- [x] `RENDER_DEPLOY_HOOK_URL` — already used

## Test plan
- [x] `pytest tests/test_render_deploy.py tests/test_api.py -q`
- [ ] Confirm `RENDER_API_KEY` is set in repo secrets
- [ ] After merge, watch **Deploy to Render** until it reports `status=live` (not just curl)


Made with [Cursor](https://cursor.com)