### PR TITLE
fix: post-deploy screenshots open a PR with auto-merge instead of pushing to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,12 @@ jobs:
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           VISUAL_PROVIDER: ${{ vars.VISUAL_PROVIDER }}
           DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL }}
+          # Passed via env, not interpolated straight into the run: string —
+          # a commit message containing a `"` (e.g. quoting a 422 error
+          # message) previously closed the --commit-message string early and
+          # spilled the rest of the message into unrecognized argv, failing
+          # this job before it ever captured a screenshot.
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
           # Deploy job already waited for Render to go live; short pause then
@@ -202,7 +208,7 @@ jobs:
           python scripts/post_deploy_visual.py \
             --repo "${{ github.repository }}" \
             --sha "${{ github.sha }}" \
-            --commit-message "${{ github.event.head_commit.message }}"
+            --commit-message "$HEAD_COMMIT_MESSAGE"
       - name: Upload deploy health JSON
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -158,6 +158,17 @@ until merged.
 3. Comments `### deploy_visual_check` on the linked issue
 4. Compares against pre-merge **branch** shots when available (not production `pre-*`)
 
+Health JSON and screenshot uploads land on a deterministic
+`deploy/screenshots-<sha>` branch and a PR against `main` with auto-merge
+enabled — **not** a direct push. The workflow-governance ruleset
+(`docs/WORKFLOW_GOVERNANCE.md`) rejects bot pushes straight to a protected
+branch, the same reason `freeze_shipped_migrations.py` opens a
+`deploy/freeze-*` PR instead of pushing (issue #362/#366). One human
+CODEOWNER approval merges it; reruns for the same deploy sha reuse the
+existing open PR (`find_open_pr_for_branch`) instead of opening a duplicate.
+The issue comment's screenshot links point at the raw content on that branch,
+so they render before the PR merges.
+
 ## Source matrix
 
 | Phase | Source | Filenames |

--- a/docs/WORKFLOW_GOVERNANCE.md
+++ b/docs/WORKFLOW_GOVERNANCE.md
@@ -264,6 +264,39 @@ other direct `put_files(repo, "main", ...)` / `git/refs/heads/main` PATCH
 call sites before adding new ones) will hit the identical 422 and should use
 the same open-PR-with-auto-merge pattern rather than a bypass actor.
 
+### Post-deploy screenshots hit the same 422 (issue #366)
+
+The prior audit for this section checked `scripts/screenshot_deploy.py` and
+`scripts/codegen_models.py`'s `put_files()` call sites and found both only
+ever target `builder/*` PR head branches — but missed
+`scripts/post_deploy_visual.py`, a separate script that *imports*
+`upload_to_branch()` from `screenshot_deploy.py` and calls it (and
+`record_health()`) with the **default branch** (`main`) as the target. The
+`Post-deploy screenshots` CI job hit the identical
+`Changes must be made through a pull request` 422 once live enforcement was
+restored, for the same structural reason as issue #362.
+
+The fix follows the exact same pattern: `post_deploy_visual.py` now commits
+`/health` JSON and screenshot uploads onto a deterministic
+`deploy/screenshots-<sha>` branch (`record_branch_name()`), opens a PR
+against `main` (or reuses one via `find_open_pr_for_branch` if a rerun for
+the same deploy sha already has one open), and enables native auto-merge
+(`open_or_reuse_record_pr()`) — one human CODEOWNER approval lands it, no
+extra click. The PR title starts with `deploy: record post-deploy artifacts`
+so the eventual squash-merge commit on `main` still matches the `test` /
+`deploy` jobs' `startsWith(..., 'deploy: record')` skip filter and does not
+re-trigger the deploy pipeline.
+
+A separate bug compounded the same CI run: `ci.yml` interpolated
+`${{ github.event.head_commit.message }}` directly into the
+`--commit-message "..."` shell string. A commit message that itself quoted a
+422 error (containing a literal `"`) closed that string early and spilled the
+remainder into unrecognized `argv`, failing the job before it ever reached
+the push. Commit messages (and any other untrusted `github.event.*` text) must
+be passed to `run:` steps via `env:` and referenced as `"$VAR"`, never
+interpolated straight into the script string — this avoids both the quoting
+break and generic Actions script-injection risk.
+
 ## Recovery and break-glass
 
 Use break-glass only when a protected workflow blocks a production incident or

--- a/scripts/post_deploy_visual.py
+++ b/scripts/post_deploy_visual.py
@@ -15,9 +15,19 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
+from typing import Any
 
 from cursor_model import DEFAULT_CURSOR_MODEL, cursor_model_dict, cursor_model_selection
-from github_api import GitHubError, api, post_issue_comment, split_repo
+from github_api import (
+    GitHubError,
+    api,
+    create_branch,
+    enable_auto_merge,
+    find_open_pr_for_branch,
+    open_pull_request,
+    post_issue_comment,
+    split_repo,
+)
 from screenshot_deploy import (
     PRE_BRANCH_PHASE,
     capture,
@@ -30,6 +40,64 @@ from screenshot_deploy import (
 )
 
 DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
+
+RECORD_COMMIT_PREFIX = "deploy: record post-deploy artifacts"
+
+
+def record_branch_name(sha: str) -> str:
+    """Deterministic per-deploy branch so a rerun for the same deploy reuses
+    one branch/PR instead of opening a duplicate (mirrors
+    ``freeze_shipped_migrations.freeze_branch_name``)."""
+    short = (sha or "local")[:12] or "local"
+    return f"deploy/screenshots-{short}"
+
+
+def record_pr_body(short: str, base_url: str) -> str:
+    return (
+        "### deploy_record\n"
+        f"- deploy: `{base_url}`\n"
+        f"- sha: `{short}`\n"
+        "- Automated, evidence-only change: records this deploy's `/health` "
+        "snapshot and screenshot uploads under `.agent/`. No application "
+        "code, migration, or test changes.\n"
+        "- Opened as a PR (not a direct push) because the workflow-governance "
+        "ruleset requires every change to `main` go through review — see "
+        "`docs/WORKFLOW_GOVERNANCE.md`. Auto-merge is enabled: approving this "
+        "PR is sufficient, no separate merge click needed.\n"
+    )
+
+
+def open_or_reuse_record_pr(
+    repo: str,
+    head_branch: str,
+    base_branch: str,
+    *,
+    short: str,
+    base_url: str,
+) -> dict[str, Any]:
+    """Open (or reuse) the auto-merge PR that lands this deploy's recorded
+    evidence on ``base_branch``.
+
+    Same pattern as ``freeze_shipped_migrations.maybe_commit_freeze``: a
+    direct push to a protected branch is rejected by the workflow-governance
+    ruleset (issue #362), so evidence commits land on a dedicated branch and
+    merge themselves via GitHub's native auto-merge the instant a human
+    CODEOWNER approves. Reruns against the same deploy sha reuse the existing
+    open PR instead of opening a duplicate.
+    """
+    existing = find_open_pr_for_branch(repo, head_branch)
+    if existing is not None:
+        return {"number": existing["number"], "url": existing["html_url"]}
+    title = f"{RECORD_COMMIT_PREFIX} ({short})"
+    pr = open_pull_request(
+        repo,
+        head=head_branch,
+        base=base_branch,
+        title=title,
+        body=record_pr_body(short, base_url),
+    )
+    enable_auto_merge(repo, pr["node_id"])
+    return {"number": pr["number"], "url": pr["html_url"]}
 
 
 def record_health(
@@ -403,19 +471,26 @@ def main(argv: list[str] | None = None) -> int:
             or find_issue_from_commit(args.repo, args.sha)
         )
         default = api("GET", f"/repos/{owner}/{name}").get("default_branch") or "main"
+        short = (args.sha or "local")[:12] or "local"
+        # Record evidence on a dedicated branch + auto-merge PR rather than
+        # pushing straight to the default branch — same reason and pattern as
+        # freeze_shipped_migrations.py's maybe_commit_freeze (issue #362): the
+        # workflow-governance ruleset rejects direct bot pushes to a
+        # protected branch with a 422.
+        record_branch = record_branch_name(args.sha)
+        create_branch(args.repo, record_branch, base_branch=default)
         base_url = resolve_base_url(args.base_url)
         health = wait_healthy(base_url)
         health_slim = {k: v for k, v in health.items() if not str(k).startswith("_")}
         health_rec = record_health(
             args.repo,
-            default,
+            record_branch,
             sha=args.sha,
             base_url=base_url,
             health=health,
         )
 
         out = Path("trace/screenshots-post")
-        short = (args.sha or "local")[:12]
         changed: list[str] | None = None
         if args.pr:
             changed = fetch_pr_changed_paths(args.repo, args.pr)
@@ -451,7 +526,7 @@ def main(argv: list[str] | None = None) -> int:
                 else f".agent/screenshots/deploy-{short}/post"
             )
             post_urls = (
-                upload_to_branch(args.repo, default, post_files, prefix)
+                upload_to_branch(args.repo, record_branch, post_files, prefix)
                 if post_files
                 else []
             )
@@ -462,6 +537,9 @@ def main(argv: list[str] | None = None) -> int:
         )
 
         if not issue_num:
+            record_pr = open_or_reuse_record_pr(
+                args.repo, record_branch, default, short=short, base_url=base_url
+            )
             print(
                 "No issue number in commit message / linked PR; "
                 f"uploaded post screenshots: {post_urls}; {health_line}"
@@ -470,6 +548,7 @@ def main(argv: list[str] | None = None) -> int:
                 "Tip: include `Closes #N` or `(#N)` in the commit/PR body "
                 "so Reviewer gets deploy_visual_check on the issue."
             )
+            print(f"record_pr={record_pr['url']}")
             return 0
 
         issue = api("GET", f"/repos/{owner}/{name}/issues/{issue_num}")
@@ -486,7 +565,7 @@ def main(argv: list[str] | None = None) -> int:
         if pre_files:
             pre_urls = upload_to_branch(
                 args.repo,
-                default,
+                record_branch,
                 pre_files,
                 f".agent/screenshots/issue-{issue_num}/pre",
             )
@@ -571,15 +650,29 @@ def main(argv: list[str] | None = None) -> int:
                 f"- all_done: `false`\n- note: refresh failed (`{acc_exc}`)\n",
             )
 
+        record_pr = open_or_reuse_record_pr(
+            args.repo, record_branch, default, short=short, base_url=base_url
+        )
+
         if visual.get("decision") == "fail":
             post_issue_comment(
                 args.repo,
                 issue_num,
                 "@human-review Post-deploy visual check failed — change may not be visible on production.\n",
             )
+            print(f"record_pr={record_pr['url']}", file=sys.stderr)
             print("visual check failed", file=sys.stderr)
             return 1
-        print(json.dumps({"issue": issue_num, "visual": visual, "post": post_urls}))
+        print(
+            json.dumps(
+                {
+                    "issue": issue_num,
+                    "visual": visual,
+                    "post": post_urls,
+                    "record_pr": record_pr["url"],
+                }
+            )
+        )
         return 0
     except Exception as exc:
         print(f"FAIL: {exc}", file=sys.stderr)

--- a/tests/test_post_deploy_visual.py
+++ b/tests/test_post_deploy_visual.py
@@ -10,6 +10,9 @@ from github_api import GitHubError
 
 from post_deploy_visual import (
     _parse_visual_json,
+    open_or_reuse_record_pr,
+    record_branch_name,
+    record_pr_body,
     visual_ai_check,
 )
 
@@ -120,3 +123,68 @@ def test_visual_ai_check_force_openai(monkeypatch: pytest.MonkeyPatch) -> None:
             )
     assert result["provider"] == "openai"
     cursor.assert_not_called()
+
+
+def test_record_branch_name_is_deterministic() -> None:
+    assert record_branch_name("abc123def456extra") == "deploy/screenshots-abc123def456"
+    assert record_branch_name("") == "deploy/screenshots-local"
+
+
+def test_record_pr_body_mentions_sha_and_auto_merge() -> None:
+    body = record_pr_body("abc123def456", "https://saberistic.com")
+    assert "abc123def456" in body
+    assert "auto-merge" in body.lower()
+    assert "WORKFLOW_GOVERNANCE" in body
+
+
+def test_open_or_reuse_record_pr_opens_with_auto_merge_when_absent() -> None:
+    with (
+        patch(
+            "post_deploy_visual.find_open_pr_for_branch", return_value=None
+        ) as find_pr,
+        patch(
+            "post_deploy_visual.open_pull_request",
+            return_value={"number": 11, "node_id": "PR_kwzz", "html_url": "https://x/11"},
+        ) as open_pr,
+        patch("post_deploy_visual.enable_auto_merge") as auto_merge,
+    ):
+        result = open_or_reuse_record_pr(
+            "o/r",
+            "deploy/screenshots-abc123def456",
+            "main",
+            short="abc123def456",
+            base_url="https://saberistic.com",
+        )
+
+    assert result == {"number": 11, "url": "https://x/11"}
+    find_pr.assert_called_once_with("o/r", "deploy/screenshots-abc123def456")
+    open_pr.assert_called_once_with(
+        "o/r",
+        head="deploy/screenshots-abc123def456",
+        base="main",
+        title="deploy: record post-deploy artifacts (abc123def456)",
+        body=record_pr_body("abc123def456", "https://saberistic.com"),
+    )
+    auto_merge.assert_called_once_with("o/r", "PR_kwzz")
+
+
+def test_open_or_reuse_record_pr_reuses_existing_open_pr() -> None:
+    with (
+        patch(
+            "post_deploy_visual.find_open_pr_for_branch",
+            return_value={"number": 12, "html_url": "https://x/12"},
+        ),
+        patch("post_deploy_visual.open_pull_request") as open_pr,
+        patch("post_deploy_visual.enable_auto_merge") as auto_merge,
+    ):
+        result = open_or_reuse_record_pr(
+            "o/r",
+            "deploy/screenshots-abc123def456",
+            "main",
+            short="abc123def456",
+            base_url="https://saberistic.com",
+        )
+
+    assert result == {"number": 12, "url": "https://x/12"}
+    open_pr.assert_not_called()
+    auto_merge.assert_not_called()


### PR DESCRIPTION
Closes #366

The `Post-deploy screenshots` CI job ([run](https://github.com/saberistic-team/agent-web/actions/runs/29521692467/job/87701977166)) failed for two stacked reasons, both fixed here:

1. `ci.yml` interpolated `${{ github.event.head_commit.message }}` directly into the `--commit-message "..."` shell string. That deploy's commit message quoted a 422 error containing a literal double-quote, which closed the shell string early and spilled the remainder into unrecognized `argv`, failing `post_deploy_visual.py` before it ever captured a screenshot. Fixed by passing the message via `env: HEAD_COMMIT_MESSAGE` and referencing `"$HEAD_COMMIT_MESSAGE"` instead.
2. Structurally, `scripts/post_deploy_visual.py`'s `record_health()` and post-screenshot `upload_to_branch()` calls push straight to the default branch (`main`). Now that the workflow-governance ruleset is truly enforced (#359/#360/#361), that direct push is rejected with the same 422 ("Changes must be made through a pull request") that `freeze_shipped_migrations.py` hit in #362 — the prior audit for that fix checked `screenshot_deploy.py`/`codegen_models.py`'s `put_files()` call sites but missed this separate script, which imports `upload_to_branch()` from `screenshot_deploy.py` and calls it against `main`.

Fix follows the exact same pattern as #362/#363 (migration freezing): post-deploy screenshots now commit onto a deterministic `deploy/screenshots-<sha>` branch, open a PR against `main` (or reuse one on rerun via `find_open_pr_for_branch`), and enable native GitHub auto-merge — one human CODEOWNER approval lands it, exactly like migration freezes.

### Changes
- `scripts/post_deploy_visual.py`: new `record_branch_name()`, `record_pr_body()`, `open_or_reuse_record_pr()` (reusing `github_api.py`'s existing `create_branch`/`find_open_pr_for_branch`/`open_pull_request`/`enable_auto_merge` — no changes needed there). `main()` creates the branch up front, redirects `record_health()` and both screenshot `upload_to_branch()` call sites to it, and opens/reuses the PR at every return path.
- `.github/workflows/ci.yml`: commit message passed via `env:` instead of inline interpolation (also closes a script-injection-shaped footgun for any future commit message).
- `docs/WORKFLOW_GOVERNANCE.md`, `docs/SCREENSHOTS.md`: document the new branch/PR/auto-merge path and correct the earlier "never main" audit note.
- `tests/test_post_deploy_visual.py`: unit tests for the three new functions, mirroring `tests/test_freeze_shipped_migrations.py`'s coverage.

### Verified
- `pytest -q -m "not contract"` (python3.12 venv) — 1756 passed, 0 failed, 75 skipped.
- `scripts/check_coverage.py` — pass (72.4% overall, unit ≥90%/integration ≥70% on `app/`).
- `scripts/validate_workflow_governance.py` — PASS.
- YAML/py syntax validated for `ci.yml` and `post_deploy_visual.py`.

Made with [Cursor](https://cursor.com)