### PR TITLE
fix: also check central-directory encryption flag before decompressing

### DIFF
--- a/site/assets/linkedin-import.js
+++ b/site/assets/linkedin-import.js
@@ -378,7 +378,12 @@
     }
 
     var localGeneralPurposeFlag = readUint16(data, off + 6);
-    if ((localGeneralPurposeFlag & 0x0001) !== 0) {
+    // Check both local and central-directory flags — a mismatched pair could
+    // otherwise slip an encrypted entry past whichever header is trusted.
+    if (
+      (localGeneralPurposeFlag & 0x0001) !== 0 ||
+      ((entry.generalPurposeFlag || 0) & 0x0001) !== 0
+    ) {
       return Promise.reject(
         new Error("Encrypted archive entries are not supported: " + entry.name)
       );


### PR DESCRIPTION
Small defense-in-depth follow-up to #262 (issue #224).

The Security Review on #262 noted that `inflateEntry()` only checked the encryption bit (general-purpose flag bit 0) on the **local** file header, not the central directory's copy of the same flag. A crafted archive with a mismatched local/central pair could otherwise slip an encrypted entry past whichever header is trusted. This checks both.

Flagged as optional/non-blocking by the reviewer, landing it separately since #262 was already merged by the time this commit was pushed.

Verified locally: `pytest -q -m browser` (12/12), `pytest -q -m \"not contract and not browser\"` (1399 passed), `scripts/check_coverage.py` OK.

Made with [Cursor](https://cursor.com)