### PR TITLE
fix: repair pg-contract suite drift from migration 019 + actor_context

### DIFF
--- a/tests/pg_contract/test_acquisition_lifecycle_e2e.py
+++ b/tests/pg_contract/test_acquisition_lifecycle_e2e.py
@@ -160,6 +160,7 @@ def test_acquisition_lifecycle_end_to_end(lifecycle_env: dict[str, Any]) -> None
     # 3. Evidence (research record)
     record = crm.attach_research_record(
         conn,
+        actor_context=ACTOR,
         record_type="public_signal",
         company_id=company_id,
         contact_id=contact_id,

--- a/tests/pg_contract/test_acquisition_recovery_e2e.py
+++ b/tests/pg_contract/test_acquisition_recovery_e2e.py
@@ -64,6 +64,7 @@ def _seed_valid_crm_state(conn: psycopg.Connection, crm: CrmService) -> dict[str
 
     evidence = crm.attach_research_record(
         conn,
+        actor_context=ACTOR,
         record_type="verified_fact",
         company_id=company_id,
         body="Existing evidence before failed import",

--- a/tests/pg_contract/test_backup_restore_contract.py
+++ b/tests/pg_contract/test_backup_restore_contract.py
@@ -26,7 +26,7 @@ def test_export_manifest_structure_on_migrated_database(
 
     snapshot = build_snapshot(pg_conn)
     assert validate_snapshot_structure(snapshot) == []
-    assert snapshot["schema_version"] == "018"
+    assert snapshot["schema_version"] == "019"
     assert set(snapshot["table_counts"]) == set(CRM_BACKUP_TABLES)
     assert snapshot["table_counts"]["schema_migrations"] == len(MIGRATIONS)
     for table in CRM_BACKUP_TABLES:


### PR DESCRIPTION
Same recurring semantic-drift class already documented in `docs/WORKFLOW_GOVERNANCE.md`: the schema on `main` is already at migration 019 (and `attach_research_record()` already requires `actor_context` per #334/#347), but two contract tests were still pinned to stale expectations from before those landed.

- `tests/pg_contract/test_backup_restore_contract.py` asserted `schema_version == "018"`; the live migrated database is now at `"019"` (contact_field_sources).
- `tests/pg_contract/test_acquisition_lifecycle_e2e.py` and `test_acquisition_recovery_e2e.py` called `CrmService.attach_research_record()` without the `actor_context` keyword that #334/#347 made required for atomic audit mutations.

This is currently failing the `PostgreSQL CRM contract suite` check on `main` itself (since commit `2b2429c6`), and blocking the contract-suite check on every open PR, including #285 and #364.

Verified locally against a real Postgres instance:
- `pytest -q -m contract` → 108 passed, 2 skipped (was 102 passed, 1 failed)
- `pytest -q -m "not contract"` → 1734 passed, unaffected

Split out as its own PR (rather than riding on #364's freeze-migrations branch) so it can go through independent review on its own merits.

Made with [Cursor](https://cursor.com)