### PR TITLE
fix(tests): tolerate admin-form modifier classes added by #238/#257

### DIFF
--- a/tests/test_admin_native_controls.py
+++ b/tests/test_admin_native_controls.py
@@ -230,7 +230,7 @@ def test_pipeline_detail_renders_themed_checkbox_and_datetime() -> None:
     assert 'type="datetime-local"' in html
     assert 'name="confirm"' in html
     assert 'type="checkbox"' in html
-    assert 'class="admin-form"' in html
+    assert re.search(r'class="admin-form(\s|")', html)
 
 
 @pytest.mark.unit
@@ -346,7 +346,7 @@ def test_preview_companies_page_includes_archived_checkbox(
     )
     assert response.status_code == 200
     body = response.text
-    assert 'class="admin-form"' in body
+    assert re.search(r'class="admin-form(\s|")', body)
     assert 'name="archived"' in body
     assert 'type="checkbox"' in body
     assert "Include archived" in body
@@ -365,7 +365,7 @@ def test_preview_contacts_page_includes_archived_checkbox(
     )
     assert response.status_code == 200
     body = response.text
-    assert 'class="admin-form"' in body
+    assert re.search(r'class="admin-form(\s|")', body)
     assert 'name="archived"' in body
     assert 'type="checkbox"' in body
     assert "Include archived" in body


### PR DESCRIPTION
## Root cause

`main` is currently red. PR #257 (issue #238, "Use responsive admin form widths") intentionally changed several admin forms from `class="admin-form"` to `class="admin-form admin-form--compact"` / `admin-form--editor` for responsive width handling, but did not update three pre-existing tests in `tests/test_admin_native_controls.py` that assert the exact string `class="admin-form"`:

- `test_pipeline_detail_renders_themed_checkbox_and_datetime`
- `test_preview_companies_page_includes_archived_checkbox`
- `test_preview_contacts_page_includes_archived_checkbox`

Because GitHub Actions tests the PR-into-`main` merge, this makes the `test` check fail on **every** open PR regardless of that PR's own changes — starving Reviewer approvals (`hard_fails: check test -> failure`) across the whole milestone.

## Fix

Match the `admin-form` class token tolerant of trailing modifier classes (`re.search(r'class="admin-form(\\s|")', ...)`) instead of requiring an exact string match.

## Verification

```
python -m pytest tests/test_admin_native_controls.py -q   # 20 passed
python -m pytest -q -m "not integration"                  # 865 passed, 31 skipped
```

This is blocking merge progress on #237, #241, #242 (and likely others) — please prioritize.

Made with [Cursor](https://cursor.com)