### PR TITLE
fix(reviewer): allow spike/ on type:docs PRs

### DIFF
--- a/AGENTS/reviewer.md
+++ b/AGENTS/reviewer.md
@@ -78,9 +78,12 @@ not apply; **do** enforce objectives.
 3. Reject stub-only heads: if the PR is only `docs/agent-updates/<n>.md` (or
    equivalent placeholder) without the deliverable files the issue required,
    `REQUEST_CHANGES` citing “return to Docs”.
-4. Reject product-scoped changes on a docs issue (`app/`, routes, DB,
-   migrations, public marketing routes) — `REQUEST_CHANGES` / escalate to
-   Planner unless the issue explicitly allowed them.
+4. Reject product-scoped changes on a docs issue (`app/`, `site/`, routes via
+   those trees, DB migrations, public marketing surfaces) — `REQUEST_CHANGES` /
+   escalate to Planner unless the issue explicitly allowed them. Supporting
+   WorldGraph research code under `spike/` (and `docs/` / `tests/` / `scripts/`
+   / `AGENTS/`) is in scope for docs issues when it keeps schema fixtures
+   honest; do not hard-fail solely for `spike/` edits.
 5. Reject invented APIs or behavior that the repo does not implement when the
    issue asked to document current/research decisions only.
 
@@ -143,8 +146,9 @@ Any of these is an automatic request-changes — do not approve:
   glitch.
 - **Docs stub-only** (`type:docs`): PR lacks the issue’s required deliverable
   files (only `docs/agent-updates/` placeholder) — return to Docs
-- **Docs out-of-scope product code** (`type:docs`): unexpected `app/` / route /
-  migration changes — return to Docs or escalate
+- **Docs out-of-scope product code** (`type:docs`): unexpected `app/` / `site/` /
+  migration changes (or other executable code outside `docs/`, `AGENTS/`,
+  `scripts/`, `tests/`, and `spike/`) — return to Docs or escalate
 
 ### Product / Builder-only hard fails
 

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -866,6 +866,27 @@ def is_landing_issue(title: str, body: str) -> bool:
     )
 
 
+def docs_out_of_scope_product_paths(filenames: list[str]) -> list[str]:
+    """Return paths that a ``type:docs`` PR must not change.
+
+    Docs issues may ship markdown/specs plus supporting research fixtures under
+    ``docs/``, agent briefs, orchestration ``scripts/``, tests, and WorldGraph
+    ``spike/`` helpers that keep schema fixtures honest. Product surfaces
+    (``app/``, ``site/``, ``migrations/``) and other unexpected executable code
+    remain hard fails.
+    """
+    allowed_prefixes = ("docs/", "AGENTS/", "scripts/", "tests/", "spike/")
+    return [
+        name
+        for name in filenames
+        if name.startswith(("app/", "site/", "migrations/"))
+        or (
+            name.endswith((".py", ".ts", ".js"))
+            and not name.startswith(allowed_prefixes)
+        )
+    ]
+
+
 def role_builder(repo: str, issue: int, brief: Path) -> None:
     data = get_issue(repo, issue)
     title = data.get("title") or f"issue-{issue}"
@@ -1368,15 +1389,7 @@ def role_reviewer(repo: str, issue: int, brief: Path) -> None:
                 "docs PR is agent-updates stub only — required deliverable "
                 "files missing; return to Docs"
             )
-        product_paths = [
-            name
-            for name in filenames
-            if name.startswith(("app/", "site/", "migrations/"))
-            or (
-                name.endswith((".py", ".ts", ".js"))
-                and not name.startswith(("docs/", "AGENTS/", "scripts/", "tests/"))
-            )
-        ]
+        product_paths = docs_out_of_scope_product_paths(filenames)
         if product_paths:
             hard_fail_reasons.append(
                 "type:docs PR includes product code paths "

--- a/tests/test_docs_product_path_allowlist.py
+++ b/tests/test_docs_product_path_allowlist.py
@@ -1,0 +1,56 @@
+"""Docs PR path allowlist for reviewer hard-fails."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_AGENT_PATH = REPO_ROOT / "scripts" / "run_agent.py"
+
+
+@pytest.fixture(scope="module")
+def run_agent_module():
+    spec = importlib.util.spec_from_file_location("run_agent_under_test", RUN_AGENT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_docs_out_of_scope_allows_spike_and_docs_support(run_agent_module) -> None:
+    allowed = [
+        "docs/worldgraph/WORLD_DEFINITION.md",
+        "docs/worldgraph/world-manifest-v0.schema.json",
+        "spike/worldgraph/deterministic_extractor.py",
+        "spike/worldgraph/manifest_schema.py",
+        "tests/test_worldgraph_manifest_v0.py",
+        "scripts/run_agent.py",
+        "AGENTS/docs.md",
+    ]
+    assert run_agent_module.docs_out_of_scope_product_paths(allowed) == []
+
+
+@pytest.mark.unit
+def test_docs_out_of_scope_flags_app_site_migrations_and_stray_code(
+    run_agent_module,
+) -> None:
+    flagged = run_agent_module.docs_out_of_scope_product_paths(
+        [
+            "app/main.py",
+            "site/assets/app.js",
+            "migrations/023_example.sql",
+            "tools/helper.py",
+            "docs/ok.md",
+            "spike/worldgraph/deterministic_extractor.py",
+        ]
+    )
+    assert flagged == [
+        "app/main.py",
+        "site/assets/app.js",
+        "migrations/023_example.sql",
+        "tools/helper.py",
+    ]


### PR DESCRIPTION
## Summary
- Exempt `spike/` from the `type:docs` product-path hard-fail in `scripts/run_agent.py` (reviewer runs this from `main`)
- Align `AGENTS/reviewer.md` so WorldGraph spike helpers are in-scope for docs issues
- Add unit coverage for the allowlist

Unblocks docs PRs like #410 that need spike extractor/schema helpers to keep World Manifest fixtures honest, without permitting `app/` / `site/` / `migrations/` changes.

## Test plan
- [x] `pytest tests/test_docs_product_path_allowlist.py -q`
- [x] After merge to `main`, re-apply `agent:reviewer` on #410 and confirm the spike hard-fail is gone


Made with [Cursor](https://cursor.com)