### PR TITLE
fix: comment post-deploy screenshots on the deploy/screenshots-<sha> record PR too

### DIFF
--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -169,8 +169,15 @@ branch, the same reason `freeze_shipped_migrations.py` opens a
 `deploy/freeze-*` PR instead of pushing (issue #362/#366). One human
 CODEOWNER approval merges it; reruns for the same deploy sha reuse the
 existing open PR (`find_open_pr_for_branch`) instead of opening a duplicate.
-The issue comment's screenshot links point at the raw content on that branch,
-so they render before the PR merges.
+
+The same `### deploy_visual_check` (or `### deploy_record` when no issue is
+linked) comment — screenshots and all — is posted on **both** the linked
+issue and the `deploy/screenshots-<sha>` record PR itself
+(`post_deploy_visual.notify_deploy`), so the CODEOWNER reviewing that PR sees
+the before/after evidence inline before approving auto-merge, instead of
+having to open the linked issue or inspect the raw PNG diff. The screenshot
+links point at the raw content on that branch, so they render before the PR
+merges.
 
 ## Source matrix
 

--- a/scripts/post_deploy_visual.py
+++ b/scripts/post_deploy_visual.py
@@ -100,6 +100,15 @@ def open_or_reuse_record_pr(
     return {"number": pr["number"], "url": pr["html_url"]}
 
 
+def notify_deploy(repo: str, issue_num: int | None, record_pr_number: int, body: str) -> None:
+    """Post deploy evidence to the record PR (its CODEOWNER reviewer should
+    see the same before/after screenshots inline, not just a generic PR body
+    or a raw file diff) and, when present, to the linked issue."""
+    post_issue_comment(repo, record_pr_number, body)
+    if issue_num:
+        post_issue_comment(repo, issue_num, body)
+
+
 def record_health(
     repo: str,
     branch: str,
@@ -536,9 +545,19 @@ def main(argv: list[str] | None = None) -> int:
             + (f" ([recorded]({health_rec['url']}))" if health_rec.get("url") else "")
         )
 
+        record_pr = open_or_reuse_record_pr(
+            args.repo, record_branch, default, short=short, base_url=base_url
+        )
+
         if not issue_num:
-            record_pr = open_or_reuse_record_pr(
-                args.repo, record_branch, default, short=short, base_url=base_url
+            # No linked issue to comment on — post the evidence to the
+            # record PR itself so its CODEOWNER reviewer sees the screenshots
+            # (not just a generic PR body) before approving auto-merge.
+            notify_deploy(
+                args.repo,
+                None,
+                record_pr["number"],
+                comment_markdown("### deploy_record", base_url, post_urls, extra=[health_line]),
             )
             print(
                 "No issue number in commit message / linked PR; "
@@ -589,7 +608,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"- visual_decision: `{visual['decision']}`\n"
                 f"- visual_summary: {visual['summary']}\n"
             )
-            post_issue_comment(args.repo, issue_num, body)
+            notify_deploy(args.repo, issue_num, record_pr["number"], body)
         else:
             visual = visual_ai_check(
                 issue_title=issue.get("title") or "",
@@ -627,7 +646,7 @@ def main(argv: list[str] | None = None) -> int:
                     pre_lines.append(f"- **{name}**")
                     pre_lines.append(f"  ![]({u})")
                 body += "\n".join(pre_lines) + "\n"
-            post_issue_comment(args.repo, issue_num, body)
+            notify_deploy(args.repo, issue_num, record_pr["number"], body)
 
         try:
             from acceptance import (
@@ -649,10 +668,6 @@ def main(argv: list[str] | None = None) -> int:
                 f"### acceptance_checklist\n- role: `post-deploy`\n"
                 f"- all_done: `false`\n- note: refresh failed (`{acc_exc}`)\n",
             )
-
-        record_pr = open_or_reuse_record_pr(
-            args.repo, record_branch, default, short=short, base_url=base_url
-        )
 
         if visual.get("decision") == "fail":
             post_issue_comment(

--- a/tests/test_post_deploy_visual.py
+++ b/tests/test_post_deploy_visual.py
@@ -10,6 +10,7 @@ from github_api import GitHubError
 
 from post_deploy_visual import (
     _parse_visual_json,
+    notify_deploy,
     open_or_reuse_record_pr,
     record_branch_name,
     record_pr_body,
@@ -188,3 +189,20 @@ def test_open_or_reuse_record_pr_reuses_existing_open_pr() -> None:
     assert result == {"number": 12, "url": "https://x/12"}
     open_pr.assert_not_called()
     auto_merge.assert_not_called()
+
+
+def test_notify_deploy_always_comments_record_pr() -> None:
+    """The record PR's CODEOWNER reviewer must see screenshots inline, even
+    when no issue is linked (no `Closes #N` / `(#N)` in the commit/PR)."""
+    with patch("post_deploy_visual.post_issue_comment") as comment:
+        notify_deploy("o/r", None, 42, "### deploy_record\nbody")
+    comment.assert_called_once_with("o/r", 42, "### deploy_record\nbody")
+
+
+def test_notify_deploy_also_comments_linked_issue() -> None:
+    with patch("post_deploy_visual.post_issue_comment") as comment:
+        notify_deploy("o/r", 99, 42, "### deploy_visual_check\nbody")
+    assert comment.call_args_list == [
+        (("o/r", 42, "### deploy_visual_check\nbody"), {}),
+        (("o/r", 99, "### deploy_visual_check\nbody"), {}),
+    ]


### PR DESCRIPTION
Follow-up to #366/#367 — spotted in [PR #368](https://github.com/saberistic-team/agent-web/pull/368): the `deploy/screenshots-<sha>` record PR opened by `post_deploy_visual.py` never got the screenshot evidence itself. The `### deploy_visual_check` (or `### deploy_record` when no issue is linked) comment only went to the linked issue — a CODEOWNER reviewing the record PR had nothing but a generic PR body and a raw PNG diff to look at before approving auto-merge.

### Change
- `scripts/post_deploy_visual.py`: new `notify_deploy(repo, issue_num, record_pr_number, body)` posts the same comment body to the record PR and, when present, to the linked issue. `main()` now opens/reuses the record PR once up front, and both existing comment call sites (the "no public pages affected" skip path and the normal visual-check path) route through `notify_deploy()` instead of commenting on the issue only.
- `tests/test_post_deploy_visual.py`: unit tests for `notify_deploy()` — PR-only (no issue) and PR+issue cases.
- `docs/SCREENSHOTS.md`: documents that the record PR gets the same comment as the linked issue.

### Verified
- `pytest -q -m "not contract"` (python3.12 venv) — 1793 passed, 0 failed, 75 skipped.
- `scripts/validate_workflow_governance.py` — PASS.

Made with [Cursor](https://cursor.com)