### PR TITLE
fix: classify ICP signals admin routes for session CSRF

### DIFF
--- a/app/admin_csrf_classification.py
+++ b/app/admin_csrf_classification.py
@@ -96,6 +96,18 @@ ADMIN_CSRF_ROUTE_POLICIES: dict[tuple[str, str], tuple[CsrfPolicy, str]] = {
         "session_csrf_required",
         "Pipeline activity creation requires a session-bound CSRF token in the form body.",
     ),
+    ("POST", "/admin/signals/rules"): (
+        "session_csrf_required",
+        "ICP rule publish requires a session-bound CSRF token in the form body.",
+    ),
+    ("POST", "/admin/signals/{company_id}/recalculate"): (
+        "session_csrf_required",
+        "ICP score recalculation requires a session-bound CSRF token in the form body.",
+    ),
+    ("POST", "/admin/signals/{company_id}/override"): (
+        "session_csrf_required",
+        "ICP score override requires a session-bound CSRF token in the form body.",
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Adds `session_csrf_required` CSRF policy entries for the three `/admin/signals` POST routes introduced by ICP scoring (#353)
- Unblocks main CI after #396 (`test_admin_csrf_classification`) so dependent PRs like #354 can remerge a green base

## Test plan
- [x] `pytest -q tests/test_admin_csrf_classification.py -m unit` (5 passed)
- [x] CI green on this PR / main after merge

Made with [Cursor](https://cursor.com)