### PR TITLE
fix: protect scripts/issue_deps.py in workflow governance

### DIFF
--- a/.github/workflow-governance-paths.json
+++ b/.github/workflow-governance-paths.json
@@ -18,6 +18,10 @@
       "category": "orchestration dispatch"
     },
     {
+      "path": "scripts/issue_deps.py",
+      "category": "issue dependency gates"
+    },
+    {
       "path": "scripts/require_planner_plan.py",
       "category": "planner gate"
     },

--- a/tests/test_workflow_governance.py
+++ b/tests/test_workflow_governance.py
@@ -266,6 +266,7 @@ def test_required_privileged_scripts_are_manifest_protected() -> None:
         "scripts/github_api.py",
         "scripts/copilot_agent.py",
         "scripts/dispatch_queue.py",
+        "scripts/issue_deps.py",
         "scripts/require_planner_plan.py",
         "scripts/priority.py",
         "scripts/project_sync.py",


### PR DESCRIPTION
## Summary
- Main CI has been failing on `Validate workflow-governance ownership` with: `workflow-invoked or transitive orchestration script is not protected: scripts/issue_deps.py`
- `#415` added `scripts/issue_deps.py` and wired it into dispatcher/agent orchestration, but did not add it to `.github/workflow-governance-paths.json`
- This PR adds the protected-path entry and asserts it in the governance tests

## Test plan
- [x] `python scripts/validate_workflow_governance.py` passes locally
- [x] `pytest tests/test_workflow_governance.py` passes
- [x] CI `test` job green on this PR
- [x] After merge, main CI no longer fails on workflow-governance ownership
