### PR TITLE
fix(agents): root reviewer AI at pr-head, not main, to stop phantom-deletion hard-fails

### DIFF
--- a/scripts/review_models.py
+++ b/scripts/review_models.py
@@ -40,6 +40,27 @@ def cursor_api_key() -> str | None:
     return value.strip() if value and value.strip() else None
 
 
+def reviewer_agent_cwd() -> str:
+    """Filesystem root for the reviewer's Cursor agent tool calls.
+
+    Reviewer Actions checkout ``main`` at ``os.getcwd()`` and the actual PR
+    under review as a sibling git worktree at ``COVERAGE_ROOT`` (``pr-head/``,
+    see reviewer.yml). Rooting the agent's local tools at ``os.getcwd()``
+    (main) left ``./`` (main) and ``./pr-head`` (the PR) both reachable side
+    by side, so the model could — instead of trusting the correct
+    merge-base ``files``/``patch`` payload already in its prompt — diff those
+    two trees directly. Any file added to main *after* a stale branch forked
+    then looks exactly like something "the PR deletes", producing false
+    changes-requested hard-fails and a Builder<->Reviewer loop for any PR that
+    is merely behind main (#342). Root the agent at the PR tree itself so
+    there is no mismatched sibling tree to conflate with the diff.
+    """
+    cov_root = (os.environ.get("COVERAGE_ROOT") or "").strip()
+    if cov_root and os.path.isdir(cov_root):
+        return cov_root
+    return os.getcwd()
+
+
 def chat_cursor(system: str, user: str, model: str | None = None) -> tuple[str, str]:
     """Ask-only Cursor agent turn; must not modify the workspace."""
     key = cursor_api_key()
@@ -56,9 +77,18 @@ def chat_cursor(system: str, user: str, model: str | None = None) -> tuple[str, 
             "cursor-sdk is not installed; pip install -r requirements-agents.txt"
         ) from exc
 
+    agent_cwd = reviewer_agent_cwd()
     prompt = (
         "READ-ONLY REVIEW TASK. Do not create, edit, delete, or move any files. "
         "Do not run mutating shell/git commands. Do not open PRs.\n"
+        "The working directory is the PR branch under review, checked out at "
+        "its own commit — it is NOT `main` and has no sibling copy of `main` "
+        "to compare against. Do not attempt to diff this working directory "
+        "against `main` or any other branch/tree; you cannot see `main` from "
+        "here. Base every claim about added/changed/deleted/reverted files "
+        "strictly on the `files` list in the Context below (already the "
+        "correct PR-vs-base diff) — never infer a deletion or revert from "
+        "your own filesystem exploration.\n"
         "Respond with JSON only (no prose outside JSON).\n\n"
         f"## Instructions\n{system}\n\n"
         f"## Context\n{user}\n"
@@ -71,7 +101,7 @@ def chat_cursor(system: str, user: str, model: str | None = None) -> tuple[str, 
                 api_key=key,
                 name="reviewer-ai",
                 mode="plan",
-                local=LocalAgentOptions(cwd=os.getcwd()),
+                local=LocalAgentOptions(cwd=agent_cwd),
             ),
         )
     except TypeError:
@@ -84,7 +114,7 @@ def chat_cursor(system: str, user: str, model: str | None = None) -> tuple[str, 
                     "apiKey": key,
                     "name": "reviewer-ai",
                     "mode": "plan",
-                    "local": {"cwd": os.getcwd()},
+                    "local": {"cwd": agent_cwd},
                 },
             )
         except Exception as exc:
@@ -376,6 +406,12 @@ def ai_review(repo: str, issue: int, pr_number: int) -> dict[str, Any]:
         "- wording/style nits when acceptance criteria are met\n"
         "If acceptance criteria are met, set decision=approved and meets_acceptance=true.\n"
         "Be concrete in reasons.\n"
+        "Never claim this PR 'deletes', 'removes', or 'reverts' a file or "
+        "function unless that exact path appears in `files` below with "
+        "status=\"removed\" (or a patch showing the specific lines removed). "
+        "A file that simply doesn't appear in `files` was not touched by this "
+        "PR — it is not evidence of a deletion, even if that file exists on "
+        "main (main may have added it after this branch was created).\n"
     )
     user = json.dumps(ctx, indent=2)
     raw, model = chat(system, user, model=model)

--- a/tests/test_review_models.py
+++ b/tests/test_review_models.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
-from review_models import ai_review, extract_json
+from review_models import ai_review, extract_json, reviewer_agent_cwd
 
 
 def test_extract_json_recovers_truncated_approved() -> None:
@@ -92,3 +93,22 @@ def test_ai_review_keeps_changes_when_real_reason_and_acceptance_claimed() -> No
             verdict = ai_review("o/r", 58, 60)
     assert verdict["decision"] == "changes-requested"
     assert verdict["meets_acceptance"] is False
+
+
+def test_reviewer_agent_cwd_prefers_pr_head_worktree(tmp_path) -> None:
+    """#342: the AI reviewer must be rooted at the PR tree (COVERAGE_ROOT),
+    never at the sibling `main` checkout — otherwise it can diff `main`
+    against `pr-head/` directly and hallucinate deletions/reverts for files
+    that were simply added to `main` after a stale branch forked."""
+    pr_head = tmp_path / "pr-head"
+    pr_head.mkdir()
+    with patch.dict(os.environ, {"COVERAGE_ROOT": str(pr_head)}):
+        assert reviewer_agent_cwd() == str(pr_head)
+
+
+def test_reviewer_agent_cwd_falls_back_when_coverage_root_missing() -> None:
+    with patch.dict(os.environ, {"COVERAGE_ROOT": "/nonexistent/pr-head-path"}):
+        assert reviewer_agent_cwd() == os.getcwd()
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("COVERAGE_ROOT", None)
+        assert reviewer_agent_cwd() == os.getcwd()


### PR DESCRIPTION
Fixes #342.

## Root cause (loop bug)

The automated Reviewer's AI check (`scripts/review_models.chat_cursor`) runs a live, tool-using Cursor Agent rooted at `local.cwd=os.getcwd()`. On `reviewer.yml`, that `cwd` is the **`main`** checkout (`actions/checkout@v4`, `ref: main`); the actual PR under review is only fetched as a sibling git worktree at `./pr-head/` (`COVERAGE_ROOT`). With both trees reachable side by side from its own filesystem tools, the model could compare `./<path>` (main) against `./pr-head/<path>` (PR head) directly instead of trusting the correct merge-base `files`/`patch` payload already supplied in its prompt. Any file added to `main` *after* a stale branch forked then looks — from that naive two-tree comparison — exactly like something "the PR deletes/reverts."

**Reproduced on PR #196**: the bot rejected it for "deletes `app/discovery` (#118)" and "reverts `admin_auth` candidate rate-limiting" — neither appears anywhere in `git diff origin/main...head` or the GitHub PR Files API. Both were simply added to `main` after PR #196's branch forked (via #118 and #241); a branch that predates a module can't have deleted it.

This is a systemic loop hazard: any builder PR that's behind `main` near a recently-landed module can get a false `changes-requested` for a "fix" that doesn't correspond to anything in its real diff, with no way for Builder to ever satisfy it.

## Fix

1. `reviewer_agent_cwd()` roots the Cursor agent's local tools at `COVERAGE_ROOT` (`pr-head/`, the actual PR tree) instead of `os.getcwd()` (`main`), removing the mismatched sibling tree.
2. The reviewer prompt now explicitly states the working directory is the PR branch, that `main` is not reachable from it, and that deletion/revert claims must come only from the supplied `files` list (`status == "removed"`) — never from ad hoc filesystem exploration.

## Testing

Added `test_reviewer_agent_cwd_prefers_pr_head_worktree` / `test_reviewer_agent_cwd_falls_back_when_coverage_root_missing` to `tests/test_review_models.py`. Full existing `test_review_models.py` + related `run_agent`/`review` suite still pass (118 passed, 3 skipped).

## Scope note

This PR only touches reviewer-automation scripts + their tests, not product code, so it's exempt from the `app/`-coverage gate; the `test` CI job (unit+integration suite) is the only relevant required check.

Made with [Cursor](https://cursor.com)