### PR TITLE
chore: ignore any .venv* directory, not just .venv/ and .venv2/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.venv*/
 __pycache__/
 *.py[cod]
 .pytest_cache/


### PR DESCRIPTION
Small housekeeping follow-up from the #224 work: local verification needed a Python 3.10+ virtualenv (system default was 3.9), so I created ad-hoc `.venv312` / `.venv312-noplaywright` dirs. Those weren't covered by the existing exact-name `.venv/` / `.venv2/` patterns. Adds a `.venv*/` wildcard so any future ad-hoc venv is ignored automatically.

No functional change; verified with `git check-ignore` against `.venv`, `.venv2`, `.venv312`, `.venv312-noplaywright`, `.venv-test` — all match.

Made with [Cursor](https://cursor.com)