### PR TITLE
fix: paginate AI reviewer PR-files fetch and de-prioritize screenshot evidence

### DIFF
--- a/scripts/review_models.py
+++ b/scripts/review_models.py
@@ -15,7 +15,7 @@ import urllib.request
 from typing import Any
 
 from cursor_model import DEFAULT_CURSOR_MODEL, cursor_model_dict, cursor_model_selection
-from github_api import GitHubError, api, split_repo
+from github_api import GitHubError, api, list_pr_files, split_repo
 
 DEFAULT_MODEL = "openai/gpt-4o-mini"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
@@ -332,14 +332,36 @@ def extract_json(text: str) -> dict[str, Any]:
     return data
 
 
+def _is_screenshot_evidence_path(path: str) -> bool:
+    return path.startswith(".agent/screenshots/")
+
+
 def collect_pr_context(repo: str, issue: int, pr_number: int) -> dict[str, Any]:
     owner, name = split_repo(repo)
     issue_data = api("GET", f"/repos/{owner}/{name}/issues/{issue}")
     pr = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}")
-    files = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}/files") or []
+    # Must paginate (default API page is only 30): PRs that also carry
+    # Reviewer screenshot evidence commonly exceed 100 files, and
+    # `.agent/screenshots/...` sorts alphabetically before `app/`/`docs/`/
+    # `tests/`, so a single unpaginated page can be 100% screenshots with
+    # every real code/test/doc file silently missing from the model's
+    # context — producing a false "screenshot-only diff" changes-requested
+    # verdict no matter how many times Builder re-pushes (mirrors the
+    # pagination bug already fixed for `list_pr_files` callers in #206).
+    files = list_pr_files(repo, pr_number)
     commits = api("GET", f"/repos/{owner}/{name}/pulls/{pr_number}/commits") or []
+    # Even with full pagination, `.agent/screenshots/...` still sorts first
+    # alphabetically, so a plain files[:20] slice can still be 100%
+    # screenshots on evidence-heavy PRs. Prioritize substantive files for
+    # the patches actually shown to the model; screenshots need no patch
+    # (policy already treats them as allowed evidence, not something to
+    # diff), so surface their count instead of crowding out real changes.
+    substantive = [
+        f for f in files if not _is_screenshot_evidence_path(f.get("filename") or "")
+    ]
+    screenshot_count = len(files) - len(substantive)
     patches = []
-    for f in files[:20]:
+    for f in substantive[:20]:
         patch = f.get("patch") or ""
         if len(patch) > 4000:
             patch = patch[:4000] + "\n…[truncated]…"
@@ -359,6 +381,7 @@ def collect_pr_context(repo: str, issue: int, pr_number: int) -> dict[str, Any]:
         "pr_body": (pr.get("body") or "")[:4000],
         "commit_messages": [c.get("commit", {}).get("message", "") for c in commits],
         "files": patches,
+        "screenshot_evidence_file_count": screenshot_count,
     }
 
 
@@ -402,6 +425,10 @@ def ai_review(repo: str, issue: int, pr_number: int) -> dict[str, Any]:
         "`branch-admin*.png` under ADMIN_PREVIEW_MODE, OR when the PR is admin-only "
         "and posted a skip/branch note — admin is never shot on saberistic.com\n"
         "- files under `.agent/screenshots/` (allowed Reviewer evidence)\n"
+        "`files` below excludes `.agent/screenshots/` entries — their count is in "
+        "`screenshot_evidence_file_count` instead. Never claim the diff is "
+        "'screenshot-only' or that no code/test/doc files changed on that basis; "
+        "judge acceptance strictly from the non-screenshot entries in `files`.\n"
         "- noisy/file-by-file commit history (gate squash-merges to main)\n"
         "- wording/style nits when acceptance criteria are met\n"
         "If acceptance criteria are met, set decision=approved and meets_acceptance=true.\n"

--- a/tests/test_review_models.py
+++ b/tests/test_review_models.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 from unittest.mock import patch
 
-from review_models import ai_review, extract_json, reviewer_agent_cwd
+from review_models import ai_review, collect_pr_context, extract_json, reviewer_agent_cwd
 
 
 def test_extract_json_recovers_truncated_approved() -> None:
@@ -112,3 +113,104 @@ def test_reviewer_agent_cwd_falls_back_when_coverage_root_missing() -> None:
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("COVERAGE_ROOT", None)
         assert reviewer_agent_cwd() == os.getcwd()
+
+
+def test_collect_pr_context_paginates_beyond_default_api_page(
+    monkeypatch: Any,
+) -> None:
+    """#377: PRs carrying >30 files (e.g. Reviewer screenshot evidence) must
+    not silently drop later pages of the diff — `pulls/{pr}/files` defaults
+    to a 30-item page, and an unpaginated call previously fed the AI model a
+    partial (often screenshot-only) `files` list no matter how many real
+    code/test/doc changes the PR actually contained."""
+    screenshots = [
+        {"filename": f".agent/screenshots/pr-1/branch-{i}.png", "status": "added"}
+        for i in range(45)
+    ]
+    code_files = [
+        {
+            "filename": "app/admin_cache_policy.py",
+            "status": "added",
+            "additions": 10,
+            "deletions": 0,
+            "patch": "+no-store",
+        }
+    ]
+    all_files = screenshots + code_files
+
+    def fake_api(method: str, path: str, **_kwargs: Any) -> Any:
+        assert method == "GET"
+        if path.endswith("/issues/337"):
+            return {"title": "issue", "body": "body"}
+        if path.endswith("/pulls/1"):
+            return {"title": "pr", "body": "pr body"}
+        if path.endswith("/pulls/1/commits"):
+            return []
+        if "/pulls/1/files" in path:
+            page = 1
+            if "page=" in path:
+                page = int(path.rsplit("page=", 1)[-1])
+            start = (page - 1) * 100
+            return all_files[start : start + 100]
+        raise AssertionError(f"unexpected path {path}")
+
+    # `list_pr_files` (github_api.py) resolves its own `api` call against
+    # github_api's globals, not review_models's imported name, so both call
+    # sites need patching to exercise the real pagination path end to end.
+    monkeypatch.setattr("review_models.api", fake_api)
+    monkeypatch.setattr("github_api.api", fake_api)
+    ctx = collect_pr_context("o/r", 337, 1)
+    filenames = [f["filename"] for f in ctx["files"]]
+    assert "app/admin_cache_policy.py" in filenames
+    assert ctx["screenshot_evidence_file_count"] == 45
+
+
+def test_collect_pr_context_prioritizes_code_over_screenshots_in_top_20(
+    monkeypatch: Any,
+) -> None:
+    """Even after pagination, `.agent/screenshots/...` sorts alphabetically
+    before `app/`/`docs/`/`tests/`, so a plain top-20 slice of a 130-file PR
+    can still be 100% screenshots. Real files must not be crowded out."""
+    screenshots = [
+        {"filename": f".agent/screenshots/pr-1/branch-{i}.png", "status": "added"}
+        for i in range(117)
+    ]
+    code_files = [
+        {
+            "filename": name,
+            "status": "added",
+            "additions": 1,
+            "deletions": 0,
+            "patch": "+x",
+        }
+        for name in [
+            "app/admin_cache_policy.py",
+            "app/main.py",
+            "docs/ADMIN_AUTH.md",
+            "tests/test_admin_cache_headers.py",
+        ]
+    ]
+    all_files = screenshots + code_files
+
+    def fake_api(method: str, path: str, **_kwargs: Any) -> Any:
+        if "/pulls/1/files" in path:
+            page = 1
+            if "page=" in path:
+                page = int(path.rsplit("page=", 1)[-1])
+            start = (page - 1) * 100
+            return all_files[start : start + 100]
+        if path.endswith("/pulls/1/commits"):
+            return []
+        return {"title": "t", "body": "b"}
+
+    monkeypatch.setattr("review_models.api", fake_api)
+    monkeypatch.setattr("github_api.api", fake_api)
+    ctx = collect_pr_context("o/r", 337, 1)
+    filenames = {f["filename"] for f in ctx["files"]}
+    assert filenames == {
+        "app/admin_cache_policy.py",
+        "app/main.py",
+        "docs/ADMIN_AUTH.md",
+        "tests/test_admin_cache_headers.py",
+    }
+    assert ctx["screenshot_evidence_file_count"] == 117


### PR DESCRIPTION
## Root cause

While bringing PR #345 (issue #337) up to date with `main`, the AI reviewer bot kept issuing `changes-requested` verdicts claiming the diff was "screenshot-only" — across three separate review runs on three different commits — even though the PR clearly adds `app/admin_cache_policy.py`, `app/admin_response_policy.py`, `app/main.py`, `docs/ADMIN_AUTH.md`, `scripts/smoke_deploy.py`, and 6 test files.

Root cause: `collect_pr_context()` in `scripts/review_models.py` fetched the PR's file list with a **raw, unpaginated** call to `GET /pulls/{pr}/files`, which defaults to a 30-item page. `scripts/github_api.py` already has a paginated `list_pr_files()` helper (added for the identical bug in #206), but `review_models.py` had its own separate, unpaginated call that never got fixed.

PRs carrying Reviewer screenshot evidence (`.agent/screenshots/pr-<n>/*.png`) routinely have 100+ files, and since `.agent/screenshots/...` sorts alphabetically *before* `app/`, `docs/`, `scripts/`, `tests/`, the first (only) page fetched was 100% screenshots. The AI model was then handed a context whose `files` list contained literally no code/test/doc changes — so it reported (accurately, given what it saw) that the diff was screenshot-only, even though the real PR diff was not.

## Fix

- `collect_pr_context()` now calls the existing paginated `list_pr_files()` helper instead of a raw `api()` call.
- Even with full pagination, a naive `files[:20]` slice can *still* be 100% screenshots on evidence-heavy PRs (alphabetical sort strikes again), so screenshot-evidence files are now filtered out before selecting the top-20 files whose patches are sent to the model. Their count is surfaced via a new `screenshot_evidence_file_count` field instead, since screenshots don't need a patch review under `docs/SCREENSHOTS.md` policy.
- The reviewer system prompt now explicitly says `files` excludes screenshot evidence and that the model must never infer "screenshot-only diff" from that list.

## Tests

Added two regression tests in `tests/test_review_models.py`:
- `test_collect_pr_context_paginates_beyond_default_api_page` — a 46-file PR (45 screenshots + 1 real code file) now surfaces the code file in `ctx["files"]` instead of silently dropping it.
- `test_collect_pr_context_prioritizes_code_over_screenshots_in_top_20` — a 121-file PR (117 screenshots + 4 real files) puts all 4 real files in the model context, not just whichever screenshots happened to sort first.

All existing `test_review_models.py` and `test_github_api.py` tests still pass.

## Why this needs independent review

`scripts/review_*.py` is covered by the workflow-governance CODEOWNERS rule requiring human review from `@saberistic`/`@mehdidehdar`/`@Amirsharifico` — this PR modifies the reviewer's own AI-context construction, so it's exactly the kind of change that rule exists to gate.

Made with [Cursor](https://cursor.com)