### PR TITLE
fix(agents): key conflict-loop signature on import module, not raw first line

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -287,17 +287,30 @@ from `app.admin_security` — a `ModuleNotFoundError`/`ImportError` that
 `builder_conflicts.py` cannot fix (it only resolves textual merge conflicts,
 not naming bugs inside Builder's own change). Every dispatch re-ran codegen,
 which reproduced the same split instead of converging, so `builder_conflicts`
-returned `broken_after_resolve` with the **identical** `smoke_error` **54
-times over 7+ hours** with nothing counting the repeats. Do not rely on
+returned `broken_after_resolve` with the **same underlying** `smoke_error`
+**54 times over 7+ hours** with nothing counting the repeats. Do not rely on
 noticing this yourself — `scripts/run_agent.py:repeated_conflict_smoke_signature`
 now scans the last `REPEATED_CONFLICT_FAILURE_LIMIT` (3) `builder_conflict_result`
 comments and escalates (`@human-review` + `status:blocked`) instead of
-requeuing when the smoke error is byte-for-byte identical across all of them.
+requeuing once they share a signature.
+**Normalize before comparing:** on #242 the *specific* missing symbol changed
+almost every cycle (`validate_admin_security_config`, then
+`LIMITER_DOMAIN_ACCOUNT`, then others) because codegen kept rewriting the same
+dead module's API differently each time, and the error text also embeds a
+random per-run temp directory (`/tmp/builder-conflict-XXXXXXXX/repo/...`) — so
+a naive byte-for-byte / first-line comparison never matched and the loop ran
+undetected even after the breaker landed. `_smoke_error_signature()` keys on
+the **module path** from `cannot import name '...' from '<module>'` /
+`No module named '<module>'` (ignoring the symbol and temp path) so repeats of
+"the same orphan module still doesn't export what tests expect" are caught
+regardless of which symbol is missing this cycle. It also skips leading bare
+`^^^^` caret-underline pytest traceback markers when falling back to a
+first-line signature for non-import failures.
 If you land on an issue already carrying that escalation comment: do **not**
 just re-run codegen again — grep the whole `app/` tree for the symbol name in
 the error, put every definition and every import in **one** canonical module,
-delete the orphan module, and only then resume normal Builder work on the
-same PR head.
+delete the orphan module and every stale test file still importing the old
+one, and only then resume normal Builder work on the same PR head.
 
 ## Dependent milestone issues (anti-loop)
 

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -148,6 +148,37 @@ def escalate(repo: str, issue: int, reason: str, assignee_hint: str | None = Non
 # consecutive identical failures). Escalate once the same signature repeats.
 REPEATED_CONFLICT_FAILURE_LIMIT = 3
 
+_IMPORT_ERROR_MODULE_RE = re.compile(
+    r"cannot import name '[^']*' from '([^']+)'|No module named '([^']+)'"
+)
+_CARET_LINE_RE = re.compile(r"^\^+$")
+
+
+def _smoke_error_signature(smoke_error: str) -> str:
+    """Normalize one ``smoke_error`` blob to a stable cross-cycle signature.
+
+    Import failures embed a random per-run temp directory in the file path
+    (``/tmp/builder-conflict-XXXXXXXX/repo/...``), and — as on #242 — codegen
+    often rewrites the same broken module's public API differently each
+    cycle, so the *specific* missing symbol also changes cycle to cycle even
+    though the same module is at fault. Key on the module path so "the same
+    orphan module still doesn't export what tests expect" is recognized
+    across cycles despite the symbol/temp-path noise. Also skip leading bare
+    ``^^^^`` caret-underline traceback markers, which pytest sometimes prints
+    before the real message and would otherwise become a useless "first
+    line" signature that never matches (this hid the #242 loop from the
+    naive first-line version of this check).
+    """
+    match = _IMPORT_ERROR_MODULE_RE.search(smoke_error)
+    if match:
+        module = match.group(1) or match.group(2)
+        return f"import-error:{module}"
+    for line in smoke_error.strip().splitlines():
+        stripped = line.strip()
+        if stripped and not _CARET_LINE_RE.match(stripped):
+            return stripped[:200]
+    return smoke_error.strip()[:200]
+
 
 def repeated_conflict_smoke_signature(
     repo: str, issue: int, *, threshold: int = REPEATED_CONFLICT_FAILURE_LIMIT
@@ -178,8 +209,7 @@ def repeated_conflict_smoke_signature(
             # without breaking the streak (it belongs to the same cycle as
             # the detailed comment already counted, or preceded it).
             continue
-        signature = error_match.group(1).strip().splitlines()[0][:200]
-        signatures.append(signature)
+        signatures.append(_smoke_error_signature(error_match.group(1)))
         if len(signatures) >= threshold:
             break
     if len(signatures) < threshold:

--- a/tests/test_run_agent_conflict_loop_breaker.py
+++ b/tests/test_run_agent_conflict_loop_breaker.py
@@ -23,6 +23,24 @@ IMPORT_ERROR = (
     "'validate_admin_security_config' from 'app.admin_security'"
 )
 
+# Real shape observed on #242: a leading caret-underline traceback marker,
+# then a *different* missing symbol each cycle from the *same* dead module,
+# with a random per-run temp directory baked into the file path.
+REAL_WORLD_ERROR_CYCLE_1 = (
+    "pytest collect failed: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+    "tests/test_admin_security_unit.py:13: in <module>\n"
+    "    from app.admin_security import (\n"
+    "E   ImportError: cannot import name 'LIMITER_DOMAIN_ACCOUNT' from "
+    "'app.admin_security' (/tmp/builder-conflict-poyn1287/repo/app/admin_security.py)\n"
+)
+REAL_WORLD_ERROR_CYCLE_2 = (
+    "pytest collect failed: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+    "tests/test_admin_login_limiter_secrets.py:24: in <module>\n"
+    "    from app.admin_security import validate_admin_security_config\n"
+    "E   ImportError: cannot import name 'validate_admin_security_config' from "
+    "'app.admin_security' (/tmp/builder-conflict-ahbbo6fx/repo/app/admin_security.py)\n"
+)
+
 
 def _conflict_result_comment(status: str, smoke_error: str | None = None) -> dict:
     lines = [
@@ -54,8 +72,21 @@ def test_identical_smoke_error_repeated_returns_signature() -> None:
         comments.append(_generic_followup("broken_after_resolve"))
     with patch("run_agent.list_issue_comments", return_value=comments):
         signature = repeated_conflict_smoke_signature("o/r", 242)
-    assert signature is not None
-    assert "validate_admin_security_config" in signature
+    assert signature == "import-error:app.admin_security"
+
+
+@pytest.mark.unit
+def test_real_world_cycles_with_different_symbol_and_temp_path_still_match() -> None:
+    """Regression: the naive first-line signature never matched real #242
+    data because each cycle's caret marker / temp path / missing symbol
+    differed even though every failure was the same dead-module import."""
+    comments = []
+    for error in (REAL_WORLD_ERROR_CYCLE_1, REAL_WORLD_ERROR_CYCLE_2, REAL_WORLD_ERROR_CYCLE_1):
+        comments.append(_conflict_result_comment("broken_after_resolve", error))
+        comments.append(_generic_followup("broken_after_resolve"))
+    with patch("run_agent.list_issue_comments", return_value=comments):
+        signature = repeated_conflict_smoke_signature("o/r", 242)
+    assert signature == "import-error:app.admin_security"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Follow-up to #261

The circuit breaker in #261 never actually fired on #242's live loop after merging. Checked the issue comments right after merge and the loop was still running.

Root cause: the exact `smoke_error` text changes almost every cycle because (a) codegen keeps rewriting `app/admin_security.py`'s API differently each time, so a *different* symbol is reported missing each cycle (`validate_admin_security_config`, then `LIMITER_DOMAIN_ACCOUNT`, then others), and (b) the error embeds a random per-run temp directory (`/tmp/builder-conflict-XXXXXXXX/repo/...`). The naive first-line comparison from #261 also sometimes picked up a bare `^^^^` caret-underline pytest traceback marker as the 'first line', which is even less stable.

## Fix

`repeated_conflict_smoke_signature()` now normalizes via `_smoke_error_signature()`: key on the **module path** from "cannot import name '...' from '<module>'" / "No module named '<module>'" (ignoring the specific symbol and the temp path), and skip caret-marker lines when falling back to a first-line signature for non-import failures.

Verified against the real #242 comment history (module `app.admin_security`, symbols `validate_admin_security_config` / `LIMITER_DOMAIN_ACCOUNT` / others across different cycles) — now correctly recognized as the same repeated failure.

## Tests

`tests/test_run_agent_conflict_loop_breaker.py` adds `test_real_world_cycles_with_different_symbol_and_temp_path_still_match` using the literal error text observed on #242's comment thread.

```
994 passed, 32 skipped (full suite, -m "not integration")
```

Made with [Cursor](https://cursor.com)