### PR TITLE
fix(agents): stop Builder pre-handoff smoke from looping forever (#115)

### DIFF
--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -312,6 +312,41 @@ the error, put every definition and every import in **one** canonical module,
 delete the orphan module and every stale test file still importing the old
 one, and only then resume normal Builder work on the same PR head.
 
+## Pre-handoff smoke loop (anti-loop)
+
+`handoff_builder_when_mergeable`'s **direct** smoke check (mergeable/clean
+heads — no conflict to resolve) had no repeat counter at all: a `smoke_failed`
+result always re-entered `status:queued` unconditionally, forever. On #115 /
+PR #265 this looped 3+ dispatches on the identical `tests/test_codegen_provider.py`
+failure (`assert "sonnet" in "composer-2.5"`) even though the PR's diff never
+touched codegen-provider selection and the same commit's real GitHub Actions
+`test` job passed. Root cause: `builder_conflicts._smoke_env()` used to inherit
+Builder's **own** runtime env — `CURSOR_MODEL` / `CODEGEN_PROVIDER` /
+`OPENAI_MODEL` / `GITHUB_MODELS_MODEL`, set from repo `vars.*` in
+`builder.yml` so Builder itself knows which provider/model to codegen
+with — into the cloned-PR-head pytest subprocess. `ci.yml`'s `test` job never
+sets those, so any non-default repo var (e.g. `CURSOR_MODEL=composer-2.5`)
+made Builder's smoke gate fail a test that only asserts *default*
+model-selection behavior, on every issue, regardless of the diff. Re-running
+codegen can never fix an environment mismatch.
+
+Two independent fixes now cover this:
+
+1. `_smoke_env()` strips those codegen-selection vars before running the
+   cloned-head pytest, so the smoke gate matches what `ci.yml` actually runs.
+2. `run_agent.repeated_smoke_result_signature()` (mirrors
+   `repeated_conflict_smoke_signature` from #242) scans the last
+   `REPEATED_CONFLICT_FAILURE_LIMIT` (3) `builder_smoke_result` comments; if
+   they share an identical `smoke_error` signature, escalate
+   (`@human-review` + `status:blocked`) instead of requeuing again.
+
+If you land on an issue already carrying that escalation comment: check
+whether the failing test only reproduces locally (never in the PR's own CI
+check) — that is an environment/harness bug, not something another codegen
+pass will fix. Fix the harness (or skip/ignore the unrelated pre-existing
+failure per **Definition of done**) rather than re-running codegen on the
+same diff again.
+
 ## Dependent milestone issues (anti-loop)
 
 When stacked issues share admin/CRM surfaces (LinkedIn import #109→#110→#111),

--- a/scripts/builder_conflicts.py
+++ b/scripts/builder_conflicts.py
@@ -121,8 +121,32 @@ def try_repair_main_after_smoke(
     return True, f"added imports for: {', '.join(added)}"
 
 
+# Builder's *own* codegen provider/model selection (how Builder itself talks
+# to Cursor/OpenAI/GitHub Models) is configured via these repo vars/secrets in
+# builder.yml. None of them are set in ci.yml's `test` job, so real CI always
+# exercises tests/test_codegen_provider.py's *default* resolution behavior.
+# `_smoke_env` used to inherit the full parent environment, which leaked
+# Builder's own `CURSOR_MODEL` (e.g. a non-default `composer-2.5` override)
+# into the cloned-PR-head pytest subprocess — failing
+# `test_select_provider_prefers_cursor_when_key_set` /
+# `test_select_provider_force_cursor` (which assert the *default* model
+# contains "sonnet") every single smoke run, on every issue, regardless of
+# the PR's diff. Re-running codegen can never fix an environment mismatch, so
+# this looped Builder forever (#115 / PR #265). Strip them so the smoke gate
+# matches what `pytest -q -m "not contract"` actually sees in ci.yml.
+_CODEGEN_SELECTION_ENV_VARS = (
+    "CURSOR_MODEL",
+    "CURSOR_MAX_MODE",
+    "CODEGEN_PROVIDER",
+    "OPENAI_MODEL",
+    "GITHUB_MODELS_MODEL",
+)
+
+
 def _smoke_env(cwd: Path, *, for_import: bool = False) -> dict[str, str]:
     env = {**os.environ, "PYTHONPATH": str(cwd)}
+    for var in _CODEGEN_SELECTION_ENV_VARS:
+        env.pop(var, None)
     if for_import:
         # Import-only: preview unlocks admin wiring without requiring secrets.
         env.setdefault("ADMIN_PREVIEW_MODE", "1")

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -217,6 +217,45 @@ def repeated_conflict_smoke_signature(
     return signatures[0] if len(set(signatures)) == 1 else None
 
 
+def repeated_smoke_result_signature(
+    repo: str, issue: int, *, threshold: int = REPEATED_CONFLICT_FAILURE_LIMIT
+) -> str | None:
+    """Return the shared smoke-error signature when the last ``threshold``
+    ``builder_smoke_result`` comments all failed with the same error.
+
+    Mirrors ``repeated_conflict_smoke_signature`` for the *other* smoke gate:
+    ``handoff_builder_when_mergeable``'s direct pre-handoff ``smoke_pr_head``
+    call, which runs even on a mergeable/clean PR (no conflict to resolve).
+    That path had no repeat counter at all — a `smoke_failed` result just
+    requeued unconditionally forever. On #115 / PR #265, three consecutive
+    Builder dispatches reproduced the identical `test_codegen_provider`
+    failure (an environment leak into the smoke subprocess, fixed separately
+    in ``builder_conflicts._smoke_env``) with nothing counting the repeats,
+    the same failure mode that #242 already taught us to catch on the
+    conflict-resolution smoke path. Escalate here too instead of looping.
+    """
+    comments = list_issue_comments(repo, issue)
+    signatures: list[str] = []
+    for comment in reversed(comments):
+        body = comment.get("body") or ""
+        if "### builder_smoke_result" not in body:
+            continue
+        status_match = re.search(r"- status: `([a-z_]+)`", body)
+        if not status_match:
+            continue
+        if status_match.group(1) != "smoke_failed":
+            break
+        error_match = re.search(r"- smoke_error: `(.+)", body, re.S)
+        if not error_match:
+            break
+        signatures.append(_smoke_error_signature(error_match.group(1)))
+        if len(signatures) >= threshold:
+            break
+    if len(signatures) < threshold:
+        return None
+    return signatures[0] if len(set(signatures)) == 1 else None
+
+
 def is_retryable_codegen_failure(exc: BaseException) -> bool:
     """True when Builder should re-enter ``status:queued`` instead of blocking.
 
@@ -477,6 +516,24 @@ def handoff_builder_when_mergeable(repo: str, issue: int) -> None:
                     "`pytest --collect-only`, and full `pytest -q` succeed.\n"
                 ),
             )
+            signature = repeated_smoke_result_signature(repo, issue)
+            if signature:
+                escalate(
+                    repo,
+                    issue,
+                    (
+                        f"Pre-handoff smoke on PR #{smoke.get('pr')} has failed "
+                        f"`{REPEATED_CONFLICT_FAILURE_LIMIT}` consecutive times with the "
+                        "identical error below. Re-running codegen cannot fix this — it "
+                        "isn't caused by this PR's diff (likely a Builder-runtime "
+                        "environment leak into the smoke subprocess, or another "
+                        "pre-existing/unrelated failure). Stopping automatic retries; "
+                        "see AGENTS/builder.md 'Pre-handoff smoke loop' for the fix.\n\n"
+                        f"```\n{signature}\n```"
+                    ),
+                )
+                write_builder_handoff("blocked")
+                return
             write_builder_handoff("waiting")
             return
         if smoke_status == "smoke_repaired":

--- a/tests/test_builder_conflicts.py
+++ b/tests/test_builder_conflicts.py
@@ -338,6 +338,34 @@ def test_smoke_env_keeps_preview_only_for_import(tmp_path, monkeypatch) -> None:
     assert "ADMIN_PREVIEW_MODE" not in pytest_env
 
 
+def test_smoke_env_strips_builders_own_codegen_selection_vars(
+    tmp_path, monkeypatch
+) -> None:
+    """Regression for #115 / PR #265: Builder's own `CURSOR_MODEL` (etc.,
+    set from repo `vars.*` in builder.yml so Builder knows which
+    provider/model *it* should codegen with) must not leak into the cloned
+    PR-head pytest subprocess. `ci.yml`'s `test` job never sets these, so a
+    non-default override (e.g. `CURSOR_MODEL=composer-2.5`) made
+    `tests/test_codegen_provider.py`'s default-model assertions fail only in
+    Builder's smoke gate — never in the PR's own CI — looping Builder forever
+    on a failure no amount of re-running codegen could fix.
+    """
+    from builder_conflicts import _smoke_env
+
+    monkeypatch.setenv("CURSOR_MODEL", "composer-2.5")
+    monkeypatch.setenv("CURSOR_MAX_MODE", "false")
+    monkeypatch.setenv("CODEGEN_PROVIDER", "cursor")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-test")
+    monkeypatch.setenv("GITHUB_MODELS_MODEL", "models-test")
+
+    for env in (_smoke_env(tmp_path, for_import=True), _smoke_env(tmp_path)):
+        assert "CURSOR_MODEL" not in env
+        assert "CURSOR_MAX_MODE" not in env
+        assert "CODEGEN_PROVIDER" not in env
+        assert "OPENAI_MODEL" not in env
+        assert "GITHUB_MODELS_MODEL" not in env
+
+
 def test_truncate_pytest_detail_keeps_tail_summary() -> None:
     from builder_conflicts import _truncate_pytest_detail
 

--- a/tests/test_run_agent_smoke_loop_breaker.py
+++ b/tests/test_run_agent_smoke_loop_breaker.py
@@ -1,0 +1,151 @@
+"""Repeated identical *pre-handoff* smoke failures must escalate, not loop forever.
+
+Regression coverage for issue #115 / PR #265: `handoff_builder_when_mergeable`'s
+direct `smoke_pr_head` call (mergeable/clean PR heads — no conflict to
+resolve) had no repeat counter at all, unlike the conflict-resolution smoke
+path (#242's `repeated_conflict_smoke_signature`). Three consecutive Builder
+dispatches reproduced the identical `tests/test_codegen_provider.py` failure
+(caused by Builder's own `CURSOR_MODEL` runtime override leaking into the
+smoke subprocess — fixed separately in `builder_conflicts._smoke_env`) with
+nothing counting the repeats, so Builder just requeued forever.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from run_agent import (
+    REPEATED_CONFLICT_FAILURE_LIMIT,
+    handoff_builder_when_mergeable,
+    repeated_smoke_result_signature,
+)
+
+SMOKE_ERROR = (
+    "pytest failed: onError: assert 'sonnet' in 'composer-2.5'\n"
+    "tests/test_codegen_provider.py:130: AssertionError"
+)
+
+
+def _smoke_result_comment(status: str, smoke_error: str | None = None) -> dict:
+    lines = [
+        "### builder_smoke_result",
+        f"- status: `{status}`",
+        "- pr: #265",
+    ]
+    if smoke_error is not None:
+        lines.append(f"- smoke_error: `{smoke_error}`")
+    return {"body": "\n".join(lines)}
+
+
+@pytest.mark.unit
+def test_identical_smoke_error_repeated_returns_signature() -> None:
+    comments = [
+        _smoke_result_comment("smoke_failed", SMOKE_ERROR)
+        for _ in range(REPEATED_CONFLICT_FAILURE_LIMIT)
+    ]
+    with patch("run_agent.list_issue_comments", return_value=comments):
+        signature = repeated_smoke_result_signature("o/r", 115)
+    assert signature is not None
+    assert "sonnet" in signature or "composer" in signature
+
+
+@pytest.mark.unit
+def test_below_threshold_does_not_trigger() -> None:
+    comments = [_smoke_result_comment("smoke_failed", SMOKE_ERROR)]
+    with patch("run_agent.list_issue_comments", return_value=comments):
+        assert repeated_smoke_result_signature("o/r", 115) is None
+
+
+@pytest.mark.unit
+def test_changing_smoke_error_does_not_trigger() -> None:
+    comments = [
+        _smoke_result_comment("smoke_failed", f"different error #{i}")
+        for i in range(REPEATED_CONFLICT_FAILURE_LIMIT)
+    ]
+    with patch("run_agent.list_issue_comments", return_value=comments):
+        assert repeated_smoke_result_signature("o/r", 115) is None
+
+
+@pytest.mark.unit
+def test_progress_more_recent_than_old_failures_resets_streak() -> None:
+    # ``list_issue_comments`` returns oldest-first, matching the GitHub API.
+    comments = [
+        _smoke_result_comment("smoke_failed", SMOKE_ERROR)
+        for _ in range(REPEATED_CONFLICT_FAILURE_LIMIT)
+    ]
+    comments.append(_smoke_result_comment("smoke_repaired"))
+    with patch("run_agent.list_issue_comments", return_value=comments):
+        assert repeated_smoke_result_signature("o/r", 115) is None
+
+
+def _patch_clean_mergeable_pr(smoke_result: dict):
+    pr = {"number": 265, "head": {"ref": "builder/115-record-authoritative"}}
+    return (
+        patch(
+            "builder_conflicts.maybe_resolve_pr_conflicts",
+            return_value={"status": "no_pr"},
+        ),
+        patch(
+            "builder_conflicts.linked_pr_conflict_status",
+            return_value={"status": "clean"},
+        ),
+        patch("builder_conflicts.linked_open_prs", return_value=[pr]),
+        patch("builder_conflicts.refresh_pr", return_value=pr),
+        patch("builder_conflicts.smoke_pr_head", return_value=smoke_result),
+    )
+
+
+@pytest.mark.unit
+def test_handoff_escalates_instead_of_looping_when_signature_repeats() -> None:
+    smoke_result = {
+        "status": "smoke_failed",
+        "pr": 265,
+        "smoke_error": SMOKE_ERROR,
+        "repairs": [],
+    }
+    patches = _patch_clean_mergeable_pr(smoke_result)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch("run_agent.post_issue_comment"),
+        patch(
+            "run_agent.repeated_smoke_result_signature",
+            return_value=SMOKE_ERROR,
+        ),
+        patch("run_agent.escalate") as escalate,
+        patch("run_agent.write_builder_handoff") as write_handoff,
+    ):
+        handoff_builder_when_mergeable("o/r", 115)
+    escalate.assert_called_once()
+    assert "265" in escalate.call_args.args[2]
+    write_handoff.assert_called_once_with("blocked")
+
+
+@pytest.mark.unit
+def test_handoff_keeps_retrying_when_signature_not_yet_repeated() -> None:
+    smoke_result = {
+        "status": "smoke_failed",
+        "pr": 265,
+        "smoke_error": SMOKE_ERROR,
+        "repairs": [],
+    }
+    patches = _patch_clean_mergeable_pr(smoke_result)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch("run_agent.post_issue_comment"),
+        patch("run_agent.repeated_smoke_result_signature", return_value=None),
+        patch("run_agent.escalate") as escalate,
+        patch("run_agent.write_builder_handoff") as write_handoff,
+    ):
+        handoff_builder_when_mergeable("o/r", 115)
+    escalate.assert_not_called()
+    write_handoff.assert_called_once_with("waiting")


### PR DESCRIPTION
Fixes the loop reported against #115 / PR #265.

## Root cause

Builder's pre-handoff smoke gate (`handoff_builder_when_mergeable` → `smoke_pr_head` → `builder_conflicts._smoke_env`) cloned the PR head and ran the full pytest suite **inheriting Builder's own runtime environment**. Builder's job env sets `CURSOR_MODEL` / `CODEGEN_PROVIDER` / `OPENAI_MODEL` / `GITHUB_MODELS_MODEL` from repo `vars.*` (`builder.yml`) so Builder itself knows which provider/model to codegen with — but `ci.yml`'s actual `test` job never sets any of those.

On #115, the repo variable `CURSOR_MODEL` is set to `composer-2.5` (a non-default override). That value leaked into the smoke subprocess and made `tests/test_codegen_provider.py::test_select_provider_prefers_cursor_when_key_set` / `test_select_provider_force_cursor` fail — both assert the *default* model contains `"sonnet"`. This is completely unrelated to PR #265's actual diff (server-side analytics), and it's not reproducible in real CI: the PR's own `test` check on GitHub Actions passed every time. Since the failure comes from an environment mismatch, no amount of re-running codegen could ever fix it, so Builder requeued `status:queued` three times in a row (and would have continued indefinitely) on the exact same error.

Compounding this, the direct pre-handoff smoke path in `handoff_builder_when_mergeable` had **no repeat/loop-breaker at all** — unlike the sibling merge-conflict-resolution smoke path, which already gained one after issue #242 (`repeated_conflict_smoke_signature`, added in a prior PR). So even a genuinely-unfixable repeated failure had nothing to stop it from looping forever.

## Fix

1. `builder_conflicts._smoke_env` now strips `CURSOR_MODEL`, `CURSOR_MAX_MODE`, `CODEGEN_PROVIDER`, `OPENAI_MODEL`, and `GITHUB_MODELS_MODEL` before running the cloned-head pytest, so Builder's smoke gate matches what `ci.yml` actually runs — this is the direct fix for #115's specific failure.
2. `run_agent.repeated_smoke_result_signature` mirrors #242's `repeated_conflict_smoke_signature`: it scans the last 3 `builder_smoke_result` comments, and `handoff_builder_when_mergeable` now escalates (`@human-review` + `status:blocked`) instead of requeuing once the identical `smoke_error` repeats — a defense-in-depth loop-breaker for this smoke path in general, in case some other unrelated/pre-existing failure trips it again in the future.
3. `AGENTS/builder.md` documents both under a new **Pre-handoff smoke loop (anti-loop)** section, following the same pattern as the existing #242 write-up.

## Testing

- Reproduced the exact failure locally: `CURSOR_MODEL=composer-2.5 CODEGEN_PROVIDER=cursor pytest tests/test_codegen_provider.py` fails the same two tests with the same assertion seen in the #115 comments; confirmed `_smoke_env` no longer passes these vars through.
- Added `tests/test_run_agent_smoke_loop_breaker.py` (signature detection + escalate-vs-requeue wiring) and a case in `tests/test_builder_conflicts.py` (env stripping).
- Full suite: `pytest -q -m "not contract"` → 1412 passed, 52 skipped.

Made with [Cursor](https://cursor.com)