### PR TITLE
fix(agents): match truncated import-error file paths in loop signature

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -306,6 +306,12 @@ the **module path** from `cannot import name '...' from '<module>'` /
 regardless of which symbol is missing this cycle. It also skips leading bare
 `^^^^` caret-underline pytest traceback markers when falling back to a
 first-line signature for non-import failures.
+`post_issue_comment` bodies get truncated to the **tail** of long pytest
+output, which regularly slices off the `cannot import name ... from` prefix
+while leaving the trailing `(/tmp/.../repo/app/<module>.py)` fragment intact
+— check that fragment **first** since it survives truncation far more
+reliably than the full phrase (this is what finally let the breaker actually
+fire on #242's live loop, two fix PRs after the first attempt).
 If you land on an issue already carrying that escalation comment: do **not**
 just re-run codegen again — grep the whole `app/` tree for the symbol name in
 the error, put every definition and every import in **one** canonical module,

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -151,6 +151,12 @@ REPEATED_CONFLICT_FAILURE_LIMIT = 3
 _IMPORT_ERROR_MODULE_RE = re.compile(
     r"cannot import name '[^']*' from '([^']+)'|No module named '([^']+)'"
 )
+# ``post_issue_comment`` bodies get truncated to the last N characters
+# (``_truncate_pytest_detail`` keeps the *tail*), which frequently slices off
+# the "cannot import name ... from '<module>'" prefix while leaving the
+# trailing "(/tmp/.../repo/app/<module>.py)" file-path fragment intact — that
+# fragment survives truncation far more reliably, so try it first.
+_IMPORT_ERROR_FILEPATH_RE = re.compile(r"/(app/[a-zA-Z_][a-zA-Z0-9_/]*)\.py\)")
 _CARET_LINE_RE = re.compile(r"^\^+$")
 
 
@@ -169,6 +175,9 @@ def _smoke_error_signature(smoke_error: str) -> str:
     line" signature that never matches (this hid the #242 loop from the
     naive first-line version of this check).
     """
+    path_match = _IMPORT_ERROR_FILEPATH_RE.search(smoke_error)
+    if path_match:
+        return f"import-error:{path_match.group(1).replace('/', '.')}"
     match = _IMPORT_ERROR_MODULE_RE.search(smoke_error)
     if match:
         module = match.group(1) or match.group(2)

--- a/tests/test_run_agent_conflict_loop_breaker.py
+++ b/tests/test_run_agent_conflict_loop_breaker.py
@@ -40,6 +40,11 @@ REAL_WORLD_ERROR_CYCLE_2 = (
     "E   ImportError: cannot import name 'validate_admin_security_config' from "
     "'app.admin_security' (/tmp/builder-conflict-ahbbo6fx/repo/app/admin_security.py)\n"
 )
+# Real shape observed on #242: the posted comment body is truncated to the
+# tail of the pytest output, which sliced off the "cannot import name ...
+# from '<module>'" prefix entirely while leaving the closing file-path
+# fragment intact.
+REAL_WORLD_ERROR_TRUNCATED = "pytest collect failed: wxz8iny3/repo/app/admin_security.py)\n"
 
 
 def _conflict_result_comment(status: str, smoke_error: str | None = None) -> dict:
@@ -82,6 +87,24 @@ def test_real_world_cycles_with_different_symbol_and_temp_path_still_match() -> 
     differed even though every failure was the same dead-module import."""
     comments = []
     for error in (REAL_WORLD_ERROR_CYCLE_1, REAL_WORLD_ERROR_CYCLE_2, REAL_WORLD_ERROR_CYCLE_1):
+        comments.append(_conflict_result_comment("broken_after_resolve", error))
+        comments.append(_generic_followup("broken_after_resolve"))
+    with patch("run_agent.list_issue_comments", return_value=comments):
+        signature = repeated_conflict_smoke_signature("o/r", 242)
+    assert signature == "import-error:app.admin_security"
+
+
+@pytest.mark.unit
+def test_truncated_comment_body_still_yields_stable_signature() -> None:
+    """GitHub comment truncation keeps the tail, which slices off the
+    "cannot import name ... from" prefix but leaves the parenthetical
+    "(.../app/<module>.py)" file-path fragment — that must still match."""
+    comments = []
+    for error in (
+        REAL_WORLD_ERROR_TRUNCATED,
+        REAL_WORLD_ERROR_CYCLE_1,
+        REAL_WORLD_ERROR_TRUNCATED,
+    ):
         comments.append(_conflict_result_comment("broken_after_resolve", error))
         comments.append(_generic_followup("broken_after_resolve"))
     with patch("run_agent.list_issue_comments", return_value=comments):


### PR DESCRIPTION
## Follow-up to #266

Checked the live #242 loop right after #266 merged — still not escalating, seeing new cycles at 00:20:43, 00:22:13, 00:26:31 all still `broken_after_resolve`.

Root cause: `post_issue_comment` / `_truncate_pytest_detail` in `builder_conflicts.py` keeps only the **tail** of long pytest output. That regularly slices the `cannot import name '...' from '<module>'` prefix off entirely while leaving the trailing `(/tmp/builder-conflict-XXXXXXXX/repo/app/<module>.py)` file-path fragment intact — so #266's from-clause regex had nothing to match on those cycles.

## Fix

`_smoke_error_signature()` now checks the file-path fragment **first** (it survives truncation far more reliably than the full phrase), falling back to the from-clause regex and then the caret-skipping first-line logic from #266.

Verified against the real #242 comment thread: all 6 most recent `smoke_error` values (a mix of full and truncated bodies, several different missing symbols across cycles) now normalize to the identical `import-error:app.admin_security` signature — this should escalate as soon as this merges and the next Builder cycle runs.

## Tests

`test_truncated_comment_body_still_yields_stable_signature` using the literal truncated body observed on the issue.

```
1019 passed, 32 skipped (full suite, -m "not integration")
```

Made with [Cursor](https://cursor.com)