### PR TITLE
fix(reviewer): ignore Project board sync check hard-fails

### DIFF
--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -1258,9 +1258,23 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
         "GET",
         f"/repos/{owner}/{name}/commits/{sha}/check-runs",
     )
+    # Dedupe to the latest run per check name. Label churn can leave older
+    # failed Project board ``sync`` runs on the same SHA alongside later
+    # successes; treating any historical failure as a hard-fail loops Builder
+    # for non-product reasons (#338 / PR #350).
+    latest_by_name: dict[str, dict] = {}
     for run in checks.get("check_runs") or []:
+        name = run.get("name") or ""
+        prev = latest_by_name.get(name)
+        if prev is None or (run.get("started_at") or "") > (prev.get("started_at") or ""):
+            latest_by_name[name] = run
+    # Non-gating orchestration: project-sync.yml job is named ``sync``.
+    _IGNORE_CHECK_NAMES = frozenset({"sync"})
+    for run in latest_by_name.values():
         conclusion = (run.get("conclusion") or "").lower()
         name_l = (run.get("name") or "").lower()
+        if name_l in _IGNORE_CHECK_NAMES:
+            continue
         if conclusion in {"failure", "timed_out", "cancelled"}:
             hard_fail_reasons.append(f"check `{run.get('name')}` → {conclusion}")
         if "security" in name_l and conclusion == "failure":


### PR DESCRIPTION
## Summary
- Reviewer hard-failed PR #350 solely on check `sync` (project-sync.yml label→board mirror), despite AI approval and green `test`
- That requeued Builder, which thrash-regenerated abandoned code
- Dedupe check-runs to latest per name and ignore non-gating `sync`

## Test plan
- [x] Diff is scoped to `scripts/run_agent.py` check-run evaluation
- [ ] Re-review #350 after merge; should not hard-fail on Project board sync

Made with [Cursor](https://cursor.com)