### PR TITLE
fix: enforce machine-readable issue dependencies before agents run

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -126,7 +126,8 @@ jobs:
           ISSUE: ${{ steps.meta.outputs.issue }}
         run: |
           set -euo pipefail
-          # Fail closed unless Reviewer posted a complete acceptance checklist.
+          # Fail closed unless Reviewer posted a complete acceptance checklist
+          # and issue dependencies are met (scripts/issue_deps.py / #204).
           python scripts/acceptance.py \
             --repo "${{ github.repository }}" \
             --issue "${ISSUE}" \

--- a/AGENTS/builder.md
+++ b/AGENTS/builder.md
@@ -8,6 +8,13 @@ that issue’s acceptance criteria.
 
 Preserve any `priority:*` label on the issue; do not strip or change it.
 
+**Before codegen:** if the issue has open GitHub `blockedBy` links, a
+`Depends on: #N` line whose targets are still open, or a prose-only
+`## Dependencies` section without issue refs, stop — escalate with
+`status:blocked` (`scripts/issue_deps.py`). Do **not** invent stand-in
+schemas/corpuses so work can proceed early (learned from
+[#204](https://github.com/saberistic-team/agent-web/issues/204)).
+
 Workflow will move you through `status:in-progress`, then hand off with
 `status:needs-review`, `review:needs-review`, and `agent:reviewer`. Project
 board Status / Priority / Review are synced automatically from those labels

--- a/AGENTS/docs.md
+++ b/AGENTS/docs.md
@@ -8,6 +8,11 @@ it matches the product and any related implementation.
 
 Preserve any `priority:*` label on the issue; do not strip or change it.
 
+**Before editing:** if dependencies are open or unstructured
+(`scripts/issue_deps.py`), escalate with `status:blocked` — do not draft
+provisional docs that guess upstream issues (learned from
+[#204](https://github.com/saberistic-team/agent-web/issues/204)).
+
 In-scope paths:
 
 - `docs/`

--- a/AGENTS/planner.md
+++ b/AGENTS/planner.md
@@ -23,12 +23,32 @@ Before any issue enters `status:queued`, it must already carry:
 - an **open** GitHub milestone for the current product phase (unless
   `priority:critical` — hotfixes may skip milestones)
 - `status:queued`
+- **machine-readable dependencies** (or an explicit `None` / `N/A`) when the
+  issue depends on other work — see Dependencies below
 
 Do **not** apply `agent:builder` or `agent:docs` when queuing. The dispatcher
 filters to open-milestone work (plus critical), then picks the next issue by
 earliest milestone due date, then `priority:*` (critical → high → medium →
 normal → low), then issue number. Record `intended_agent` and `milestone` in
 `### planner_plan`.
+
+### Dependencies (required when work is blocked on other issues)
+
+Prose-only “start after Manifest / corpus …” is **not** enough (learned from
+[#204](https://github.com/saberistic-team/agent-web/issues/204)). Before
+`status:queued`:
+
+1. Prefer GitHub **blocked by** links on the issue, **and/or**
+2. Add an explicit body line: `Depends on: #199, #200` (or
+   `## Dependencies` containing only those refs / `None` / `N/A`).
+
+If a `## Dependencies` section has narrative text but **no** `#N` refs, do
+**not** queue — rewrite to `Depends on:` or set `status:blocked` with
+`@human-review`. Do not invent stand-in schemas so a later spike can “guess”
+upstream docs.
+
+Dispatcher (`scripts/dispatch_queue.py`) and Builder/Docs/Reviewer/Gate all
+enforce the same rules via `scripts/issue_deps.py`.
 
 Humans open/close milestones to mark the current phase. You assign issues to an
 open milestone (prefer the parent’s open milestone, else the earliest-due open
@@ -98,3 +118,6 @@ Escalate when:
 - scope is outside any agent role (policy, secrets, billing, legal, etc.)
 - decomposition cannot be decided without a human call
 - a dependency or decision is not resolvable from the issue alone
+- dependencies exist but are not machine-readable (`Depends on: #N` /
+  GitHub blockedBy / explicit `None`), or listed dependency issues are still
+  open — use `status:blocked`, do **not** queue

--- a/AGENTS/reviewer.md
+++ b/AGENTS/reviewer.md
@@ -14,14 +14,20 @@ issue’s original acceptance criteria before `review:approved`.
 
 Before approving you must:
 
-1. Confirm the linked PR **merges cleanly** into its base (`mergeable` /
+1. Confirm **dependencies are met** (`scripts/issue_deps.py`): no open
+   GitHub `blockedBy`, no open `Depends on: #N` targets, and no prose-only
+   `## Dependencies` section. If unmet, request changes with
+   `terminal: true` / open-dependencies wording so orchestration sets
+   `status:blocked` — **do not** requeue Builder/Docs and **do not** approve
+   (learned from [#204](https://github.com/saberistic-team/agent-web/issues/204)).
+2. Confirm the linked PR **merges cleanly** into its base (`mergeable` /
    `mergeable_state` not dirty). If GitHub reports conflicts (e.g. another
    branch merged after Builder/Docs handed off), **request changes immediately**
    and return the issue to the implementing agent (`agent:builder` or
    `agent:docs` via the priority queue — dispatcher uses `type:*`) — do not
    approve or spend the rest of the review budget on a conflicted PR. Merge
    conflicts are always implementing-agent work on the same PR head.
-2. Capture **headless Chromium screenshots** via Actions Playwright
+3. Capture **headless Chromium screenshots** via Actions Playwright
    (`scripts/screenshot_deploy.py`, preferring the **PR-head** copy under
    `COVERAGE_ROOT` when present — see [docs/SCREENSHOTS.md](../docs/SCREENSHOTS.md))
    at **desktop and mobile** viewports (plus admin tablet / narrow-desktop /
@@ -34,18 +40,18 @@ Before approving you must:
    the PR touches no visual pages (tests/docs only). Upload all PNGs in
    **one** commit via `upload_to_branch` (never one Contents API commit per
    image — that storms CI and can dirty the PR mid-review).
-3. Check **visual readability** on the **PR branch** screenshots / live
+4. Check **visual readability** on the **PR branch** screenshots / live
    capture: hero and primary copy must stay inside the viewport (no horizontal
    overflow / text out of frame on mobile). New admin/data tables under
    ``ADMIN_PREVIEW_MODE`` must show **randomized mock rows** (not an empty
    “no records yet” shell) unless the issue is explicitly about empty states.
-4. Run **Cursor / OpenAI / Models AI review** ([docs/MODELS.md](../docs/MODELS.md),
+5. Run **Cursor / OpenAI / Models AI review** ([docs/MODELS.md](../docs/MODELS.md),
    [docs/DESIGN.md](../docs/DESIGN.md), [docs/TESTING.md](../docs/TESTING.md))
    — prefers Cursor when `CURSOR_API_KEY` is set. Do **not** request changes
    for missing saberistic.com pre shots or for `/admin` evidence that was
    already captured (or correctly skipped) under `ADMIN_PREVIEW_MODE`.
-5. Enforce **service coverage** on `app/`: unit ≥90%, integration ≥70%
-6. Post an **`### acceptance_checklist`** that marks each acceptance criterion
+6. Enforce **service coverage** on `app/`: unit ≥90%, integration ≥70%
+7. Post an **`### acceptance_checklist`** that marks each acceptance criterion
    done/not_done with links to evidence (PR, commits, files, screenshots).
    **Pre-merge “published” criteria** (e.g. launch articles live on `/insights`)
    are satisfied by **PR-head evidence** — code routes, `LAUNCH_REVIEW.md` /

--- a/docs/IDENTITIES.md
+++ b/docs/IDENTITIES.md
@@ -79,6 +79,7 @@ Every agent action must produce a **visible GitHub event** under the role bot:
 | `### agent_start` / `### agent_finish` / `### agent_failed` | Issue comment |
 | `### planner_plan` / `### planner_release` | Issue comment (required before queue) |
 | `### dispatcher_dispatch` | Issue comment when the priority queue applies `agent:builder` / `agent:docs` |
+| `### dispatcher_skip` | Issue comment when queued work is skipped for open / unstructured dependencies (`scripts/issue_deps.py`) |
 | `### permission_check` | Issue comment (pass **and** fail) |
 | `### gate_release_plan` / `### gate_merge` | Issue comment |
 | Builder/Docs commits + PRs | Commits/PRs as Builder/Docs App |

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -88,7 +88,7 @@ while the issue is in the orchestration pipeline.
 | `status:new` | **Entry point only.** Fresh work that has not been claimed by any agent. Humans (or intake automation) may apply this; **only the Planner may move an issue out of `status:new`.** |
 | `status:queued` | Accepted by the Planner and waiting in the **priority queue**. The dispatcher applies `agent:builder` or `agent:docs` when that agent is free, highest priority first. |
 | `status:in-progress` | An agent is actively working the issue. |
-| `status:blocked` | Work cannot proceed until an **external** dependency or decision is resolved. Do **not** use for transient Cursor SDK timeouts, soft file-budget overruns, coverage gaps, or merge conflicts — those re-enter `status:queued` (`waiting` handoff). |
+| `status:blocked` | Work cannot proceed until an **external** dependency or decision is resolved — including open `Depends on: #N` / GitHub `blockedBy` targets, or a prose-only `## Dependencies` section that Planner must rewrite. Do **not** use for transient Cursor SDK timeouts, soft file-budget overruns, coverage gaps, or merge conflicts — those re-enter `status:queued` (`waiting` handoff). |
 | `status:needs-review` | Implementation is ready for review (pairs with the `review` axis). |
 | `status:done` | Work is complete and accepted; Gate sets this only after a complete `### acceptance_checklist` and close. |
 | `status:failed` | The run failed or was aborted; needs human or Planner intervention. |
@@ -111,8 +111,12 @@ while the issue is in the orchestration pipeline.
   issues on an **open** GitHub milestone (see Milestones below), then sort by
   earliest milestone due date, then priority, then issue number, and apply at
   most one run per agent while that agent already has `status:in-progress`
-  work. The dispatch workflow also runs on a `*/10 * * * *` cron so queued
-  work is drained without waiting for a new label event.
+  work. Issues with **open** or **unstructured** dependencies
+  (`scripts/issue_deps.py` — GitHub `blockedBy`, `Depends on: #N`, or a
+  prose-only `## Dependencies` section) are skipped with
+  `### dispatcher_skip` until blockers close (learned from #204). The
+  dispatch workflow also runs on a `*/10 * * * *` cron so queued work is
+  drained without waiting for a new label event.
 
 ---
 
@@ -143,6 +147,21 @@ unblocker), even with no milestone or a closed milestone.
 not filter by milestone (avoids a stuck queue). Prefer keeping exactly one
 current open milestone in normal operation; use due dates when multiple are
 open so agents drain earlier phases first.
+
+### Issue dependencies
+
+Cross-issue blockers must be **machine-readable** before Planner queues and
+before Dispatcher starts Builder/Docs:
+
+| Form | Example |
+|------|---------|
+| GitHub blockedBy | Issue A “blocked by” issue B in the GitHub UI |
+| Body line | `Depends on: #199, #200` |
+| Section | `## Dependencies` containing `#199` refs, or `None` / `N/A` |
+
+A `## Dependencies` section with narrative prose and **no** `#N` refs is
+unstructured — Planner sets `status:blocked`; Dispatcher skips; Gate refuses
+merge (`scripts/issue_deps.py`, learned from #204).
 
 ---
 

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -703,6 +703,11 @@ def latest_checklist(repo: str, issue: int) -> dict[str, Any] | None:
 
 def require_checklist_complete(repo: str, issue: int) -> dict[str, Any]:
     """Gate helper: fail unless latest acceptance_checklist has all_done true."""
+    from issue_deps import require_dependencies_met
+
+    # Fail closed on open / unstructured dependencies before merge (#204).
+    require_dependencies_met(repo, issue)
+
     latest = latest_checklist(repo, issue)
     if not latest:
         raise GitHubError(

--- a/scripts/dispatch_queue.py
+++ b/scripts/dispatch_queue.py
@@ -4,9 +4,10 @@
 Queued work carries ``status:queued`` + ``type:*`` + ``priority:*`` without
 ``agent:builder`` / ``agent:docs``. This script lists those issues, keeps only
 issues on an **open** GitHub milestone (or ``priority:critical`` hotfixes),
-sorts by earliest milestone due date, then priority, then issue number, and
-applies the intended agent label when that agent is not already
-``status:in-progress``.
+skips issues with open or unstructured dependencies
+(``scripts/issue_deps.py``), sorts by earliest milestone due date, then
+priority, then issue number, and applies the intended agent label when that
+agent is not already ``status:in-progress``.
 """
 
 from __future__ import annotations
@@ -22,8 +23,13 @@ from github_api import (
     add_labels,
     api,
     delete_label,
+    list_issue_comments,
     post_issue_comment,
     split_repo,
+)
+from issue_deps import (
+    dependency_block_reason,
+    dispatcher_skip_comment,
 )
 from milestones import (
     dispatch_sort_key,
@@ -151,11 +157,21 @@ def ensure_priority(repo: str, issue: dict[str, Any]) -> str:
     return priority
 
 
+def _recent_dispatcher_skip(repo: str, issue_number: int) -> bool:
+    """True when the newest issue comment is already a deps skip (avoid cron spam)."""
+    comments = list_issue_comments(repo, issue_number)
+    if not comments:
+        return False
+    body = comments[-1].get("body") or ""
+    return "### dispatcher_skip" in body and "open_dependencies" in body
+
+
 def dispatch_next(repo: str, *, dry_run: bool = False) -> dict[str, Any]:
     """Dispatch at most one builder and one docs issue per run."""
     awaiting, skipped_milestone = list_awaiting_dispatch(repo)
     dispatched: list[dict[str, Any]] = []
     skipped_busy: list[dict[str, Any]] = []
+    skipped_deps: list[dict[str, Any]] = []
     busy_agents: set[str] = set()
 
     for issue in awaiting:
@@ -172,6 +188,26 @@ def dispatch_next(repo: str, *, dry_run: bool = False) -> dict[str, Any]:
             skipped_busy.append(
                 {"issue": number, "agent": agent, "reason": "already_dispatched_this_run"}
             )
+            continue
+
+        dep_reason = dependency_block_reason(
+            repo, number, body=issue.get("body") or ""
+        )
+        if dep_reason:
+            skipped_deps.append(
+                {
+                    "issue": number,
+                    "agent": agent,
+                    "reason": "open_dependencies",
+                    "detail": dep_reason,
+                }
+            )
+            if not dry_run and not _recent_dispatcher_skip(repo, number):
+                post_issue_comment(
+                    repo,
+                    number,
+                    dispatcher_skip_comment(number, dep_reason),
+                )
             continue
 
         priority = (
@@ -212,6 +248,7 @@ def dispatch_next(repo: str, *, dry_run: bool = False) -> dict[str, Any]:
         "awaiting": [int(i["number"]) for i in awaiting],
         "dispatched": dispatched,
         "skipped_busy": skipped_busy,
+        "skipped_deps": skipped_deps,
         "skipped_milestone": skipped_milestone,
     }
 

--- a/scripts/issue_deps.py
+++ b/scripts/issue_deps.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Issue dependency guards (learned from #204 premature merge).
+
+Machine-readable dependencies are required before Planner queues work and
+before Dispatcher / Builder / Docs / Reviewer / Gate proceed:
+
+- GitHub ``blockedBy`` relationships (preferred)
+- Explicit body lines: ``Depends on: #199, #200`` / ``Blocked by: #199``
+- Issue refs (``#N`` or full issue URLs) inside a ``## Dependencies`` /
+  ``## Dependency`` section
+
+A non-empty ``## Dependencies`` section with **no** parseable issue numbers is
+treated as unstructured and fail-closed (Planner must rewrite to ``Depends on:``
+or mark ``None`` / ``N/A``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import Any
+
+from github_api import GitHubError, api, graphql, split_repo
+
+DEPENDS_ON_LINE_RE = re.compile(
+    r"(?im)^(?:depends\s+on|blocked\s+by|blockers?)\s*:?\s*(.+)$"
+)
+ISSUE_REF_RE = re.compile(
+    r"(?:https://github\.com/[^/\s]+/[^/\s]+/issues/|#)(\d+)\b"
+)
+DEPENDENCIES_SECTION_RE = re.compile(
+    r"(?is)##\s*dependenc(?:y|ies)\s*\n(.*?)(?=\n##\s|\Z)"
+)
+_NONE_RE = re.compile(r"(?is)^\s*(?:none|n/?a|no\s+dependencies?)\s*\.?\s*$")
+_PROVISIONAL_OK_RE = re.compile(
+    r"(?is)\b(?:provisional\s+(?:ok|allowed)|deps?\s+exempt|dependency\s+exempt)\b"
+)
+
+
+def dependency_section(body: str) -> str | None:
+    """Return the ``## Dependencies`` / ``## Dependency`` section body, if any."""
+    match = DEPENDENCIES_SECTION_RE.search(body or "")
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def parse_dependency_issue_numbers(body: str) -> list[int]:
+    """Parse machine-readable dependency issue numbers from an issue body."""
+    text = body or ""
+    found: list[int] = []
+    seen: set[int] = set()
+
+    def _add(raw: str) -> None:
+        for match in ISSUE_REF_RE.finditer(raw):
+            number = int(match.group(1))
+            if number not in seen:
+                seen.add(number)
+                found.append(number)
+
+    for match in DEPENDS_ON_LINE_RE.finditer(text):
+        value = match.group(1).strip()
+        if _NONE_RE.match(value):
+            continue
+        _add(value)
+
+    section = dependency_section(text)
+    if section and not _NONE_RE.match(section):
+        _add(section)
+
+    return found
+
+
+def has_unstructured_dependencies(body: str) -> bool:
+    """True when a Dependencies section has prose but no issue refs.
+
+    Explicit ``None`` / ``N/A`` / ``no dependencies`` is fine. A provisional
+    exemption phrase also clears the unstructured check (still prefer
+    ``Depends on:`` when real blockers exist).
+    """
+    section = dependency_section(body or "")
+    if section is None:
+        return False
+    if _NONE_RE.match(section):
+        return False
+    if _PROVISIONAL_OK_RE.search(section):
+        return False
+    if parse_dependency_issue_numbers(
+        f"## Dependencies\n{section}\n"
+    ):
+        return False
+    # Non-empty prose without refs — fail closed (#204).
+    return len(section) >= 12
+
+
+def fetch_github_blocked_by(repo: str, issue: int) -> list[dict[str, Any]]:
+    """Return GitHub ``blockedBy`` nodes for ``issue`` (may be empty)."""
+    owner, name = split_repo(repo)
+    data = graphql(
+        """
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            issue(number: $number) {
+              blockedBy(first: 20) {
+                nodes { number title state }
+              }
+            }
+          }
+        }
+        """,
+        {"owner": owner, "name": name, "number": int(issue)},
+    )
+    issue_data = ((data or {}).get("repository") or {}).get("issue") or {}
+    nodes = ((issue_data.get("blockedBy") or {}).get("nodes")) or []
+    return [node for node in nodes if node and node.get("number") is not None]
+
+
+def _issue_state(repo: str, number: int) -> dict[str, Any]:
+    owner, name = split_repo(repo)
+    data = api("GET", f"/repos/{owner}/{name}/issues/{int(number)}") or {}
+    return {
+        "number": int(number),
+        "title": data.get("title") or "",
+        "state": (data.get("state") or "open").lower(),
+    }
+
+
+def open_dependency_blockers(
+    repo: str,
+    issue: int,
+    *,
+    body: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return still-open blockers for ``issue``.
+
+    Combines GitHub ``blockedBy`` with body ``Depends on:`` / Dependencies
+    section refs. Closed dependencies are ignored.
+    """
+    if body is None:
+        owner, name = split_repo(repo)
+        issue_data = api("GET", f"/repos/{owner}/{name}/issues/{int(issue)}") or {}
+        body = issue_data.get("body") or ""
+
+    blockers: dict[int, dict[str, Any]] = {}
+
+    try:
+        for node in fetch_github_blocked_by(repo, issue):
+            number = int(node["number"])
+            state = str(node.get("state") or "OPEN").lower()
+            if state != "open":
+                continue
+            blockers[number] = {
+                "number": number,
+                "title": node.get("title") or "",
+                "state": "open",
+                "source": "blocked_by",
+            }
+    except GitHubError:
+        # GraphQL may be unavailable for some tokens; body refs still apply.
+        pass
+
+    for number in parse_dependency_issue_numbers(body or ""):
+        if number == int(issue):
+            continue
+        if number in blockers:
+            continue
+        meta = _issue_state(repo, number)
+        if meta["state"] != "open":
+            continue
+        blockers[number] = {**meta, "source": "body"}
+
+    return sorted(blockers.values(), key=lambda item: int(item["number"]))
+
+
+def format_blocker_refs(blockers: list[dict[str, Any]]) -> str:
+    if not blockers:
+        return "(none)"
+    return ", ".join(f"#{int(b['number'])}" for b in blockers)
+
+
+def dependency_block_reason(
+    repo: str,
+    issue: int,
+    *,
+    body: str | None = None,
+) -> str | None:
+    """Human-readable reason when dependencies are unmet, else ``None``."""
+    if body is None:
+        owner, name = split_repo(repo)
+        issue_data = api("GET", f"/repos/{owner}/{name}/issues/{int(issue)}") or {}
+        body = issue_data.get("body") or ""
+
+    if has_unstructured_dependencies(body or ""):
+        return (
+            f"#{issue} has a ## Dependencies section without machine-readable "
+            "issue refs. Rewrite as `Depends on: #N, #M` (or `None` / `N/A`), "
+            "or set GitHub blockedBy links — do not invent stand-in schemas "
+            "(learned from #204)."
+        )
+
+    blockers = open_dependency_blockers(repo, issue, body=body)
+    if not blockers:
+        return None
+    refs = format_blocker_refs(blockers)
+    titles = "; ".join(
+        f"#{int(b['number'])} {b.get('title') or ''}".strip() for b in blockers
+    )
+    return (
+        f"#{issue} is blocked by open dependencies: {refs}. "
+        f"Wait until they close (or remove the Depends-on / blockedBy link). "
+        f"Details: {titles}"
+    )
+
+
+def require_dependencies_met(
+    repo: str,
+    issue: int,
+    *,
+    body: str | None = None,
+) -> None:
+    """Raise ``GitHubError`` when open or unstructured dependencies remain."""
+    reason = dependency_block_reason(repo, issue, body=body)
+    if reason:
+        raise GitHubError(reason)
+
+
+def dispatcher_skip_comment(issue: int, reason: str) -> str:
+    return (
+        "### dispatcher_skip\n"
+        f"- issue: `#{issue}`\n"
+        "- reason: `open_dependencies`\n"
+        f"- detail: {reason}\n"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--issue", type=int, required=True)
+    parser.add_argument(
+        "--mode",
+        choices=("check", "require"),
+        default="check",
+        help="check prints JSON; require exits non-zero when blocked",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        owner, name = split_repo(args.repo)
+        issue_data = (
+            api("GET", f"/repos/{owner}/{name}/issues/{int(args.issue)}") or {}
+        )
+        body = issue_data.get("body") or ""
+        reason = dependency_block_reason(args.repo, args.issue, body=body)
+        blockers = open_dependency_blockers(args.repo, args.issue, body=body)
+        payload = {
+            "issue": args.issue,
+            "ok": reason is None,
+            "unstructured": has_unstructured_dependencies(body),
+            "blockers": blockers,
+            "reason": reason,
+        }
+        print(json.dumps(payload, sort_keys=True, indent=2))
+        if args.mode == "require" and reason:
+            return 1
+        return 0
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/review_decision.py
+++ b/scripts/review_decision.py
@@ -27,7 +27,11 @@ _FIXABLE_RE = re.compile(
     r"return to Docs|agent-updates stub|docs PR|type:docs PR",
     re.I,
 )
-_TERMINAL_RE = re.compile(r"terminal:\s*true|worklog-only", re.I)
+_TERMINAL_RE = re.compile(
+    r"terminal:\s*true|worklog-only|open dependencies|unstructured dependencies|"
+    r"machine-readable",
+    re.I,
+)
 
 
 def is_fixable_changes_requested(body: str) -> bool:

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -30,6 +30,7 @@ from github_api import (
     post_issue_comment,
     split_repo,
 )
+from issue_deps import dependency_block_reason
 from milestones import (
     ensure_open_milestone,
     issue_milestone_number,
@@ -723,6 +724,19 @@ def role_planner(repo: str, issue: int, brief: Path) -> None:
     body = data.get("body") or ""
     labels = {label["name"] for label in data.get("labels") or []}
 
+    # Fail closed on open / unstructured dependencies before queue (#204).
+    dep_reason = dependency_block_reason(repo, issue, body=body)
+    if dep_reason:
+        escalate(
+            repo,
+            issue,
+            (
+                "Cannot queue until dependencies are machine-readable and closed.\n\n"
+                f"{dep_reason}"
+            ),
+        )
+        return
+
     type_label = next((l for l in labels if l.startswith("type:")), None)
     if type_label is None:
         if re.search(r"\bdocs?\b", title + "\n" + body, re.I):
@@ -856,6 +870,13 @@ def role_builder(repo: str, issue: int, brief: Path) -> None:
     data = get_issue(repo, issue)
     title = data.get("title") or f"issue-{issue}"
     body = data.get("body") or ""
+
+    # Do not invent stand-in schemas while upstream issues are still open (#204).
+    dep_reason = dependency_block_reason(repo, issue, body=body)
+    if dep_reason:
+        escalate(repo, issue, dep_reason)
+        write_builder_handoff("blocked")
+        return
 
     # Ops / verify issues: run smoke against production; no stub PR (avoids
     # reviewer↔builder loops on worklog-only PRs).
@@ -1031,6 +1052,13 @@ def role_docs(repo: str, issue: int, brief: Path) -> None:
     data = get_issue(repo, issue)
     title = data.get("title") or f"issue-{issue}"
     body = data.get("body") or ""
+
+    dep_reason = dependency_block_reason(repo, issue, body=body)
+    if dep_reason:
+        escalate(repo, issue, dep_reason)
+        write_docs_handoff("blocked")
+        return
+
     # Prefer existing linked PR head (including after review:changes-requested).
     prs = linked_open_prs(repo, issue)
     if prs:
@@ -1178,6 +1206,31 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
     }
     is_docs_issue = "type:docs" in issue_labels
     implementer = "Docs" if is_docs_issue else "Builder"
+
+    # Open / unstructured dependencies: terminal block, do not requeue Builder (#204).
+    dep_reason = dependency_block_reason(
+        repo, issue, body=issue_data_early.get("body") or ""
+    )
+    if dep_reason:
+        body = (
+            "### reviewer_decision\n"
+            "- decision: `blocked`\n"
+            "- terminal: true\n"
+            f"- brief: `{brief}`\n"
+            "- hard_fails:\n"
+            f"  - open dependencies: {dep_reason}\n"
+        )
+        api(
+            "POST",
+            f"/repos/{owner}/{name}/pulls/{pr_number}/reviews",
+            body={
+                "commit_id": pr["head"]["sha"],
+                "event": "REQUEST_CHANGES",
+                "body": body,
+            },
+        )
+        post_issue_comment(repo, issue, body)
+        return
 
     # Merge conflicts first — return to implementing agent; skip the rest.
     try:

--- a/tests/test_dispatch_queue.py
+++ b/tests/test_dispatch_queue.py
@@ -200,3 +200,72 @@ def test_list_awaiting_dispatch_orders_by_earliest_due(
 
     assert [i["number"] for i in awaiting] == [202, 201]
     assert skipped == []
+
+
+@pytest.mark.unit
+def test_dispatch_next_skips_open_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dispatch_queue import dispatch_next
+
+    monkeypatch.setattr(
+        "dispatch_queue.list_awaiting_dispatch",
+        lambda repo: (
+            [
+                {
+                    "number": 204,
+                    "body": "Depends on: #199\n",
+                    "labels": [
+                        {"name": "status:queued"},
+                        {"name": "type:feature"},
+                        {"name": "priority:low"},
+                    ],
+                    "milestone": {"title": "WorldGraph"},
+                },
+                {
+                    "number": 210,
+                    "body": "## Dependencies\nNone\n",
+                    "labels": [
+                        {"name": "status:queued"},
+                        {"name": "type:feature"},
+                        {"name": "priority:normal"},
+                    ],
+                    "milestone": {"title": "WorldGraph"},
+                },
+            ],
+            [],
+        ),
+    )
+    monkeypatch.setattr("dispatch_queue.agent_in_progress", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        "dispatch_queue.dependency_block_reason",
+        lambda repo, number, body="": (
+            f"#{number} is blocked by open dependencies: #199"
+            if number == 204
+            else None
+        ),
+    )
+    monkeypatch.setattr("dispatch_queue._recent_dispatcher_skip", lambda *_a, **_k: False)
+    comments: list[tuple[int, str]] = []
+    monkeypatch.setattr(
+        "dispatch_queue.post_issue_comment",
+        lambda repo, number, body: comments.append((number, body)),
+    )
+    monkeypatch.setattr("dispatch_queue.ensure_priority", lambda *_a, **_k: "priority:normal")
+    monkeypatch.setattr("dispatch_queue.delete_label", lambda *_a, **_k: None)
+    monkeypatch.setattr("dispatch_queue.add_labels", lambda *_a, **_k: None)
+
+    result = dispatch_next("o/r", dry_run=False)
+
+    assert result["skipped_deps"][0]["issue"] == 204
+    assert result["dispatched"] == [
+        {
+            "issue": 210,
+            "agent": "agent:builder",
+            "priority": "priority:normal",
+            "milestone": "WorldGraph",
+        }
+    ]
+    assert comments[0][0] == 204
+    assert "### dispatcher_skip" in comments[0][1]
+    assert any("### dispatcher_dispatch" in body for _, body in comments)

--- a/tests/test_issue_deps.py
+++ b/tests/test_issue_deps.py
@@ -1,0 +1,146 @@
+"""Unit tests for issue dependency guards (#204)."""
+
+from __future__ import annotations
+
+import pytest
+
+from github_api import GitHubError
+from issue_deps import (
+    dependency_block_reason,
+    has_unstructured_dependencies,
+    open_dependency_blockers,
+    parse_dependency_issue_numbers,
+    require_dependencies_met,
+)
+
+
+@pytest.mark.unit
+def test_parse_depends_on_line() -> None:
+    body = "Summary\n\nDepends on: #199, #200\n\n## Acceptance criteria\n- [ ] done\n"
+    assert parse_dependency_issue_numbers(body) == [199, 200]
+
+
+@pytest.mark.unit
+def test_parse_blocked_by_line_and_urls() -> None:
+    body = (
+        "Blocked by: https://github.com/saberistic-team/agent-web/issues/199 "
+        "and #200\n"
+    )
+    assert parse_dependency_issue_numbers(body) == [199, 200]
+
+
+@pytest.mark.unit
+def test_parse_dependencies_section_refs() -> None:
+    body = (
+        "## Dependencies\n"
+        "- Manifest: #199\n"
+        "- Corpus: #200\n"
+        "\n"
+        "## Acceptance criteria\n"
+        "- [ ] x\n"
+    )
+    assert parse_dependency_issue_numbers(body) == [199, 200]
+
+
+@pytest.mark.unit
+def test_parse_none_dependencies() -> None:
+    assert parse_dependency_issue_numbers("## Dependencies\nNone\n") == []
+    assert parse_dependency_issue_numbers("Depends on: N/A\n") == []
+    assert not has_unstructured_dependencies("## Dependencies\nNone\n")
+    assert not has_unstructured_dependencies("## Dependencies\nN/A\n")
+
+
+@pytest.mark.unit
+def test_unstructured_dependencies_like_issue_204() -> None:
+    body = (
+        "## Dependencies\n"
+        "\n"
+        "Start only after Manifest v0, the research corpus, and the MVP "
+        "requirements are stable enough to test. If dispatched earlier, "
+        "return the issue to planning rather than guessing the schema.\n"
+    )
+    assert has_unstructured_dependencies(body)
+    assert parse_dependency_issue_numbers(body) == []
+
+
+@pytest.mark.unit
+def test_provisional_exemption_clears_unstructured() -> None:
+    body = (
+        "## Dependencies\n"
+        "Provisional OK — spike may use fixture schema.\n"
+    )
+    assert not has_unstructured_dependencies(body)
+
+
+@pytest.mark.unit
+def test_open_blockers_from_body_skips_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("issue_deps.fetch_github_blocked_by", lambda *_a, **_k: [])
+    states = {
+        199: {"number": 199, "title": "Manifest", "state": "open"},
+        200: {"number": 200, "title": "Corpus", "state": "closed"},
+    }
+    monkeypatch.setattr(
+        "issue_deps._issue_state",
+        lambda repo, number: states[number],
+    )
+    blockers = open_dependency_blockers(
+        "o/r",
+        204,
+        body="Depends on: #199, #200\n",
+    )
+    assert [b["number"] for b in blockers] == [199]
+    assert blockers[0]["source"] == "body"
+
+
+@pytest.mark.unit
+def test_open_blockers_from_github_blocked_by(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "issue_deps.fetch_github_blocked_by",
+        lambda *_a, **_k: [
+            {"number": 199, "title": "Manifest", "state": "OPEN"},
+            {"number": 198, "title": "Done", "state": "CLOSED"},
+        ],
+    )
+    blockers = open_dependency_blockers("o/r", 204, body="")
+    assert [b["number"] for b in blockers] == [199]
+    assert blockers[0]["source"] == "blocked_by"
+
+
+@pytest.mark.unit
+def test_dependency_block_reason_unstructured() -> None:
+    body = (
+        "## Dependencies\n"
+        "Start only after Manifest v0 and the research corpus are stable.\n"
+    )
+    reason = dependency_block_reason("o/r", 204, body=body)
+    assert reason is not None
+    assert "machine-readable" in reason
+
+
+@pytest.mark.unit
+def test_require_dependencies_met_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("issue_deps.fetch_github_blocked_by", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "issue_deps._issue_state",
+        lambda *_a, **_k: {"number": 199, "title": "Manifest", "state": "open"},
+    )
+    with pytest.raises(GitHubError, match="#199"):
+        require_dependencies_met("o/r", 204, body="Depends on: #199\n")
+
+
+@pytest.mark.unit
+def test_require_dependencies_met_ok_when_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("issue_deps.fetch_github_blocked_by", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "issue_deps._issue_state",
+        lambda *_a, **_k: {"number": 199, "title": "Manifest", "state": "closed"},
+    )
+    require_dependencies_met("o/r", 204, body="Depends on: #199\n")

--- a/tests/test_review_decision.py
+++ b/tests/test_review_decision.py
@@ -124,6 +124,25 @@ def test_resolve_blocks_terminal_marker() -> None:
     )
 
 
+def test_resolve_blocks_open_dependencies() -> None:
+    body = (
+        "### reviewer_decision\n"
+        "- decision: `blocked`\n"
+        "- terminal: true\n"
+        "- hard_fails:\n"
+        "  - open dependencies: #204 is blocked by open dependencies: #199\n"
+    )
+    assert not is_fixable_changes_requested(body)
+    assert (
+        resolve_decision(
+            latest_state="CHANGES_REQUESTED",
+            latest_body=body,
+            prior_changes_requested=0,
+        )
+        == "blocked"
+    )
+
+
 def test_resolve_blocks_judgment_ping_pong() -> None:
     body = "### reviewer_decision\n- hard_fails:\n  - product judgment: wrong positioning\n"
     assert (


### PR DESCRIPTION
## Summary
- Add `scripts/issue_deps.py` to parse `Depends on: #N`, `## Dependencies` refs, and GitHub `blockedBy`, and fail closed on prose-only dependency sections (learned from #204).
- Wire enforcement through dispatcher skip, Planner/Builder/Docs block, Reviewer terminal `blocked`, and Gate merge (`acceptance.py --mode require`).
- Document the intake rule in AGENTS briefs + `docs/LABELS.md`, with unit coverage for parse/dispatch/review paths.

## Test plan
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_issue_deps.py tests/test_dispatch_queue.py tests/test_review_decision.py -q`
- [ ] Confirm a queued issue with `Depends on: #<open>` gets `### dispatcher_skip` and is not labeled `agent:*`
- [ ] Confirm Planner sets `status:blocked` for a prose-only `## Dependencies` section
- [ ] Confirm Gate `require` fails while an upstream dependency issue is still open


Made with [Cursor](https://cursor.com)