### PR TITLE
Require independent review for workflow governance (#229)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# Independent human owners for workflow governance.
+#
+# The organization currently has no maintainer team. Keep these individual,
+# human accounts in sync with the maintainers listed in
+# docs/WORKFLOW_GOVERNANCE.md. Do not add GitHub Apps or bot accounts here.
+
+# GitHub Actions
+/.github/workflows/** @saberistic @mehdidehdar @Amirsharifico
+
+# Reviewer automation
+/scripts/review_*.py @saberistic @mehdidehdar @Amirsharifico
+/scripts/review_decision.py @saberistic @mehdidehdar @Amirsharifico
+/scripts/acceptance.py @saberistic @mehdidehdar @Amirsharifico
+/scripts/check_permission.py @saberistic @mehdidehdar @Amirsharifico
+/scripts/pr_labels.py @saberistic @mehdidehdar @Amirsharifico
+/scripts/run_agent.py @saberistic @mehdidehdar @Amirsharifico
+/scripts/write_trace.py @saberistic @mehdidehdar @Amirsharifico
+
+# Builder prompts and configuration
+/scripts/codegen_*.py @saberistic @mehdidehdar @Amirsharifico
+/scripts/builder_conflicts.py @saberistic @mehdidehdar @Amirsharifico
+/scripts/cursor_sdk_patch.py @saberistic @mehdidehdar @Amirsharifico
+/AGENTS/** @saberistic @mehdidehdar @Amirsharifico
+/.github/copilot-instructions.md @saberistic @mehdidehdar @Amirsharifico
+
+# Repository policy and the self-validating policy checker
+/docs/WORKFLOW_GOVERNANCE.md @saberistic @mehdidehdar @Amirsharifico
+/docs/IDENTITIES.md @saberistic @mehdidehdar @Amirsharifico
+/docs/LABELS.md @saberistic @mehdidehdar @Amirsharifico
+/.github/CODEOWNERS @saberistic @mehdidehdar @Amirsharifico
+/.github/workflow-governance-paths.json @saberistic @mehdidehdar @Amirsharifico
+/.github/rulesets/** @saberistic @mehdidehdar @Amirsharifico
+/scripts/validate_workflow_governance.py @saberistic @mehdidehdar @Amirsharifico
+/tests/test_workflow_governance.py @saberistic @mehdidehdar @Amirsharifico

--- a/.github/rulesets/independent-workflow-review.json
+++ b/.github/rulesets/independent-workflow-review.json
@@ -1,0 +1,26 @@
+{
+  "name": "Require independent review for workflow governance",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "~DEFAULT_BRANCH"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}

--- a/.github/workflow-governance-paths.json
+++ b/.github/workflow-governance-paths.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "protected_paths": [
+    {
+      "path": ".github/workflows/**",
+      "category": "GitHub Actions workflows"
+    },
+    {
+      "path": "scripts/review_*.py",
+      "category": "reviewer automation"
+    },
+    {
+      "path": "scripts/review_decision.py",
+      "category": "reviewer automation"
+    },
+    {
+      "path": "scripts/acceptance.py",
+      "category": "reviewer automation"
+    },
+    {
+      "path": "scripts/check_permission.py",
+      "category": "reviewer automation"
+    },
+    {
+      "path": "scripts/pr_labels.py",
+      "category": "reviewer automation"
+    },
+    {
+      "path": "scripts/run_agent.py",
+      "category": "reviewer and Builder orchestration"
+    },
+    {
+      "path": "scripts/write_trace.py",
+      "category": "reviewer and Builder audit trail"
+    },
+    {
+      "path": "scripts/codegen_*.py",
+      "category": "Builder configuration"
+    },
+    {
+      "path": "scripts/builder_conflicts.py",
+      "category": "Builder configuration"
+    },
+    {
+      "path": "scripts/cursor_sdk_patch.py",
+      "category": "Builder configuration"
+    },
+    {
+      "path": "AGENTS/**",
+      "category": "Builder prompts and repository policy"
+    },
+    {
+      "path": ".github/copilot-instructions.md",
+      "category": "Builder prompts and repository policy"
+    },
+    {
+      "path": "docs/WORKFLOW_GOVERNANCE.md",
+      "category": "repository policy"
+    },
+    {
+      "path": "docs/IDENTITIES.md",
+      "category": "repository policy"
+    },
+    {
+      "path": "docs/LABELS.md",
+      "category": "repository policy"
+    },
+    {
+      "path": ".github/CODEOWNERS",
+      "category": "repository policy"
+    },
+    {
+      "path": ".github/workflow-governance-paths.json",
+      "category": "repository policy"
+    },
+    {
+      "path": ".github/rulesets/**",
+      "category": "repository policy"
+    },
+    {
+      "path": "scripts/validate_workflow_governance.py",
+      "category": "repository policy"
+    },
+    {
+      "path": "tests/test_workflow_governance.py",
+      "category": "repository policy"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: pip install -r requirements.txt
+      - name: Validate workflow-governance ownership
+        run: python scripts/validate_workflow_governance.py
       - name: Run tests
         run: pytest -q
       - name: Service coverage

--- a/docs/WORKFLOW_GOVERNANCE.md
+++ b/docs/WORKFLOW_GOVERNANCE.md
@@ -1,0 +1,113 @@
+# Workflow governance and independent review
+
+The workflows that build, review, and merge changes are privileged code. A
+change to them must not be accepted solely by the author or by an automation
+identity controlled by that same change.
+
+## Protected paths
+
+The machine-readable inventory is
+[`.github/workflow-governance-paths.json`](../.github/workflow-governance-paths.json).
+It explicitly protects:
+
+- all GitHub Actions workflows (`.github/workflows/**`);
+- reviewer and Gate automation (`scripts/review_*.py`,
+  `scripts/review_decision.py`, `scripts/acceptance.py`,
+  `scripts/check_permission.py`, `scripts/pr_labels.py`,
+  `scripts/run_agent.py`, and `scripts/write_trace.py`);
+- Builder prompts and configuration (`AGENTS/**`,
+  `.github/copilot-instructions.md`, `scripts/codegen_*.py`,
+  `scripts/builder_conflicts.py`, and `scripts/cursor_sdk_patch.py`);
+- the ownership, ruleset, documentation, and validation policy itself.
+
+When adding a new workflow-support path, add it to that inventory and
+`.github/CODEOWNERS` in the same pull request. CI runs
+`python scripts/validate_workflow_governance.py` and fails if any existing
+protected file has no owner or has a bot owner.
+
+## Who may approve
+
+The current organization has no human maintainer team, so the human
+collaborators with admin access are CODEOWNERS:
+
+- `@saberistic`
+- `@mehdidehdar`
+- `@Amirsharifico`
+
+GitHub Apps and gate/reviewer/builder bots are deliberately not CODEOWNERS.
+Once a human maintainer team exists, replace these individual entries with
+that team and update this document.
+
+For a PR touching a protected path, one of those humans who is **not the PR
+author** must submit an approving review. The author’s review does not satisfy
+GitHub’s required approval. The required CODEOWNER review cannot be satisfied
+by a workflow-controlled bot because no bot is a CODEOWNER. A Reviewer bot
+review may still help with the normal feature checklist, but it is not the
+independent authorization to merge this class of PR.
+
+## Ruleset enforcement
+
+The reviewed source of truth for the GitHub ruleset is
+[`.github/rulesets/independent-workflow-review.json`](../.github/rulesets/independent-workflow-review.json).
+It targets the default branch and requires:
+
+- one approving pull-request review;
+- a CODEOWNER review;
+- re-review after a new push; and
+- resolved review threads.
+
+Apply it as a repository administrator:
+
+```bash
+gh api --method POST \
+  repos/saberistic-team/agent-web/rulesets \
+  --input .github/rulesets/independent-workflow-review.json
+```
+
+Then validate the live configuration:
+
+```bash
+gh api repos/saberistic-team/agent-web/rulesets \
+  --jq '.[] | select(.name == "Require independent review for workflow governance")'
+```
+
+The active repository ruleset is
+[`#18975712`](https://github.com/saberistic-team/agent-web/rules/18975712).
+
+If GitHub rejects the API request, use **Settings → Rules → Rulesets → New
+ruleset → New branch ruleset**, select the default branch, and configure the
+four requirements above. Do not add bypass actors. Record the resulting
+ruleset URL and the setup/validation command output in the linked issue or PR.
+
+Rulesets enforce the approval mechanics; CODEOWNERS narrows the extra owner
+approval to the protected files. CI validates the repository-side inventory
+and ownership mapping, but it cannot replace GitHub’s review authorization.
+
+## Recovery and break-glass
+
+Use break-glass only when a protected workflow blocks a production incident or
+prevents the normal review process from running. It is not a shortcut for a
+routine change.
+
+1. Open a public incident issue before changing protection, titled
+   `Break-glass: <incident summary>`, and include the incident impact, affected
+   workflow, proposed minimal change, and the two human administrators involved.
+2. Two distinct human admins assess the incident. One changes the ruleset in
+   GitHub Settings; the other performs or reviews the minimal repair. Do not
+   use an App token, deploy key, or workflow token to bypass the ruleset.
+3. Temporarily disable only the blocking ruleset condition (or, if GitHub
+   cannot express that, disable the ruleset for the shortest practical window).
+   Do not add a permanent bypass actor.
+4. Merge the smallest repair, immediately restore the exact ruleset from
+   `.github/rulesets/independent-workflow-review.json`, and run the validation
+   command above plus `python scripts/validate_workflow_governance.py`.
+5. Add the merge commit, ruleset audit-log link or screenshot, timestamps,
+   approvers, and validation output to the incident issue. Open a normal
+   follow-up PR for any cleanup and obtain independent CODEOWNER approval.
+
+If the Reviewer or Builder workflow is broken, do not rely on its labels or
+approval. Use the recovery procedure, then verify the repair by manually
+running the workflow from Actions or by opening a harmless test PR. Existing
+feature review and Builder retry continue to use their current labels and
+automation; this policy adds a human CODEOWNER requirement only when protected
+files are changed.

--- a/scripts/validate_workflow_governance.py
+++ b/scripts/validate_workflow_governance.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Validate CODEOWNERS coverage for security-sensitive workflow paths."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = Path(".github/workflow-governance-paths.json")
+CODEOWNERS = Path(".github/CODEOWNERS")
+
+
+def _glob_regex(pattern: str) -> re.Pattern[str]:
+    """Compile the CODEOWNERS subset used by this repository."""
+    pattern = pattern.lstrip("/")
+    result = []
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "*" and pattern[index : index + 3] == "**/":
+            result.append("(?:.*/)?")
+            index += 3
+        elif char == "*" and pattern[index : index + 2] == "**":
+            result.append(".*")
+            index += 2
+        elif char == "*":
+            result.append("[^/]*")
+            index += 1
+        elif char == "?":
+            result.append("[^/]")
+            index += 1
+        else:
+            result.append(re.escape(char))
+            index += 1
+    return re.compile("^" + "".join(result) + "$")
+
+
+def parse_codeowners(contents: str) -> list[tuple[str, list[str]]]:
+    """Return ordered CODEOWNERS patterns and their owners."""
+    rules = []
+    for number, line in enumerate(contents.splitlines(), start=1):
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        fields = line.split()
+        if len(fields) < 2:
+            raise ValueError(f"CODEOWNERS line {number} has no owner")
+        rules.append((fields[0], fields[1:]))
+    return rules
+
+
+def matching_owners(path: str, rules: list[tuple[str, list[str]]]) -> list[str]:
+    """Return owners from the last matching CODEOWNERS rule."""
+    owners: list[str] = []
+    for pattern, candidate_owners in rules:
+        if _glob_regex(pattern).match(path):
+            owners = candidate_owners
+    return owners
+
+
+def repository_files(root: Path) -> list[str]:
+    return sorted(
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file()
+        and ".git" not in path.relative_to(root).parts
+        and "__pycache__" not in path.relative_to(root).parts
+    )
+
+
+def validate(root: Path = ROOT) -> list[str]:
+    """Return policy errors; an empty list means ownership is complete."""
+    manifest_path = root / MANIFEST
+    codeowners_path = root / CODEOWNERS
+    if not manifest_path.is_file():
+        return [f"missing manifest: {MANIFEST}"]
+    if not codeowners_path.is_file():
+        return [f"missing CODEOWNERS: {CODEOWNERS}"]
+
+    payload = json.loads(manifest_path.read_text())
+    protected = payload.get("protected_paths")
+    if not isinstance(protected, list) or not protected:
+        return ["manifest must contain a non-empty protected_paths list"]
+
+    rules = parse_codeowners(codeowners_path.read_text())
+    files = repository_files(root)
+    errors: list[str] = []
+    for entry in protected:
+        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+            errors.append(f"invalid protected path entry: {entry!r}")
+            continue
+        pattern = entry["path"]
+        matching_files = [path for path in files if _glob_regex(pattern).match(path)]
+        if not matching_files:
+            errors.append(f"protected pattern matches no repository file: {pattern}")
+            continue
+        for path in matching_files:
+            owners = matching_owners(path, rules)
+            if not owners:
+                errors.append(f"unowned protected path: {path} (from {pattern})")
+                continue
+            bot_owners = [owner for owner in owners if "bot" in owner.lower()]
+            if bot_owners:
+                errors.append(
+                    f"protected path has bot CODEOWNER: {path} ({', '.join(bot_owners)})"
+                )
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+    print("PASS: every protected workflow-governance path has human CODEOWNERS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workflow_governance.py
+++ b/tests/test_workflow_governance.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from validate_workflow_governance import validate
+
+
+def _write_policy_repo(
+    root: Path, *, codeowners: str = "/.github/workflows/** @human-owner\n"
+) -> None:
+    (root / ".github" / "workflows").mkdir(parents=True)
+    (root / ".github" / "workflows" / "reviewer.yml").write_text("name: Reviewer\n")
+    (root / ".github" / "CODEOWNERS").write_text(codeowners)
+    (root / ".github" / "workflow-governance-paths.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "protected_paths": [
+                    {
+                        "path": ".github/workflows/**",
+                        "category": "GitHub Actions workflows",
+                    }
+                ],
+            }
+        )
+    )
+
+
+def test_repository_workflow_governance_is_fully_owned() -> None:
+    assert validate() == []
+
+
+def test_unowned_protected_path_fails_clearly(tmp_path: Path) -> None:
+    _write_policy_repo(tmp_path, codeowners="/docs/** @human-owner\n")
+
+    assert validate(tmp_path) == [
+        "unowned protected path: .github/workflows/reviewer.yml "
+        "(from .github/workflows/**)"
+    ]
+
+
+def test_bot_cannot_be_protected_path_codeowner(tmp_path: Path) -> None:
+    _write_policy_repo(
+        tmp_path, codeowners="/.github/workflows/** @reviewer-bot\n"
+    )
+
+    assert validate(tmp_path) == [
+        "protected path has bot CODEOWNER: .github/workflows/reviewer.yml "
+        "(@reviewer-bot)"
+    ]


### PR DESCRIPTION
## Summary
- add human-only CODEOWNERS for Actions, reviewer automation, Builder prompts/configuration, and governance policy
- enforce review mechanics with active ruleset #18975712 and validate protected-path ownership in CI
- document approvers, workflow recovery, and an auditable two-admin break-glass process

Closes #229

## Test plan
- [x] `python3 scripts/validate_workflow_governance.py`
- [x] `python3 -m pytest -q tests/test_workflow_governance.py`
- [ ] CI uses Python 3.12 (the local full suite cannot collect under macOS Python 3.9 because existing models use `str | None` annotations)

## Independent approval required
This PR changes the governance controls themselves. Please obtain approval from an independent human maintainer (`@saberistic`, `@mehdidehdar`, or `@Amirsharifico`) before merge. The Reviewer/Gate bot review is checklist evidence only and must not serve as the authorizing approval.

Made with [Cursor](https://cursor.com)