### PR TITLE
fix: stop AI-gating post-deploy visual verification, leave it to admin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         with:
           app-id: ${{ secrets.BUILDER_APP_ID }}
           private-key: ${{ secrets.BUILDER_PRIVATE_KEY }}
-      - name: Capture post screenshots + visual check
+      - name: Capture post-deploy screenshots + record health
         env:
           GITHUB_TOKEN: ${{ steps.builder.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -192,7 +192,6 @@ jobs:
           CURSOR_MODEL: ${{ vars.CURSOR_MODEL }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
-          VISUAL_PROVIDER: ${{ vars.VISUAL_PROVIDER }}
           DEPLOY_BASE_URL: ${{ vars.DEPLOY_BASE_URL }}
           # Passed via env, not interpolated straight into the run: string —
           # a commit message containing a `"` (e.g. quoting a 422 error

--- a/docs/IDENTITIES.md
+++ b/docs/IDENTITIES.md
@@ -50,9 +50,9 @@ Unrelated org install (not part of the agent loop): `digitalocean` (installation
 
 Builder also uses:
 
-- Secret `CURSOR_API_KEY` for Builder coding + Reviewer + post-deploy visual
-  ([MODELS.md](MODELS.md))
-- Optional `OPENAI_API_KEY` backup for review / acceptance / visual / codegen
+- Secret `CURSOR_API_KEY` for Builder coding + Reviewer + post-deploy
+  acceptance checks ([MODELS.md](MODELS.md))
+- Optional `OPENAI_API_KEY` backup for review / acceptance / codegen
 - Optional `MODELS_TOKEN` for GitHub Models backup
 - Builder App must keep `contents: write` so `git/refs` branch creation works
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,8 +1,10 @@
-# Builder / Reviewer / visual model providers
+# Builder / Reviewer model providers
 
-**Builder codegen**, **Reviewer AI** (PR review + acceptance), and
-**post-deploy visual** prefer the **Cursor Agent SDK** when `CURSOR_API_KEY`
-is set. OpenAI and GitHub Models are backups (OpenAI quota is often exhausted).
+**Builder codegen** and **Reviewer AI** (PR review + acceptance) prefer the
+**Cursor Agent SDK** when `CURSOR_API_KEY` is set. OpenAI and GitHub Models
+are backups (OpenAI quota is often exhausted). Post-deploy screenshots are
+captured as evidence only — verification is a manual admin step, not an
+AI-gated check (see [SCREENSHOTS.md](SCREENSHOTS.md)).
 Every Cursor SDK call defaults to Claude **Sonnet with Max Mode enabled**
 (`scripts/cursor_model.py`) — override with `CURSOR_MODEL` / `CURSOR_MAX_MODE`.
 
@@ -77,23 +79,17 @@ commit per file, which storms CI and races merges).
 
 1. Issue gets `agent:reviewer`
 2. `scripts/review_models.py` → Cursor (`mode=plan`, read-only) → OpenAI → Models
-3. Acceptance AI uses the same `chat()` stack
+3. Acceptance AI uses the same `chat()` stack (including the post-deploy
+   acceptance-checklist refresh in `scripts/post_deploy_visual.py`)
 4. Force with `REVIEW_PROVIDER=cursor|openai|github-models`
-
-## Post-deploy visual flow
-
-1. CI `post-deploy-visual` after Render deploy
-2. `scripts/post_deploy_visual.py` → Cursor (`mode=plan`, read local PNGs) →
-   OpenAI vision backup
-3. Force with `VISUAL_PROVIDER=cursor|openai`
 
 ## Auth
 
 | Token | Purpose |
 |-------|---------|
 | Builder / Reviewer App tokens | Comments, labels, commits, PRs, reviews |
-| `CURSOR_API_KEY` | **Preferred** Cursor SDK for Builder + Reviewer + visual |
-| `OPENAI_API_KEY` | Optional backup for review / acceptance / visual |
+| `CURSOR_API_KEY` | **Preferred** Cursor SDK for Builder + Reviewer + acceptance |
+| `OPENAI_API_KEY` | Optional backup for review / acceptance |
 | `MODELS_TOKEN` (optional) | GitHub Models last-resort backup |
 
 ## Variables
@@ -102,19 +98,17 @@ commit per file, which storms CI and races merges).
 |----------|---------|
 | `CODEGEN_PROVIDER` | unset → Cursor if key present, else OpenAI, else Models |
 | `REVIEW_PROVIDER` | unset → Cursor if key present, else OpenAI, else Models |
-| `VISUAL_PROVIDER` | unset → Cursor if key present, else OpenAI |
 | `CURSOR_MODEL` | `sonnet-4.5` |
 | `CURSOR_MAX_MODE` | `true` (Max Mode on for every Cursor SDK call; set `false` to disable) |
 | `CURSOR_RUNTIME` | `local` in Actions (Builder); set `cloud` only when needed |
-| `OPENAI_MODEL` | Path-specific defaults when unset: codegen / post-deploy visual → `gpt-4.1-mini`; Reviewer / acceptance / conflict helpers → `gpt-4o-mini` |
+| `OPENAI_MODEL` | Path-specific defaults when unset: codegen → `gpt-4.1-mini`; Reviewer / acceptance / conflict helpers → `gpt-4o-mini` |
 | `GITHUB_MODELS_MODEL` | `openai/gpt-4o-mini` |
 
 ## Cursor setup
 
 1. Create a Cursor API key (user or team service account)
 2. Repo secret: `CURSOR_API_KEY`
-3. Repo variables: `CODEGEN_PROVIDER=cursor`, optionally `REVIEW_PROVIDER=cursor`,
-   `VISUAL_PROVIDER=cursor`
+3. Repo variables: `CODEGEN_PROVIDER=cursor`, optionally `REVIEW_PROVIDER=cursor`
 4. Optional: `CURSOR_MODEL=sonnet-4.5` (defaults to Sonnet with Max Mode on;
    `CURSOR_MAX_MODE=false` disables Max Mode), `CURSOR_RUNTIME=local`
 5. For Builder **cloud** only: connect GitHub so Cursor can clone/open PRs

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -166,8 +166,20 @@ until merged.
 
 1. Polls `/health` as JSON; records under `.agent/deploy/<sha>/`
 2. Captures `post-*.png` of **public** PR-affected routes on **saberistic.com**
-3. Comments `### deploy_visual_check` on the linked issue
-4. Compares against pre-merge **branch** shots when available (not production `pre-*`)
+3. Comments `### deploy_visual_check` on the linked issue, including any
+   pre-merge **branch** shots available for side-by-side comparison
+4. **No automated pass/fail** — verification is a manual admin step (see
+   "Post-deploy visual verification" below). Screenshots and health are
+   evidence only.
+
+### Post-deploy visual verification
+
+`scripts/post_deploy_visual.py` used to ask Cursor/OpenAI to compare
+before/after screenshots and gate the CI job on a `pass`/`fail` decision.
+That was removed: many post-deploy changes are backend/security-only with no
+visible public-page diff, which produced routine false-negative failures
+(the AI correctly reporting "nothing to see" and failing the job over it).
+An admin now reviews the posted screenshots directly instead.
 
 Health JSON and screenshot uploads land on a deterministic
 `deploy/screenshots-<sha>` branch and a PR against `main` with auto-merge
@@ -205,7 +217,7 @@ merges.
 | `DEPLOY_BASE_URL` | variable | default `https://saberistic.com` (post-deploy) |
 | `COVERAGE_ROOT` / `PR_HEAD_ROOT` | env | PR checkout root for branch screenshots |
 | `SCREENSHOTS_REQUIRED` | variable | default true for Reviewer when pages are affected |
-| `CURSOR_API_KEY` | secret | Preferred visual / review |
+| `CURSOR_API_KEY` | secret | Preferred model for Reviewer / acceptance checks |
 | `RENDER_DEPLOY_HOOK_URL` | secret | deploy trigger |
 | `RENDER_API_KEY` | secret | poll deploy status until live/failed |
 | `RENDER_SERVICE_ID` | secret | optional `srv-…` if not parseable from the hook URL |
@@ -213,6 +225,6 @@ merges.
 ## Scripts / workflows
 
 - `scripts/screenshot_deploy.py` — discovery, PR filter, preview capture, upload
-- `scripts/post_deploy_visual.py` — production capture + visual check
+- `scripts/post_deploy_visual.py` — production capture + health recording (manual visual review, no automated gate)
 - `.github/workflows/reviewer.yml` — pre-merge Playwright
 - `.github/workflows/ci.yml` — `post-deploy-visual` job

--- a/scripts/post_deploy_visual.py
+++ b/scripts/post_deploy_visual.py
@@ -1,23 +1,22 @@
 #!/usr/bin/env python3
-"""After deploy: capture post screenshots and ask Cursor (preferred) / OpenAI
-whether the issue change is visible.
+"""After deploy: capture post-deploy screenshots and record deploy health.
+
+Screenshots and health are posted as evidence for a human to review — this
+script no longer runs an automated visual pass/fail check (see #372-class
+conflicts and false negatives on non-visual changes; verification is now a
+manual admin step).
 """
 
 from __future__ import annotations
 
 import argparse
-import base64
 import json
 import os
 import re
 import sys
-import urllib.error
-import urllib.parse
-import urllib.request
 from pathlib import Path
 from typing import Any
 
-from cursor_model import DEFAULT_CURSOR_MODEL, cursor_model_dict, cursor_model_selection
 from github_api import (
     GitHubError,
     api,
@@ -38,8 +37,6 @@ from screenshot_deploy import (
     wait_healthy,
     comment_markdown,
 )
-
-DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
 
 RECORD_COMMIT_PREFIX = "deploy: record post-deploy artifacts"
 
@@ -153,16 +150,6 @@ def record_health(
     return {"path": f"{prefix}/deploy-health.json", "url": raw_url, "json": json.dumps(slim)}
 
 
-def cursor_api_key() -> str | None:
-    value = os.environ.get("CURSOR_API_KEY")
-    return value.strip() if value and value.strip() else None
-
-
-def openai_key() -> str | None:
-    value = os.environ.get("OPENAI_API_KEY")
-    return value.strip() if value and value.strip() else None
-
-
 def find_issue_number(message: str) -> int | None:
     # Prefer explicit closes / (#N) from PR merges
     for pattern in (
@@ -219,247 +206,6 @@ def list_branch_pre_urls(repo: str, ref: str, pr: int | None) -> list[str]:
                 f"https://raw.githubusercontent.com/{owner}/{name}/{ref}/{path}"
             )
     return urls
-
-
-def _parse_visual_json(text: str, *, model: str, provider: str) -> dict:
-    text = (text or "").strip()
-    fence = re.search(r"```(?:json)?\s*([\s\S]*?)```", text)
-    if fence:
-        text = fence.group(1).strip()
-    try:
-        data = json.loads(text)
-    except json.JSONDecodeError:
-        start, end = text.find("{"), text.rfind("}")
-        if start < 0 or end <= start:
-            raise GitHubError(f"{provider} visual did not return JSON: {text[:400]!r}")
-        data = json.loads(text[start : end + 1])
-    if not isinstance(data, dict):
-        raise GitHubError(f"{provider} visual JSON root must be object")
-    decision = str(data.get("decision") or "fail").lower()
-    if decision not in {"pass", "fail", "skip"}:
-        decision = "fail"
-    return {
-        "visible": data.get("visible"),
-        "summary": str(data.get("summary") or text[:500]),
-        "decision": decision,
-        "model": model,
-        "provider": provider,
-    }
-
-
-def _visual_prompt(
-    issue_title: str,
-    issue_body: str,
-    pre_paths: list[Path],
-    post_paths: list[Path],
-) -> str:
-    pre_list = "\n".join(f"- {p.resolve()}" for p in pre_paths) or "- (none)"
-    post_list = "\n".join(f"- {p.resolve()}" for p in post_paths) or "- (none)"
-    return (
-        "READ-ONLY VISUAL CHECK. Do not create, edit, delete, or move any files. "
-        "Do not run mutating shell/git commands. Do not open PRs.\n"
-        "Open the screenshot PNG paths below (Read tool) and compare before vs after.\n"
-        "Respond with JSON only (no prose outside JSON):\n"
-        '{"visible": boolean, "summary": "string", "decision": "pass"|"fail"}\n'
-        "pass if the post screenshots clearly show the issue change; "
-        "fail if unchanged or unrelated.\n\n"
-        f"Issue title: {issue_title}\n"
-        f"Issue body:\n{(issue_body or '')[:4000]}\n\n"
-        f"BEFORE screenshot paths:\n{pre_list}\n\n"
-        f"AFTER screenshot paths:\n{post_list}\n"
-    )
-
-
-def visual_ai_check_cursor(
-    *,
-    issue_title: str,
-    issue_body: str,
-    pre_paths: list[Path],
-    post_paths: list[Path],
-) -> dict:
-    key = cursor_api_key()
-    if not key:
-        raise GitHubError("missing CURSOR_API_KEY")
-    model = os.environ.get("CURSOR_MODEL") or DEFAULT_CURSOR_MODEL
-    try:
-        from cursor_sdk import Agent, AgentOptions, LocalAgentOptions
-        from cursor_sdk_patch import patch_callback_auth_tokens
-
-        patch_callback_auth_tokens()
-    except ImportError as exc:
-        raise GitHubError(
-            "cursor-sdk is not installed; pip install -r requirements-agents.txt"
-        ) from exc
-
-    prompt = _visual_prompt(issue_title, issue_body, pre_paths, post_paths)
-    try:
-        result = Agent.prompt(
-            prompt,
-            AgentOptions(
-                model=cursor_model_selection(model),
-                api_key=key,
-                name="post-deploy-visual",
-                mode="plan",
-                local=LocalAgentOptions(cwd=os.getcwd()),
-            ),
-        )
-    except TypeError:
-        try:
-            result = Agent.prompt(
-                prompt,
-                {
-                    "model": cursor_model_dict(model),
-                    "apiKey": key,
-                    "name": "post-deploy-visual",
-                    "mode": "plan",
-                    "local": {"cwd": os.getcwd()},
-                },
-            )
-        except Exception as exc:
-            raise GitHubError(f"Cursor visual failed: {exc}") from exc
-    except Exception as exc:
-        raise GitHubError(f"Cursor visual failed: {exc}") from exc
-
-    status = getattr(result, "status", None)
-    text = (getattr(result, "result", None) or "").strip()
-    if status != "finished":
-        raise GitHubError(
-            f"Cursor visual run status={status!r} "
-            f"agent_id={getattr(result, 'agent_id', '')} "
-            f"result={text[:400]!r}"
-        )
-    if not text:
-        raise GitHubError("Cursor visual returned empty content")
-    return _parse_visual_json(text, model=model, provider="cursor")
-
-
-def visual_ai_check_openai(
-    *,
-    issue_title: str,
-    issue_body: str,
-    pre_paths: list[Path],
-    post_paths: list[Path],
-) -> dict:
-    """OpenAI vision backup when Cursor is unavailable."""
-    key = openai_key()
-    if not key:
-        raise GitHubError("missing OPENAI_API_KEY")
-    model = os.environ.get("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
-    content: list[dict] = [
-        {
-            "type": "text",
-            "text": (
-                "You compare before/after screenshots of a deployed website.\n"
-                "Return ONLY JSON: "
-                '{"visible": boolean, "summary": "string", "decision": "pass"|"fail"}.\n'
-                "pass if the post screenshots clearly show the issue change; "
-                "fail if unchanged or unrelated.\n\n"
-                f"Issue title: {issue_title}\n"
-                f"Issue body:\n{(issue_body or '')[:4000]}\n"
-            ),
-        }
-    ]
-    for label, paths in (("BEFORE", pre_paths), ("AFTER", post_paths)):
-        content.append({"type": "text", "text": f"\n{label} screenshots follow."})
-        for p in paths:
-            b64 = base64.b64encode(p.read_bytes()).decode("ascii")
-            content.append(
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{b64}"},
-                }
-            )
-    payload = {
-        "model": model,
-        "temperature": 0.1,
-        "response_format": {"type": "json_object"},
-        "messages": [{"role": "user", "content": content}],
-    }
-    req = urllib.request.Request(
-        "https://api.openai.com/v1/chat/completions",
-        data=json.dumps(payload).encode("utf-8"),
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {key}",
-            "Content-Type": "application/json",
-            "User-Agent": "agent-web-visual",
-        },
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=180) as resp:
-            body = json.loads(resp.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        raise GitHubError(f"OpenAI visual -> {exc.code}: {detail}") from exc
-    choices = body.get("choices") or []
-    out_text = ""
-    if choices:
-        out_text = str((choices[0].get("message") or {}).get("content") or "").strip()
-    return _parse_visual_json(out_text, model=model, provider="openai")
-
-
-def visual_ai_check(
-    *,
-    issue_title: str,
-    issue_body: str,
-    pre_paths: list[Path],
-    post_paths: list[Path],
-) -> dict:
-    """Compare before/after screenshots: Cursor preferred, OpenAI backup."""
-    force = (os.environ.get("VISUAL_PROVIDER") or "").strip().lower()
-    errors: list[str] = []
-
-    def _try_cursor() -> dict | None:
-        if not cursor_api_key():
-            return None
-        try:
-            return visual_ai_check_cursor(
-                issue_title=issue_title,
-                issue_body=issue_body,
-                pre_paths=pre_paths,
-                post_paths=post_paths,
-            )
-        except Exception as exc:
-            errors.append(f"cursor: {exc}")
-            return None
-
-    def _try_openai() -> dict | None:
-        if not openai_key():
-            return None
-        try:
-            return visual_ai_check_openai(
-                issue_title=issue_title,
-                issue_body=issue_body,
-                pre_paths=pre_paths,
-                post_paths=post_paths,
-            )
-        except Exception as exc:
-            errors.append(f"openai: {exc}")
-            return None
-
-    if force in {"cursor", "cursor-sdk", "composer"}:
-        order = ["cursor", "openai"]
-    elif force in {"openai", "chatgpt"}:
-        order = ["openai", "cursor"]
-    else:
-        order = ["cursor", "openai"]
-
-    for name in order:
-        got = _try_cursor() if name == "cursor" else _try_openai()
-        if got is not None:
-            return got
-
-    if not cursor_api_key() and not openai_key():
-        return {
-            "visible": None,
-            "summary": "CURSOR_API_KEY and OPENAI_API_KEY missing; skipped visual AI check",
-            "decision": "skip",
-            "model": "",
-            "provider": "none",
-        }
-    raise GitHubError(
-        "visual AI check failed: " + " | ".join(errors or ["no providers"])
-    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -570,8 +316,6 @@ def main(argv: list[str] | None = None) -> int:
             print(f"record_pr={record_pr['url']}")
             return 0
 
-        issue = api("GET", f"/repos/{owner}/{name}/issues/{issue_num}")
-
         # Before shots are PR-branch previews (no saberistic.com pre-merge).
         pre_files = sorted(
             p
@@ -590,13 +334,6 @@ def main(argv: list[str] | None = None) -> int:
             )
 
         if not post_files and changed is not None:
-            visual = {
-                "visible": None,
-                "summary": "No public pages affected by merge; visual check skipped",
-                "decision": "skip",
-                "model": "",
-                "provider": "none",
-            }
             body = (
                 "### deploy_visual_check\n"
                 f"- deploy: `{base_url}`\n"
@@ -605,27 +342,17 @@ def main(argv: list[str] | None = None) -> int:
                 f"{health_line}\n"
                 "- routes (public, PR-affected): (none)\n"
                 "- note: no public pages affected; screenshots skipped\n"
-                f"- visual_decision: `{visual['decision']}`\n"
-                f"- visual_summary: {visual['summary']}\n"
             )
             notify_deploy(args.repo, issue_num, record_pr["number"], body)
         else:
-            visual = visual_ai_check(
-                issue_title=issue.get("title") or "",
-                issue_body=issue.get("body") or "",
-                pre_paths=pre_files,
-                post_paths=post_files,
-            )
-
+            # No automated pass/fail here — an admin reviews the linked
+            # screenshots manually (see #372-class evidence-PR conflicts and
+            # false negatives on non-visual/backend-only changes).
             extra = [
                 "- phase: `post-deploy`",
                 f"- issue: #{issue_num}",
                 health_line,
-                f"- visual_provider: `{visual.get('provider')}`",
-                f"- visual_decision: `{visual.get('decision')}`",
-                f"- visual_visible: `{visual.get('visible')}`",
-                f"- visual_model: `{visual.get('model')}`",
-                f"- visual_summary: {visual.get('summary')}",
+                "- note: visual verification is manual — review the screenshots below.",
             ]
             if routes and changed is not None:
                 extra.insert(
@@ -669,20 +396,10 @@ def main(argv: list[str] | None = None) -> int:
                 f"- all_done: `false`\n- note: refresh failed (`{acc_exc}`)\n",
             )
 
-        if visual.get("decision") == "fail":
-            post_issue_comment(
-                args.repo,
-                issue_num,
-                "@human-review Post-deploy visual check failed — change may not be visible on production.\n",
-            )
-            print(f"record_pr={record_pr['url']}", file=sys.stderr)
-            print("visual check failed", file=sys.stderr)
-            return 1
         print(
             json.dumps(
                 {
                     "issue": issue_num,
-                    "visual": visual,
                     "post": post_urls,
                     "record_pr": record_pr["url"],
                 }

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -963,7 +963,7 @@ def role_builder(repo: str, issue: int, brief: Path) -> None:
                     "body": (
                         f"Closes #{issue}\n\n"
                         "Screenshot infra: pre-merge Reviewer captures + post-deploy "
-                        "visual check (see docs/SCREENSHOTS.md).\n"
+                        "evidence capture (see docs/SCREENSHOTS.md).\n"
                     ),
                 },
             )

--- a/tests/test_post_deploy_visual.py
+++ b/tests/test_post_deploy_visual.py
@@ -1,129 +1,19 @@
-"""Unit tests for post-deploy visual provider selection (no live API)."""
+"""Unit tests for post-deploy evidence recording (no live API).
+
+Post-deploy visual verification is a manual admin step, not an automated
+pass/fail gate — see ``post_deploy_visual.py``'s module docstring.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-from github_api import GitHubError
-
 from post_deploy_visual import (
-    _parse_visual_json,
     notify_deploy,
     open_or_reuse_record_pr,
     record_branch_name,
     record_pr_body,
-    visual_ai_check,
 )
-
-
-def test_parse_visual_json_fenced() -> None:
-    raw = '```json\n{"visible": true, "summary": "ok", "decision": "pass"}\n```'
-    data = _parse_visual_json(raw, model="m", provider="cursor")
-    assert data["decision"] == "pass"
-    assert data["visible"] is True
-    assert data["provider"] == "cursor"
-
-
-def test_visual_ai_check_skips_without_keys(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("VISUAL_PROVIDER", raising=False)
-    result = visual_ai_check(
-        issue_title="t",
-        issue_body="b",
-        pre_paths=[],
-        post_paths=[],
-    )
-    assert result["decision"] == "skip"
-    assert result["provider"] == "none"
-
-
-def test_visual_ai_check_prefers_cursor(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("CURSOR_API_KEY", "ck_test")
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("VISUAL_PROVIDER", raising=False)
-    post = tmp_path / "post-home.png"
-    post.write_bytes(b"png")
-    with patch(
-        "post_deploy_visual.visual_ai_check_cursor",
-        return_value={
-            "visible": True,
-            "summary": "seen",
-            "decision": "pass",
-            "model": "composer-2.5",
-            "provider": "cursor",
-        },
-    ) as cursor:
-        with patch("post_deploy_visual.visual_ai_check_openai") as openai:
-            result = visual_ai_check(
-                issue_title="Email-only form",
-                issue_body="Remove phone",
-                pre_paths=[],
-                post_paths=[post],
-            )
-    assert result["provider"] == "cursor"
-    assert result["decision"] == "pass"
-    cursor.assert_called_once()
-    openai.assert_not_called()
-
-
-def test_visual_ai_check_falls_back_to_openai(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    monkeypatch.setenv("CURSOR_API_KEY", "ck_test")
-    monkeypatch.setenv("OPENAI_API_KEY", "sk_test")
-    monkeypatch.delenv("VISUAL_PROVIDER", raising=False)
-    post = tmp_path / "post-home.png"
-    post.write_bytes(b"png")
-    with patch(
-        "post_deploy_visual.visual_ai_check_cursor",
-        side_effect=GitHubError("cursor down"),
-    ):
-        with patch(
-            "post_deploy_visual.visual_ai_check_openai",
-            return_value={
-                "visible": True,
-                "summary": "backup",
-                "decision": "pass",
-                "model": "gpt-4o-mini",
-                "provider": "openai",
-            },
-        ) as openai:
-            result = visual_ai_check(
-                issue_title="t",
-                issue_body="b",
-                pre_paths=[],
-                post_paths=[post],
-            )
-    assert result["provider"] == "openai"
-    openai.assert_called_once()
-
-
-def test_visual_ai_check_force_openai(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("CURSOR_API_KEY", "ck_test")
-    monkeypatch.setenv("OPENAI_API_KEY", "sk_test")
-    monkeypatch.setenv("VISUAL_PROVIDER", "openai")
-    with patch("post_deploy_visual.visual_ai_check_cursor") as cursor:
-        with patch(
-            "post_deploy_visual.visual_ai_check_openai",
-            return_value={
-                "visible": False,
-                "summary": "forced",
-                "decision": "fail",
-                "model": "gpt",
-                "provider": "openai",
-            },
-        ):
-            result = visual_ai_check(
-                issue_title="t",
-                issue_body="b",
-                pre_paths=[],
-                post_paths=[],
-            )
-    assert result["provider"] == "openai"
-    cursor.assert_not_called()
 
 
 def test_record_branch_name_is_deterministic() -> None:


### PR DESCRIPTION
### Summary

The `post-deploy-visual` CI job asked Cursor/OpenAI to compare pre/post-deploy screenshots and failed the job on a `fail` decision. Most post-deploy changes are backend/security-only with no visible public-page diff, so this routinely produced a correct-but-unhelpful "nothing to see" verdict that failed the job and posted an `@human-review` escalation anyway — the AI check added noise without adding signal.

Example: [issue #331](https://github.com/saberistic-team/agent-web/issues/331)'s post-deploy job failed because the AI (correctly) reported the admin-preview-mode/security-middleware change had no visible public-page evidence to judge.

### Changes

- Remove `visual_ai_check` / `visual_ai_check_cursor` / `visual_ai_check_openai` and the JSON-parsing/prompt helpers from `scripts/post_deploy_visual.py`.
- Stop failing the job / posting `@human-review` based on a visual decision. Screenshots (post-deploy + any pre-merge branch shots) are still captured and posted to the issue + record PR — an admin now reviews them manually instead of an AI gate.
- Drop the now-unused `VISUAL_PROVIDER` env var from the CI job. `CURSOR_API_KEY`/`CURSOR_MODEL`/`OPENAI_API_KEY`/`OPENAI_MODEL` stay — the acceptance-checklist refresh in the same job still uses them.
- Update `docs/SCREENSHOTS.md`, `docs/MODELS.md`, `docs/IDENTITIES.md` accordingly.

### Testing

- `pytest -q -m "not integration and not contract"` — 1295 passed
- `python scripts/check_coverage.py` — passed
- Validated `.github/workflows/ci.yml` YAML

### Note

This is PR 1 of 2 — [the follow-up PR](fix/skip-post-deploy-screenshot-capture) removes post-deploy screenshot capture entirely (the actual conflict-prone piece, e.g. #372) and is stacked on top of this one.

Made with [Cursor](https://cursor.com)