### PR TITLE
fix: paginate PR files in reviewer hard-fail check

### DIFF
--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -26,6 +26,7 @@ from github_api import (
     api,
     delete_label,
     list_issue_comments,
+    list_pr_files,
     post_issue_comment,
     split_repo,
 )
@@ -1170,7 +1171,10 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
             hard_fail_reasons.append(f"security check failed: {run.get('name')}")
 
     # Missing tests / stub-only / scaffold-sync heuristics
-    files = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}/files") or []
+    # Use the paginated helper (not raw `api()`): the default PR-files page
+    # is only 30 items, which silently dropped tests/ on PRs with >30 changed
+    # files and caused a false "no test file updates" hard-fail loop (#206).
+    files = list_pr_files(repo, pr_number)
     filenames = [f["filename"] for f in files]
     only_worklog = filenames and all(
         name.startswith(".agent/worklogs/") or name.endswith(".md")


### PR DESCRIPTION
## Problem

PR #206 has been stuck in an infinite builder↔reviewer loop since ~3:24 AM today (20+ hours, dozens of cycles), which is also what makes the "Project board sync" workflow look like it's looping — every label flip on issue #204 re-triggers it.

Every reviewer cycle on #206 shows the AI itself judging the PR `approved` (`ai_decision: approved`, `acceptance_all_done: true`), but a hard-fail gate keeps overriding it with `changes-requested`:

```
hard_fails:
  - behavior/code change without test file updates
```

This is a false positive — the PR includes `tests/test_worldgraph_spike.py` plus 15 fixture files.

## Root cause

`role_reviewer()`'s "missing tests" heuristic fetched PR files with a raw, unpaginated call:

```python
files = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}/files") or []
```

GitHub's PR-files endpoint defaults to a page size of **30**. PR #206 has 47 changed files; I confirmed against the live API that the unpaginated call returns exactly 30 items, cut off right after `scripts/run_agent.py` — every file under `spike/worldgraph/*.py` and all of `tests/` (sorted later) is silently dropped. So `tests_touched` computes `False` and the hard-fail fires forever, even though tests exist. Since the check is unrelated to any real defect, the builder can never satisfy it.

The codebase already has a paginated helper for exactly this (`list_pr_files` in `scripts/github_api.py`, per-page 100, follows pagination), already used correctly in `acceptance.py` and `screenshot_deploy.py` — it just wasn't used at this specific call site.

## Fix

Swap the raw `api()` call for `list_pr_files(repo, pr_number)` in `role_reviewer()`.

## Testing

- `python3 -m pytest tests/test_github_api.py tests/test_run_agent_codegen_retry.py tests/test_builder_conflicts.py` → 48 passed
- Verified via the live API that `pulls/206/files` without `per_page`/pagination truncates at 30 items and drops `tests/`, confirming the bug reproduces exactly as described.

Once this merges, re-running the reviewer on PR #206 should see the full file list and let it converge (assuming no other real issues).

Made with [Cursor](https://cursor.com)