### PR TITLE
fix(builder): make local Cursor SDK commit messages describe the change

### DIFF
--- a/scripts/codegen_cursor.py
+++ b/scripts/codegen_cursor.py
@@ -244,6 +244,28 @@ def _slugify(text: str, limit: int = 40) -> str:
     return (slug or "work")[:limit]
 
 
+def _commit_subject(issue: int, title: str, summary: str) -> str:
+    """Build a `builder(#N): …` subject that describes the change, not the tool.
+
+    Prefers the agent's own one-line summary of what it did; falls back to the
+    issue title when the agent returned no usable summary.
+    """
+    prefix = f"builder(#{issue}): "
+    first_line = next(
+        (line.strip() for line in (summary or "").splitlines() if line.strip()),
+        "",
+    )
+    # Strip common leading filler ("I implemented...", "Summary:", markdown bullets).
+    first_line = re.sub(r"^[#*\-\s]+", "", first_line)
+    first_line = re.sub(r"^(summary|done|result)\s*:\s*", "", first_line, flags=re.I)
+    subject = first_line or title.strip() or "implement change"
+    subject = re.sub(r"\s+", " ", subject).strip()
+    max_len = 72 - len(prefix)
+    if len(subject) > max_len:
+        subject = subject[: max_len - 1].rstrip() + "…"
+    return f"{prefix}{subject}"
+
+
 def _build_local(
     repo: str,
     issue: int,
@@ -316,7 +338,7 @@ def _build_local(
 
     branch, existing_pr = resolve_builder_branch(repo, issue, title)
     ensure_branch(repo, branch, base_sha)
-    commit_message = f"builder(#{issue}): implement via Cursor SDK"
+    commit_message = _commit_subject(issue, title, getattr(result, "result", "") or "")
     put_file_batch(repo, branch, files, commit_message)
 
     if existing_pr:

--- a/tests/test_codegen_cursor.py
+++ b/tests/test_codegen_cursor.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from codegen_cursor import _pr_number_from_url, build_prompt
+from codegen_cursor import _commit_subject, _pr_number_from_url, build_prompt
 
 
 def test_pr_number_from_url() -> None:
@@ -28,6 +28,31 @@ def test_build_prompt_includes_issue(tmp_path) -> None:
     assert "do NOT git commit" in text
     assert "User flow" in text
     assert "Be minimal." in text
+
+
+def test_commit_subject_uses_agent_summary() -> None:
+    subject = _commit_subject(
+        242, "Add pricing page", "Added a new pricing page with three tiers.\n\nMore details..."
+    )
+    assert subject == "builder(#242): Added a new pricing page with three tiers."
+
+
+def test_commit_subject_strips_filler_prefix() -> None:
+    subject = _commit_subject(242, "Add pricing page", "Summary: added the pricing page.")
+    assert subject == "builder(#242): added the pricing page."
+
+
+def test_commit_subject_falls_back_to_title() -> None:
+    subject = _commit_subject(242, "Add pricing page", "")
+    assert subject == "builder(#242): Add pricing page"
+
+
+def test_commit_subject_truncates_long_lines() -> None:
+    long_summary = "x" * 100
+    subject = _commit_subject(242, "Add pricing page", long_summary)
+    assert subject.startswith("builder(#242): ")
+    assert len(subject) <= 72
+    assert subject.endswith("…")
 
 
 def test_cursor_runtime_defaults_local(monkeypatch) -> None:


### PR DESCRIPTION
Builder's local-runtime Cursor SDK codegen path hardcoded every commit to `builder(#N): implement via Cursor SDK`, regardless of what actually changed.

Now the commit subject is derived from the Cursor agent's own one-line summary of the change (falling back to the issue title when no summary is available), so commits look like `builder(#242): Added a new pricing page with three tiers.` instead of the generic tool name.

- Added `_commit_subject()` helper in `scripts/codegen_cursor.py` with filler-stripping and truncation.
- Added 4 unit tests covering summary extraction, filler-stripping, title fallback, and truncation.

No issue tracks this; it's a small DX fix to Builder's own commit-message quality.

Made with [Cursor](https://cursor.com)