### PR TITLE
fix: stop capturing post-deploy production screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
             --branch main
 
   post-deploy-visual:
-    name: Post-deploy screenshots
+    name: Post-deploy health record
     needs: deploy
     if: >-
       github.event_name == 'push' &&
@@ -173,18 +173,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install Playwright + agent deps
-        run: |
-          pip install playwright==1.49.1
-          python -m playwright install --with-deps chromium
-          pip install -r requirements-agents.txt
+      - name: Install agent deps
+        run: pip install -r requirements-agents.txt
       - name: Mint Builder token for uploads/comments
         id: builder
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.BUILDER_APP_ID }}
           private-key: ${{ secrets.BUILDER_PRIVATE_KEY }}
-      - name: Capture post-deploy screenshots + record health
+      - name: Record post-deploy health
         env:
           GITHUB_TOKEN: ${{ steps.builder.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -197,12 +194,12 @@ jobs:
           # a commit message containing a `"` (e.g. quoting a 422 error
           # message) previously closed the --commit-message string early and
           # spilled the rest of the message into unrecognized argv, failing
-          # this job before it ever captured a screenshot.
+          # this job before it ever recorded health.
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
           # Deploy job already waited for Render to go live; short pause then
-          # re-check health before screenshots.
+          # re-check health.
           sleep 5
           python scripts/post_deploy_visual.py \
             --repo "${{ github.repository }}" \

--- a/AGENTS/reviewer.md
+++ b/AGENTS/reviewer.md
@@ -28,7 +28,8 @@ Before approving you must:
    open-mobile-nav evidence routes when the PR-head script defines them) for
    **PR-affected pages on the PR head only** (local uvicorn with
    `ADMIN_PREVIEW_MODE` so admin pages can be captured without login). Do **not**
-   screenshot saberistic.com pre-merge — production shots are post-deploy:
+   screenshot saberistic.com — production is never screenshotted (pre-merge or
+   post-deploy; post-deploy only records `/health` JSON):
    - **PR branch** — `branch-*.png` (public + all admin nav pages when affected)
    Post on the PR and issue — not Copilot / MCP browsers. Skip capture when
    the PR touches no visual pages (tests/docs only). Upload all PNGs in

--- a/docs/HELLO_API.md
+++ b/docs/HELLO_API.md
@@ -62,7 +62,7 @@ On every push/merge to `main`, [`.github/workflows/ci.yml`](../.github/workflows
    the Render deploy `update_failed` and fails this CI job. After live, CI also
    requires `/health` `schema_version` to match the latest migration in the tree.
 4. `Freeze shipped migrations` and `post-deploy-visual` run after a successful
-   deploy (screenshots + digest freeze)
+   deploy (health record + digest freeze; no screenshots)
 
 CI skips push jobs whose commit message starts with `review: record` or
 `deploy: record` / `deploy: freeze` (screenshot/health/migration-freeze recorder commits).

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -2,9 +2,10 @@
 
 **Builder codegen** and **Reviewer AI** (PR review + acceptance) prefer the
 **Cursor Agent SDK** when `CURSOR_API_KEY` is set. OpenAI and GitHub Models
-are backups (OpenAI quota is often exhausted). Post-deploy screenshots are
-captured as evidence only — verification is a manual admin step, not an
-AI-gated check (see [SCREENSHOTS.md](SCREENSHOTS.md)).
+are backups (OpenAI quota is often exhausted). There is no post-deploy
+screenshot capture or AI-gated visual check — post-deploy only records
+`/health` JSON; production verification is a manual admin step (see
+[SCREENSHOTS.md](SCREENSHOTS.md)).
 Every Cursor SDK call defaults to Claude **Sonnet with Max Mode enabled**
 (`scripts/cursor_model.py`) — override with `CURSOR_MODEL` / `CURSOR_MAX_MODE`.
 

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -1,18 +1,21 @@
-# Deploy screenshots (pre-merge + post-deploy)
+# Deploy screenshots (pre-merge only)
 
 Visual evidence for the agent loop. **Only** GitHub Actions + headless
 Chromium via Playwright (`scripts/screenshot_deploy.py`). Do **not** use
 Copilot, Playwright MCP, or any IDE browser agent for gate evidence.
+
+Screenshot capture is **pre-merge only** (Reviewer, on the PR head). There is
+no post-deploy production screenshot capture — post-deploy only records
+`/health` JSON evidence; see "Post-deploy" below.
 
 ## Which routes are captured
 
 | Phase | Host | Routes |
 |-------|------|--------|
 | **Pre-merge (Reviewer)** | PR-head local uvicorn | PR-affected **public** pages **and** all admin nav pages + `/admin/login` when admin files change |
-| **Post-deploy** | [saberistic.com](https://saberistic.com) | PR-affected **public** pages only — **never** `/admin/*` |
 
-Pre-merge does **not** screenshot saberistic.com. Production shots are
-post-deploy only.
+Pre-merge does **not** screenshot saberistic.com — and production is never
+screenshotted at all (see "Post-deploy" below).
 
 ### `ADMIN_PREVIEW_MODE`
 
@@ -111,21 +114,21 @@ when the configured route does not match the expected status.
 |------------|----------|----------|
 | **Admin (pre-merge)** | `/admin`, `/admin/companies`, …, `/admin/login` | Captured on PR head under `ADMIN_PREVIEW_MODE` when affected |
 | **Admin error fixtures (pre-merge)** | `/admin/briefs/503` (HTTP 503) | Declared expected status; must render HTML under preview auth |
-| **Admin (post-deploy)** | `/admin/*` | **Never** screenshotted on saberistic.com |
-| **Health** | `/health` | Polled as **JSON evidence only** (never a PNG) |
+| **Anything on saberistic.com** | Any route | **Never** screenshotted — production has no screenshot capture |
+| **Health** | `/health` | Polled post-deploy as **JSON evidence only** (never a PNG) |
 | **JSON APIs** | `/hello`, `/api/*`, `/webhooks/*` | Skipped |
 | **Meta / static** | `/robots.txt`, `/sitemap.xml`, `/assets/*`, OpenAPI docs | Skipped |
 | **Legacy redirects** | `/what-we-do.html`, … | Skipped |
 | **Unaffected pages** | Routes not implied by the PR diff | Skipped |
 
-### How “affected” is decided
+### How “affected” is decided (pre-merge)
 
-| Changed paths | Pre-merge routes | Post-deploy routes |
-|---------------|------------------|--------------------|
-| `site/about.html`, … | That public page | Same |
-| `site/assets/*`, shared layout | All public (+ all admin pre-merge) | All public |
-| `app/admin_*` | All admin nav pages + `/admin/login` | None (skip) |
-| `tests/` / `docs/` / `scripts/` only | None | None |
+| Changed paths | Pre-merge routes |
+|---------------|------------------|
+| `site/about.html`, … | That public page |
+| `site/assets/*`, shared layout | All public (+ all admin pre-merge) |
+| `app/admin_*` | All admin nav pages + `/admin/login` |
+| `tests/` / `docs/` / `scripts/` only | None |
 
 ## Which script Reviewer runs
 
@@ -164,47 +167,42 @@ until merged.
 
 ## Post-deploy (after merge to `main`)
 
-1. Polls `/health` as JSON; records under `.agent/deploy/<sha>/`
-2. Captures `post-*.png` of **public** PR-affected routes on **saberistic.com**
-3. Comments `### deploy_visual_check` on the linked issue, including any
-   pre-merge **branch** shots available for side-by-side comparison
-4. **No automated pass/fail** — verification is a manual admin step (see
-   "Post-deploy visual verification" below). Screenshots and health are
-   evidence only.
+**No screenshots.** Post-deploy only polls `/health` as JSON and records it
+under `.agent/deploy/<sha>/`, then comments `### deploy_record` on the linked
+issue. Production screenshot capture and the AI visual pass/fail decision
+that used to run here have both been removed:
 
-### Post-deploy visual verification
+- The AI decision routinely false-negatived on backend/security-only changes
+  with no visible public-page diff, failing the CI job and posting an
+  `@human-review` escalation over nothing.
+- Retries/reruns of the same deploy sha recaptured non-deterministic
+  screenshots at the same evidence-branch paths, producing unresolvable
+  binary "added in both" conflicts on the auto-merge record PR (e.g. #372).
 
-`scripts/post_deploy_visual.py` used to ask Cursor/OpenAI to compare
-before/after screenshots and gate the CI job on a `pass`/`fail` decision.
-That was removed: many post-deploy changes are backend/security-only with no
-visible public-page diff, which produced routine false-negative failures
-(the AI correctly reporting "nothing to see" and failing the job over it).
-An admin now reviews the posted screenshots directly instead.
+Visual evidence is now **pre-merge only** (Reviewer's `branch-*.png`, above);
+verifying a specific change is actually live on production is a manual admin
+step (e.g. opening the page yourself).
 
-Health JSON and screenshot uploads land on a deterministic
-`deploy/screenshots-<sha>` branch and a PR against `main` with auto-merge
-enabled — **not** a direct push. The workflow-governance ruleset
-(`docs/WORKFLOW_GOVERNANCE.md`) rejects bot pushes straight to a protected
-branch, the same reason `freeze_shipped_migrations.py` opens a
-`deploy/freeze-*` PR instead of pushing (issue #362/#366). One human
-CODEOWNER approval merges it; reruns for the same deploy sha reuse the
-existing open PR (`find_open_pr_for_branch`) instead of opening a duplicate.
+Health JSON lands on a deterministic `deploy/health-<sha>` branch and a PR
+against `main` with auto-merge enabled — **not** a direct push. The
+workflow-governance ruleset (`docs/WORKFLOW_GOVERNANCE.md`) rejects bot
+pushes straight to a protected branch, the same reason
+`freeze_shipped_migrations.py` opens a `deploy/freeze-*` PR instead of
+pushing (issue #362/#366). One human CODEOWNER approval merges it; reruns for
+the same deploy sha reuse the existing open PR (`find_open_pr_for_branch`)
+instead of opening a duplicate.
 
-The same `### deploy_visual_check` (or `### deploy_record` when no issue is
-linked) comment — screenshots and all — is posted on **both** the linked
-issue and the `deploy/screenshots-<sha>` record PR itself
+The same `### deploy_record` comment is posted on **both** the linked issue
+and the `deploy/health-<sha>` record PR itself
 (`post_deploy_visual.notify_deploy`), so the CODEOWNER reviewing that PR sees
-the before/after evidence inline before approving auto-merge, instead of
-having to open the linked issue or inspect the raw PNG diff. The screenshot
-links point at the raw content on that branch, so they render before the PR
-merges.
+the health record inline, not just a generic PR body.
 
 ## Source matrix
 
 | Phase | Source | Filenames |
 |-------|--------|-----------|
 | Pre-merge | PR head (local uvicorn + `ADMIN_PREVIEW_MODE`) | `branch-home.png`, `branch-admin.png`, `branch-admin-companies.png`, … |
-| Post-deploy | Production (`saberistic.com`) | `post-*.png` (public only) |
+| Post-deploy | Production (`saberistic.com`) | none — `/health` JSON only |
 
 ## Config
 
@@ -214,7 +212,7 @@ merges.
 | `APP_ENV` | env | `development` on PR preview server (script sets this) |
 | `SERVER_BIND_HOST` | env | `127.0.0.1` on PR preview server (loopback bind; script sets this) |
 | `BASE_URL` | env | `http://127.0.0.1:<port>` on PR preview server (script sets this) |
-| `DEPLOY_BASE_URL` | variable | default `https://saberistic.com` (post-deploy) |
+| `DEPLOY_BASE_URL` | variable | default `https://saberistic.com` (post-deploy health check) |
 | `COVERAGE_ROOT` / `PR_HEAD_ROOT` | env | PR checkout root for branch screenshots |
 | `SCREENSHOTS_REQUIRED` | variable | default true for Reviewer when pages are affected |
 | `CURSOR_API_KEY` | secret | Preferred model for Reviewer / acceptance checks |
@@ -224,7 +222,7 @@ merges.
 
 ## Scripts / workflows
 
-- `scripts/screenshot_deploy.py` — discovery, PR filter, preview capture, upload
-- `scripts/post_deploy_visual.py` — production capture + health recording (manual visual review, no automated gate)
+- `scripts/screenshot_deploy.py` — discovery, PR filter, preview capture, upload (pre-merge only)
+- `scripts/post_deploy_visual.py` — post-deploy `/health` recording only (no screenshots, no automated gate)
 - `.github/workflows/reviewer.yml` — pre-merge Playwright
 - `.github/workflows/ci.yml` — `post-deploy-visual` job

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -472,9 +472,10 @@ def ai_check_remaining(
         "CSS/layout guardrail tests may satisfy sizing criteria when present shots "
         "+ tests agree and AI review approved; do not mark not_done solely because "
         "an older 58-shot run lacked extras that the PR-head screenshot script now "
-        "defines (learned from #167). saberistic.com shots are post-deploy only. "
-        "Do NOT mark criteria not_done solely for missing production `pre-*` "
-        "PNGs or missing `/admin` shots on saberistic.com.\n"
+        "defines (learned from #167). saberistic.com is never screenshotted "
+        "(pre-merge or post-deploy). Do NOT mark criteria not_done solely for "
+        "missing production `pre-*`/`post-*` PNGs or missing `/admin` shots "
+        "on saberistic.com.\n"
         "If evidence is missing, status must be not_done.\n"
     )
     slim = {

--- a/scripts/digest_trace.py
+++ b/scripts/digest_trace.py
@@ -155,7 +155,7 @@ def _issue_work(rows: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
             and ("merge" in action or action == "gate:review-approved")
         ):
             bucket["merged"] = True
-            bucket["screenshotish"] = True  # post-deploy visual follows merge
+            bucket["screenshotish"] = True  # pre-merge screenshots already posted by review
     return by_issue
 
 
@@ -310,9 +310,9 @@ def render_digest(rows: list[dict[str, Any]], *, since: datetime, until: datetim
     lines.extend(["", "### Screenshots & visual evidence", ""])
     lines.append(
         "Pre-merge Reviewer captures **PR branch** only (local uvicorn, "
-        "`ADMIN_PREVIEW_MODE` for `/admin`); post-deploy CI captures "
-        "**saberistic.com** public pages only "
-        "([docs/SCREENSHOTS.md](../docs/SCREENSHOTS.md))."
+        "`ADMIN_PREVIEW_MODE` for `/admin`); this is the only screenshot "
+        "evidence — post-deploy CI records `/health` JSON only, no "
+        "screenshots ([docs/SCREENSHOTS.md](../docs/SCREENSHOTS.md))."
     )
     lines.append("")
     if not screenshot_issues:
@@ -331,7 +331,7 @@ def render_digest(rows: list[dict[str, Any]], *, since: datetime, until: datetim
             ):
                 parts.append("pre-merge screenshots (PR branch)")
             if meta["merged"]:
-                parts.append("post-deploy screenshots (production)")
+                parts.append("post-deploy health record (no screenshots)")
             if not parts:
                 parts.append("review / visual gate activity")
             lines.append(f"| #{issue} | {'; '.join(parts)} |")

--- a/scripts/post_deploy_visual.py
+++ b/scripts/post_deploy_visual.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""After deploy: capture post-deploy screenshots and record deploy health.
+"""After deploy: record deploy health.
 
-Screenshots and health are posted as evidence for a human to review — this
-script no longer runs an automated visual pass/fail check (see #372-class
-conflicts and false negatives on non-visual changes; verification is now a
-manual admin step).
+This used to also capture and upload post-deploy production screenshots
+under ``.agent/screenshots/issue-<n>/post/``, but re-running the same deploy
+sha (retries, manual reruns) recaptured non-deterministic screenshots at the
+same paths, and the record-PR branch is force-reset to the latest ``main``
+each run — combined, that produced unresolvable binary "added in both"
+conflicts on the auto-merge record PR (e.g. #372). Screenshot capture is now
+Reviewer's job pre-merge only (``docs/SCREENSHOTS.md``); post-deploy just
+confirms the app is healthy.
 """
 
 from __future__ import annotations
@@ -27,16 +31,7 @@ from github_api import (
     post_issue_comment,
     split_repo,
 )
-from screenshot_deploy import (
-    PRE_BRANCH_PHASE,
-    capture,
-    fetch_pr_changed_paths,
-    resolve_base_url,
-    resolve_screenshot_routes,
-    upload_to_branch,
-    wait_healthy,
-    comment_markdown,
-)
+from screenshot_deploy import resolve_base_url, upload_to_branch, wait_healthy
 
 RECORD_COMMIT_PREFIX = "deploy: record post-deploy artifacts"
 
@@ -46,7 +41,7 @@ def record_branch_name(sha: str) -> str:
     one branch/PR instead of opening a duplicate (mirrors
     ``freeze_shipped_migrations.freeze_branch_name``)."""
     short = (sha or "local")[:12] or "local"
-    return f"deploy/screenshots-{short}"
+    return f"deploy/health-{short}"
 
 
 def record_pr_body(short: str, base_url: str) -> str:
@@ -55,8 +50,8 @@ def record_pr_body(short: str, base_url: str) -> str:
         f"- deploy: `{base_url}`\n"
         f"- sha: `{short}`\n"
         "- Automated, evidence-only change: records this deploy's `/health` "
-        "snapshot and screenshot uploads under `.agent/`. No application "
-        "code, migration, or test changes.\n"
+        "snapshot under `.agent/`. No application code, migration, or test "
+        "changes.\n"
         "- Opened as a PR (not a direct push) because the workflow-governance "
         "ruleset requires every change to `main` go through review — see "
         "`docs/WORKFLOW_GOVERNANCE.md`. Auto-merge is enabled: approving this "
@@ -99,8 +94,8 @@ def open_or_reuse_record_pr(
 
 def notify_deploy(repo: str, issue_num: int | None, record_pr_number: int, body: str) -> None:
     """Post deploy evidence to the record PR (its CODEOWNER reviewer should
-    see the same before/after screenshots inline, not just a generic PR body
-    or a raw file diff) and, when present, to the linked issue."""
+    see the same health record, not just a generic PR body) and, when
+    present, to the linked issue."""
     post_issue_comment(repo, record_pr_number, body)
     if issue_num:
         post_issue_comment(repo, issue_num, body)
@@ -182,32 +177,6 @@ def find_issue_from_commit(repo: str, sha: str) -> int | None:
     return None
 
 
-def list_branch_pre_urls(repo: str, ref: str, pr: int | None) -> list[str]:
-    """Return PR-branch pre-merge preview shot URLs (``branch-*.png``)."""
-    owner, name = split_repo(repo)
-    if not pr:
-        return []
-    prefix = f".agent/screenshots/pr-{pr}"
-    try:
-        nodes = api("GET", f"/repos/{owner}/{name}/contents/{prefix}?ref={ref}") or []
-    except GitHubError:
-        return []
-    if not isinstance(nodes, list):
-        return []
-    urls = []
-    for node in nodes:
-        path = node.get("path") or ""
-        name_part = path.rsplit("/", 1)[-1]
-        if name_part.startswith(f"{PRE_BRANCH_PHASE}-") and name_part.endswith(".png"):
-            # Prefer desktop public shots for visual compare; skip admin on prod compare.
-            if "-admin" in name_part:
-                continue
-            urls.append(
-                f"https://raw.githubusercontent.com/{owner}/{name}/{ref}/{path}"
-            )
-    return urls
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", required=True)
@@ -245,47 +214,6 @@ def main(argv: list[str] | None = None) -> int:
             health=health,
         )
 
-        out = Path("trace/screenshots-post")
-        changed: list[str] | None = None
-        if args.pr:
-            changed = fetch_pr_changed_paths(args.repo, args.pr)
-        elif args.sha:
-            # Resolve merged PR(s) for this deploy SHA and union their files.
-            try:
-                prs = api("GET", f"/repos/{owner}/{name}/commits/{args.sha}/pulls") or []
-            except GitHubError:
-                prs = []
-            paths: list[str] = []
-            for pr in prs if isinstance(prs, list) else []:
-                num = pr.get("number")
-                if num:
-                    paths.extend(fetch_pr_changed_paths(args.repo, int(num)))
-            changed = paths or None
-        routes = resolve_screenshot_routes(
-            changed_files=changed, include_admin=False
-        )
-        if not routes and changed is not None:
-            post_files: list = []
-            post_urls: list[str] = []
-        else:
-            post_files = capture(
-                base_url,
-                out,
-                phase="post",
-                routes=routes if changed is not None else None,
-                allow_admin=False,
-            ).paths
-            prefix = (
-                f".agent/screenshots/issue-{issue_num}/post"
-                if issue_num
-                else f".agent/screenshots/deploy-{short}/post"
-            )
-            post_urls = (
-                upload_to_branch(args.repo, record_branch, post_files, prefix)
-                if post_files
-                else []
-            )
-
         health_line = (
             f"- health: `{json.dumps(health_slim, separators=(',', ':'))}`"
             + (f" ([recorded]({health_rec['url']}))" if health_rec.get("url") else "")
@@ -295,85 +223,25 @@ def main(argv: list[str] | None = None) -> int:
             args.repo, record_branch, default, short=short, base_url=base_url
         )
 
+        body_lines = [
+            "### deploy_record",
+            f"- deploy: `{base_url}`",
+            f"- sha: `{short}`",
+        ]
+        if issue_num:
+            body_lines.append(f"- issue: #{issue_num}")
+        body_lines.append(health_line)
+        notify_deploy(args.repo, issue_num, record_pr["number"], "\n".join(body_lines) + "\n")
+
         if not issue_num:
-            # No linked issue to comment on — post the evidence to the
-            # record PR itself so its CODEOWNER reviewer sees the screenshots
-            # (not just a generic PR body) before approving auto-merge.
-            notify_deploy(
-                args.repo,
-                None,
-                record_pr["number"],
-                comment_markdown("### deploy_record", base_url, post_urls, extra=[health_line]),
-            )
-            print(
-                "No issue number in commit message / linked PR; "
-                f"uploaded post screenshots: {post_urls}; {health_line}"
-            )
+            # No linked issue to comment on beyond the record PR above.
+            print(f"No issue number in commit message / linked PR; {health_line}")
             print(
                 "Tip: include `Closes #N` or `(#N)` in the commit/PR body "
-                "so Reviewer gets deploy_visual_check on the issue."
+                "so the acceptance checklist refreshes on the issue."
             )
             print(f"record_pr={record_pr['url']}")
             return 0
-
-        # Before shots are PR-branch previews (no saberistic.com pre-merge).
-        pre_files = sorted(
-            p
-            for p in Path("trace/screenshots").glob("branch-*.png")
-            if "-admin" not in p.name
-        )
-        pre_urls = (
-            list_branch_pre_urls(args.repo, default, args.pr) if not pre_files else []
-        )
-        if pre_files:
-            pre_urls = upload_to_branch(
-                args.repo,
-                record_branch,
-                pre_files,
-                f".agent/screenshots/issue-{issue_num}/pre",
-            )
-
-        if not post_files and changed is not None:
-            body = (
-                "### deploy_visual_check\n"
-                f"- deploy: `{base_url}`\n"
-                "- phase: `post-deploy`\n"
-                f"- issue: #{issue_num}\n"
-                f"{health_line}\n"
-                "- routes (public, PR-affected): (none)\n"
-                "- note: no public pages affected; screenshots skipped\n"
-            )
-            notify_deploy(args.repo, issue_num, record_pr["number"], body)
-        else:
-            # No automated pass/fail here — an admin reviews the linked
-            # screenshots manually (see #372-class evidence-PR conflicts and
-            # false negatives on non-visual/backend-only changes).
-            extra = [
-                "- phase: `post-deploy`",
-                f"- issue: #{issue_num}",
-                health_line,
-                "- note: visual verification is manual — review the screenshots below.",
-            ]
-            if routes and changed is not None:
-                extra.insert(
-                    2,
-                    "- routes (public, PR-affected): "
-                    + ", ".join(f"`{r}`" for r in routes),
-                )
-            body = comment_markdown(
-                "### deploy_visual_check",
-                base_url,
-                post_urls,
-                extra=extra,
-            )
-            if pre_urls:
-                pre_lines = ["\n#### Pre-merge branch screenshots"]
-                for u in pre_urls:
-                    name = u.rsplit("/", 1)[-1]
-                    pre_lines.append(f"- **{name}**")
-                    pre_lines.append(f"  ![]({u})")
-                body += "\n".join(pre_lines) + "\n"
-            notify_deploy(args.repo, issue_num, record_pr["number"], body)
 
         try:
             from acceptance import (
@@ -400,7 +268,6 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(
                 {
                     "issue": issue_num,
-                    "post": post_urls,
                     "record_pr": record_pr["url"],
                 }
             )

--- a/scripts/review_models.py
+++ b/scripts/review_models.py
@@ -396,8 +396,9 @@ def ai_review(repo: str, issue: int, pr_number: int) -> dict[str, Any]:
         "shells (“no … yet”, empty tables, placeholder milestone copy) — Builder "
         "must ship randomized mock rows in app/admin_preview.py for screenshots.\n"
         "Screenshot policy (docs/SCREENSHOTS.md) — do NOT request changes for:\n"
-        "- missing saberistic.com / production `pre-*.png` on the PR (pre-merge captures "
-        "PR-head `branch-*.png` only; production shots are post-deploy)\n"
+        "- missing saberistic.com / production screenshots on the PR (pre-merge captures "
+        "PR-head `branch-*.png` only; production is never screenshotted — post-deploy "
+        "records `/health` JSON only, no screenshots)\n"
         "- missing `/admin` screenshots when Reviewer evidence already includes "
         "`branch-admin*.png` under ADMIN_PREVIEW_MODE, OR when the PR is admin-only "
         "and posted a skip/branch note — admin is never shot on saberistic.com\n"
@@ -480,7 +481,7 @@ def ai_review(repo: str, issue: int, pr_number: int) -> dict[str, Any]:
             decision = "approved"
             reasons = [
                 "Screenshot policy: admin uses ADMIN_PREVIEW_MODE on PR branch; "
-                "saberistic.com shots are post-deploy only"
+                "saberistic.com is never screenshotted"
             ] + policy_hits
     return {
         "decision": decision,

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -1394,7 +1394,8 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
         coverage_note = "- coverage: skipped (PR does not touch app/*.py)\n"
 
     # Pre-merge screenshots: PR-head only (incl. admin via ADMIN_PREVIEW_MODE).
-    # saberistic.com shots are post-deploy only. Docs reviews skip capture.
+    # saberistic.com is never screenshotted; post-deploy only records
+    # `/health`. Docs reviews skip capture.
     screenshot_note = ""
     if is_docs_issue:
         body_shots = (
@@ -1432,8 +1433,8 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
             if not routes:
                 body_shots = (
                     "### reviewer_screenshots_pre\n"
-                    "- production: skipped pre-merge "
-                    "(saberistic.com shots are post-deploy only)\n"
+                    "- production: never screenshotted "
+                    "(saberistic.com; post-deploy only records `/health`)\n"
                     "- routes (PR-affected): (none)\n"
                     "- note: no pages affected by this PR "
                     "(tests/docs/scripts only); screenshots skipped\n"

--- a/scripts/screenshot_deploy.py
+++ b/scripts/screenshot_deploy.py
@@ -886,7 +886,8 @@ def capture_pre_dual(
 ) -> PreCaptureResult:
     """Pre-merge: screenshot PR branch only (local uvicorn + ADMIN_PREVIEW_MODE).
 
-    Does **not** capture saberistic.com — production shots are post-deploy only.
+    Does **not** capture saberistic.com — production is never screenshotted;
+    post-deploy only records `/health` JSON (see docs/SCREENSHOTS.md).
     ``prod_*`` fields stay empty for API compatibility with older callers.
     When ``changed_files`` is provided, only affected public + admin routes
     are captured. Admin pages require the preview server's ADMIN_PREVIEW_MODE.
@@ -1565,8 +1566,8 @@ def comment_markdown_pre_dual(
     routes: list[str | ScreenshotTarget] | None = None,
     targets: list[ScreenshotTarget] | None = None,
 ) -> str:
-    """PR review comment: branch preview shots only (no saberistic.com pre)."""
-    del prod_url, prod_urls  # production screenshots are post-deploy only
+    """PR review comment: branch preview shots only (no saberistic.com ever)."""
+    del prod_url, prod_urls  # production is never screenshotted (docs/SCREENSHOTS.md)
     resolved_targets = targets
     if resolved_targets is None and routes is not None:
         if routes and all(isinstance(item, str) for item in routes):
@@ -1576,7 +1577,7 @@ def comment_markdown_pre_dual(
     lines = [
         "### reviewer_screenshots_pre",
         f"- branch (PR head local, ADMIN_PREVIEW_MODE): `{branch_url}`",
-        "- production: skipped pre-merge (saberistic.com shots are post-deploy only)",
+        "- production: never screenshotted (saberistic.com; post-deploy only records `/health`)",
     ]
     if resolved_targets is not None:
         lines.append(
@@ -1672,8 +1673,8 @@ def main(argv: list[str] | None = None) -> int:
             if not routes:
                 body = (
                     "### reviewer_screenshots_pre\n"
-                    "- production: skipped pre-merge "
-                    "(saberistic.com shots are post-deploy only)\n"
+                    "- production: never screenshotted "
+                    "(saberistic.com; post-deploy only records `/health`)\n"
                     "- routes (PR-affected): (none)\n"
                     "- note: no pages affected by this PR "
                     "(tests/docs/scripts only); screenshots skipped\n"

--- a/tests/test_digest_trace.py
+++ b/tests/test_digest_trace.py
@@ -62,7 +62,7 @@ def test_digest_includes_issues_prs_features_screenshots() -> None:
     assert "merged by Gate" in md
     assert "### Screenshots & visual evidence" in md
     assert "pre-merge screenshots (PR branch)" in md
-    assert "post-deploy screenshots (production)" in md
+    assert "post-deploy health record (no screenshots)" in md
     assert "ADMIN_PREVIEW_MODE" in md
     assert "Issues with screenshot evidence" in md
     assert "**1**" in md or "1" in md  # features / screenshot counts present

--- a/tests/test_post_deploy_visual.py
+++ b/tests/test_post_deploy_visual.py
@@ -17,8 +17,8 @@ from post_deploy_visual import (
 
 
 def test_record_branch_name_is_deterministic() -> None:
-    assert record_branch_name("abc123def456extra") == "deploy/screenshots-abc123def456"
-    assert record_branch_name("") == "deploy/screenshots-local"
+    assert record_branch_name("abc123def456extra") == "deploy/health-abc123def456"
+    assert record_branch_name("") == "deploy/health-local"
 
 
 def test_record_pr_body_mentions_sha_and_auto_merge() -> None:
@@ -41,17 +41,17 @@ def test_open_or_reuse_record_pr_opens_with_auto_merge_when_absent() -> None:
     ):
         result = open_or_reuse_record_pr(
             "o/r",
-            "deploy/screenshots-abc123def456",
+            "deploy/health-abc123def456",
             "main",
             short="abc123def456",
             base_url="https://saberistic.com",
         )
 
     assert result == {"number": 11, "url": "https://x/11"}
-    find_pr.assert_called_once_with("o/r", "deploy/screenshots-abc123def456")
+    find_pr.assert_called_once_with("o/r", "deploy/health-abc123def456")
     open_pr.assert_called_once_with(
         "o/r",
-        head="deploy/screenshots-abc123def456",
+        head="deploy/health-abc123def456",
         base="main",
         title="deploy: record post-deploy artifacts (abc123def456)",
         body=record_pr_body("abc123def456", "https://saberistic.com"),
@@ -70,7 +70,7 @@ def test_open_or_reuse_record_pr_reuses_existing_open_pr() -> None:
     ):
         result = open_or_reuse_record_pr(
             "o/r",
-            "deploy/screenshots-abc123def456",
+            "deploy/health-abc123def456",
             "main",
             short="abc123def456",
             base_url="https://saberistic.com",


### PR DESCRIPTION
### Summary

Stacked on #373. The `post-deploy-visual` CI job also captured production screenshots (`.agent/screenshots/issue-<n>/post/*.png`) on every merge to `main`, uploading them to a deterministic `deploy/screenshots-<sha>` branch/PR. Re-running the same deploy sha (retries, manual reruns) recaptured non-deterministic screenshots at the same paths — combined with that branch being force-reset to the latest `main` each run, this produced unresolvable binary "added in both" conflicts on the auto-merge record PR.

[PR #372](https://github.com/saberistic-team/agent-web/pull/372) is a live example: a second run for the same deploy sha (`7c1cba6127f0`) recorded a different capture of the same screenshot paths that PR #371 had already merged, so #372 permanently conflicts and can never merge.

This isn't a Reviewer-created artifact — it's produced entirely by the automated `Post-deploy screenshots` CI job that runs *after* merge + Render deploy, a separate mechanism from Reviewer's pre-merge PR-branch screenshots (`AGENTS/reviewer.md`, `.agent/screenshots/pr-<n>/`), which are completely unaffected by this change.

### Changes

- `scripts/post_deploy_visual.py`: drop screenshot capture/upload, the pre-merge branch-shot lookup, and `comment_markdown` usage. The job now only polls `/health`, records it under `.agent/deploy/<sha>/`, and posts a plain `### deploy_record` comment (health only) to the issue + record PR. The acceptance-checklist refresh is unchanged.
- Rename the evidence branch from `deploy/screenshots-<sha>` to `deploy/health-<sha>` to match what it actually holds now.
- `ci.yml`: drop the Playwright/Chromium install from this job (not needed here anymore) and rename the job/step to reflect health-only recording.
- Update `docs/SCREENSHOTS.md`, `docs/MODELS.md`, `docs/HELLO_API.md`, `AGENTS/reviewer.md`, and stale "production shots are post-deploy" wording in `screenshot_deploy.py`, `run_agent.py`, `acceptance.py`, `review_models.py`, `digest_trace.py` (+ its test) — production is now never screenshotted, pre-merge or post-deploy.

### Testing

- `pytest -q -m "not integration and not contract"` — 1295 passed
- `python scripts/check_coverage.py` — passed
- Validated `.github/workflows/ci.yml` YAML

### Follow-up

Will close #372 separately as a casualty of the mechanism removed here.

Made with [Cursor](https://cursor.com)