### PR TITLE
fix: reconcile GitHub issue deps before queue and dispatch

### DIFF
--- a/AGENTS/planner.md
+++ b/AGENTS/planner.md
@@ -38,17 +38,25 @@ Prose-only “start after Manifest / corpus …” is **not** enough (learned fr
 [#204](https://github.com/saberistic-team/agent-web/issues/204)). Before
 `status:queued`:
 
-1. Prefer GitHub **blocked by** links on the issue, **and/or**
+1. Prefer GitHub **blocked by** / **blocking** and **parent / sub-issue** links
 2. Add an explicit body line: `Depends on: #199, #200` (or
-   `## Dependencies` containing only those refs / `None` / `N/A`).
+   `## Dependencies` containing only those refs / `None` / `N/A`)
+3. When spawning children, GitHub parent/child must be set (`addSubIssue`) so
+   open children block the parent from dequeue
 
-If a `## Dependencies` section has narrative text but **no** `#N` refs, do
-**not** queue — rewrite to `Depends on:` or set `status:blocked` with
-`@human-review`. Do not invent stand-in schemas so a later spike can “guess”
-upstream docs.
+Planner and Dispatcher run `reconcile_issue_dependencies` (`scripts/issue_deps.py`):
+they read related issues/PRs, derive missing deps from strong ordering phrases
+and linked PR bodies, then **write** missing `blockedBy` / sub-issue links and
+sync `Depends on:` before queue / dequeue. A `### dependency_reconcile` comment
+records what was added.
 
-Dispatcher (`scripts/dispatch_queue.py`) and Builder/Docs/Reviewer/Gate all
-enforce the same rules via `scripts/issue_deps.py`.
+If a `## Dependencies` section has narrative text but **no** `#N` refs (and
+reconcile cannot infer any), do **not** queue — rewrite to `Depends on:` or set
+`status:blocked` with `@human-review`. Do not invent stand-in schemas so a later
+spike can “guess” upstream docs.
+
+Builder/Docs/Reviewer/Gate enforce the same closed-deps rules via
+`scripts/issue_deps.py`.
 
 Humans open/close milestones to mark the current phase. You assign issues to an
 open milestone (prefer the parent’s open milestone, else the earliest-due open

--- a/docs/IDENTITIES.md
+++ b/docs/IDENTITIES.md
@@ -80,6 +80,7 @@ Every agent action must produce a **visible GitHub event** under the role bot:
 | `### planner_plan` / `### planner_release` | Issue comment (required before queue) |
 | `### dispatcher_dispatch` | Issue comment when the priority queue applies `agent:builder` / `agent:docs` |
 | `### dispatcher_skip` | Issue comment when queued work is skipped for open / unstructured dependencies (`scripts/issue_deps.py`) |
+| `### dependency_reconcile` | Issue comment when Planner/Dispatcher add missing `blockedBy` / sub-issue links or sync `Depends on:` |
 | `### permission_check` | Issue comment (pass **and** fail) |
 | `### gate_release_plan` / `### gate_merge` | Issue comment |
 | Builder/Docs commits + PRs | Commits/PRs as Builder/Docs App |

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -155,13 +155,20 @@ before Dispatcher starts Builder/Docs:
 
 | Form | Example |
 |------|---------|
-| GitHub blockedBy | Issue A “blocked by” issue B in the GitHub UI |
+| GitHub blockedBy / blocking | Issue A “blocked by” issue B in the GitHub UI |
+| Parent / sub-issue | Child linked under parent; open children block the parent |
 | Body line | `Depends on: #199, #200` |
 | Section | `## Dependencies` containing `#199` refs, or `None` / `N/A` |
 
-A `## Dependencies` section with narrative prose and **no** `#N` refs is
-unstructured — Planner sets `status:blocked`; Dispatcher skips; Gate refuses
-merge (`scripts/issue_deps.py`, learned from #204).
+Planner and Dispatcher **reconcile** missing links before queue/dequeue: they
+read the issue, related issues, and linked PRs, derive blockers from strong
+ordering phrases, then add GitHub `blockedBy` / sub-issue edges and sync
+`Depends on:` (`scripts/issue_deps.py`). A `### dependency_reconcile` comment
+records writes.
+
+A `## Dependencies` section with narrative prose and **no** `#N` refs (and no
+inferable numbers) is unstructured — Planner sets `status:blocked`; Dispatcher
+skips; Gate refuses merge (learned from #204).
 
 ---
 

--- a/scripts/dispatch_queue.py
+++ b/scripts/dispatch_queue.py
@@ -30,6 +30,8 @@ from github_api import (
 from issue_deps import (
     dependency_block_reason,
     dispatcher_skip_comment,
+    reconcile_comment,
+    reconcile_issue_dependencies,
 )
 from milestones import (
     dispatch_sort_key,
@@ -190,9 +192,33 @@ def dispatch_next(repo: str, *, dry_run: bool = False) -> dict[str, Any]:
             )
             continue
 
-        dep_reason = dependency_block_reason(
-            repo, number, body=issue.get("body") or ""
-        )
+        # Derive + write missing blockedBy / parent-child / Depends-on before
+        # deciding whether this queued issue may start.
+        reconcile_summary: dict[str, Any]
+        if dry_run:
+            reconcile_summary = {
+                "body": issue.get("body") or "",
+                "blockers": [],
+                "added_blocked_by": [],
+                "added_sub_issues": [],
+                "body_updated": False,
+            }
+            dep_reason = dependency_block_reason(
+                repo, number, body=issue.get("body") or "", reconcile=False
+            )
+        else:
+            reconcile_summary = reconcile_issue_dependencies(
+                repo, number, body=issue.get("body") or "", write=True
+            )
+            note = reconcile_comment(reconcile_summary)
+            if note:
+                post_issue_comment(repo, number, note)
+            dep_reason = dependency_block_reason(
+                repo,
+                number,
+                body=str(reconcile_summary.get("body") or issue.get("body") or ""),
+                reconcile=False,
+            )
         if dep_reason:
             skipped_deps.append(
                 {
@@ -200,6 +226,11 @@ def dispatch_next(repo: str, *, dry_run: bool = False) -> dict[str, Any]:
                     "agent": agent,
                     "reason": "open_dependencies",
                     "detail": dep_reason,
+                    "reconcile": {
+                        "added_blocked_by": reconcile_summary.get("added_blocked_by"),
+                        "added_sub_issues": reconcile_summary.get("added_sub_issues"),
+                        "body_updated": reconcile_summary.get("body_updated"),
+                    },
                 }
             )
             if not dry_run and not _recent_dispatcher_skip(repo, number):

--- a/scripts/issue_deps.py
+++ b/scripts/issue_deps.py
@@ -4,10 +4,14 @@
 Machine-readable dependencies are required before Planner queues work and
 before Dispatcher / Builder / Docs / Reviewer / Gate proceed:
 
-- GitHub ``blockedBy`` relationships (preferred)
+- GitHub ``blockedBy`` / ``blocking`` relationships (preferred)
+- GitHub parent / sub-issue links
 - Explicit body lines: ``Depends on: #199, #200`` / ``Blocked by: #199``
-- Issue refs (``#N`` or full issue URLs) inside a ``## Dependencies`` /
-  ``## Dependency`` section
+- Issue refs inside a ``## Dependencies`` / ``## Dependency`` section
+
+Planner and Dispatcher call ``reconcile_issue_dependencies`` so missing
+GitHub links are derived from the issue body, linked PRs, and parent/child
+relationships, then written back before queue / dequeue decisions.
 
 A non-empty ``## Dependencies`` section with **no** parseable issue numbers is
 treated as unstructured and fail-closed (Planner must rewrite to ``Depends on:``
@@ -22,7 +26,7 @@ import re
 import sys
 from typing import Any
 
-from github_api import GitHubError, api, graphql, split_repo
+from github_api import GitHubError, api, graphql, linked_open_prs, split_repo
 
 DEPENDS_ON_LINE_RE = re.compile(
     r"(?im)^(?:depends\s+on|blocked\s+by|blockers?)\s*:?\s*(.+)$"
@@ -36,6 +40,26 @@ DEPENDENCIES_SECTION_RE = re.compile(
 _NONE_RE = re.compile(r"(?is)^\s*(?:none|n/?a|no\s+dependencies?)\s*\.?\s*$")
 _PROVISIONAL_OK_RE = re.compile(
     r"(?is)\b(?:provisional\s+(?:ok|allowed)|deps?\s+exempt|dependency\s+exempt)\b"
+)
+# Strong ordering phrases that mention an issue number nearby.
+_INFER_DEP_RE = re.compile(
+    r"(?is)(?:"
+    r"depends\s+on|blocked\s+by|blockers?|requires|prerequisite|"
+    r"complete\s+after|start\s+only\s+after|blocked\s+until|"
+    r"must\s+wait\s+(?:for|until)|after\s+completing|"
+    r"use(?:s|ing)?\s+(?:the\s+)?.{0,80}?\s+from|"
+    r"produced\s+by|from\s+the\s+earlier"
+    r").{0,120}?(?:https://github\.com/[^/\s]+/[^/\s]+/issues/|#)(\d+)\b"
+    r"|"
+    r"(?:https://github\.com/[^/\s]+/[^/\s]+/issues/|#)(\d+)\b.{0,60}?"
+    r"(?:must|should)\s+(?:land|merge|close|complete|ship)\s+first"
+)
+_PARENT_LINE_RE = re.compile(
+    r"(?im)^(?:parent|parent\s+issue|child\s+of|sub-?issue\s+of)\s*:?\s*.{0,40}?"
+    r"(?:https://github\.com/[^/\s]+/[^/\s]+/issues/|#)(\d+)\b"
+)
+_CHILD_OF_COMMENT_RE = re.compile(
+    r"(?i)(?:child\s+of|queued\s+as\s+one-commit\s+child\s+of)\s+#(\d+)"
 )
 
 
@@ -73,6 +97,30 @@ def parse_dependency_issue_numbers(body: str) -> list[int]:
     return found
 
 
+def infer_dependency_issue_numbers(body: str) -> list[int]:
+    """Infer dependency issue numbers from strong ordering phrases in prose."""
+    found: list[int] = []
+    seen: set[int] = set(parse_dependency_issue_numbers(body))
+    for match in _INFER_DEP_RE.finditer(body or ""):
+        raw = match.group(1) or match.group(2)
+        if not raw:
+            continue
+        number = int(raw)
+        if number in seen:
+            continue
+        seen.add(number)
+        found.append(number)
+    return found
+
+
+def parse_parent_issue_number(body: str) -> int | None:
+    """Return an explicit parent issue number from the body, if any."""
+    match = _PARENT_LINE_RE.search(body or "")
+    if match:
+        return int(match.group(1))
+    return None
+
+
 def has_unstructured_dependencies(body: str) -> bool:
     """True when a Dependencies section has prose but no issue refs.
 
@@ -87,24 +135,36 @@ def has_unstructured_dependencies(body: str) -> bool:
         return False
     if _PROVISIONAL_OK_RE.search(section):
         return False
-    if parse_dependency_issue_numbers(
-        f"## Dependencies\n{section}\n"
-    ):
+    if parse_dependency_issue_numbers(f"## Dependencies\n{section}\n"):
+        return False
+    if infer_dependency_issue_numbers(f"## Dependencies\n{section}\n"):
         return False
     # Non-empty prose without refs — fail closed (#204).
     return len(section) >= 12
 
 
-def fetch_github_blocked_by(repo: str, issue: int) -> list[dict[str, Any]]:
-    """Return GitHub ``blockedBy`` nodes for ``issue`` (may be empty)."""
+def fetch_issue_relationships(repo: str, issue: int) -> dict[str, Any]:
+    """Load GitHub blockedBy/blocking/parent/subIssues plus body for ``issue``."""
     owner, name = split_repo(repo)
     data = graphql(
         """
         query($owner: String!, $name: String!, $number: Int!) {
           repository(owner: $owner, name: $name) {
             issue(number: $number) {
-              blockedBy(first: 20) {
-                nodes { number title state }
+              id
+              number
+              title
+              state
+              body
+              parent { number title state id }
+              blockedBy(first: 30) {
+                nodes { id number title state }
+              }
+              blocking(first: 30) {
+                nodes { id number title state }
+              }
+              subIssues(first: 30) {
+                nodes { id number title state }
               }
             }
           }
@@ -112,8 +172,19 @@ def fetch_github_blocked_by(repo: str, issue: int) -> list[dict[str, Any]]:
         """,
         {"owner": owner, "name": name, "number": int(issue)},
     )
-    issue_data = ((data or {}).get("repository") or {}).get("issue") or {}
-    nodes = ((issue_data.get("blockedBy") or {}).get("nodes")) or []
+    issue_data = ((data or {}).get("repository") or {}).get("issue")
+    if not issue_data:
+        raise GitHubError(f"issue #{issue} not found in {repo}")
+    return issue_data
+
+
+def fetch_github_blocked_by(repo: str, issue: int) -> list[dict[str, Any]]:
+    """Return GitHub ``blockedBy`` nodes for ``issue`` (may be empty)."""
+    try:
+        rel = fetch_issue_relationships(repo, issue)
+    except GitHubError:
+        return []
+    nodes = ((rel.get("blockedBy") or {}).get("nodes")) or []
     return [node for node in nodes if node and node.get("number") is not None]
 
 
@@ -124,6 +195,309 @@ def _issue_state(repo: str, number: int) -> dict[str, Any]:
         "number": int(number),
         "title": data.get("title") or "",
         "state": (data.get("state") or "open").lower(),
+        "id": data.get("node_id"),
+        "body": data.get("body") or "",
+    }
+
+
+def _node_state(node: dict[str, Any]) -> str:
+    return str(node.get("state") or "OPEN").lower()
+
+
+def _issue_node_id(repo: str, number: int) -> str:
+    rel = fetch_issue_relationships(repo, number)
+    node_id = rel.get("id")
+    if not node_id:
+        raise GitHubError(f"missing node id for #{number}")
+    return str(node_id)
+
+
+def add_blocked_by_link(repo: str, issue: int, blocking_issue: int) -> str:
+    """Ensure ``issue`` is blocked by ``blocking_issue``. Returns ok|exists|fail."""
+    if int(issue) == int(blocking_issue):
+        return "skip_self"
+    try:
+        graphql(
+            """
+            mutation($input: AddBlockedByInput!) {
+              addBlockedBy(input: $input) { issue { number } }
+            }
+            """,
+            {
+                "input": {
+                    "issueId": _issue_node_id(repo, issue),
+                    "blockingIssueId": _issue_node_id(repo, blocking_issue),
+                }
+            },
+        )
+        return "ok"
+    except GitHubError as exc:
+        msg = str(exc).lower()
+        if "already been taken" in msg or "already" in msg:
+            return "exists"
+        return f"fail:{exc}"
+
+
+def add_sub_issue_link(repo: str, parent: int, child: int) -> str:
+    """Ensure ``child`` is a GitHub sub-issue of ``parent``."""
+    if int(parent) == int(child):
+        return "skip_self"
+    try:
+        graphql(
+            """
+            mutation($input: AddSubIssueInput!) {
+              addSubIssue(input: $input) {
+                issue { number }
+                subIssue { number }
+              }
+            }
+            """,
+            {
+                "input": {
+                    "issueId": _issue_node_id(repo, parent),
+                    "subIssueId": _issue_node_id(repo, child),
+                    "replaceParent": False,
+                }
+            },
+        )
+        return "ok"
+    except GitHubError as exc:
+        msg = str(exc).lower()
+        if "already" in msg or "duplicate" in msg:
+            return "exists"
+        return f"fail:{exc}"
+
+
+def sync_depends_on_body(repo: str, issue: int, blockers: list[int], body: str) -> str:
+    """Rewrite/insert a machine-readable Depends on line; return updated body."""
+    blockers = sorted({int(n) for n in blockers if int(n) != int(issue)})
+    if not blockers:
+        return body
+    deps_line = "Depends on: " + ", ".join(f"#{n}" for n in blockers)
+    section = (
+        "## Dependencies\n\n"
+        f"{deps_line}\n\n"
+        "Derived/maintained for dispatcher and reviewer "
+        "(`scripts/issue_deps.py`).\n"
+    )
+    text = body or ""
+    if re.search(r"(?im)^##\s*dependenc(?:y|ies)\s*$", text):
+        updated, count = re.subn(
+            r"(?is)##\s*dependenc(?:y|ies)\s*\n.*?(?=\n##\s|\Z)",
+            section.rstrip() + "\n\n",
+            text,
+            count=1,
+        )
+        if count:
+            return updated
+    if DEPENDS_ON_LINE_RE.search(text):
+        return DEPENDS_ON_LINE_RE.sub(deps_line, text, count=1)
+    match = re.search(r"(?im)^##\s*acceptance criteria\s*$", text)
+    if match:
+        return text[: match.start()] + section + "\n" + text[match.start() :]
+    return text.rstrip() + "\n\n" + section
+
+
+def _patch_issue_body(repo: str, issue: int, body: str) -> None:
+    owner, name = split_repo(repo)
+    api(
+        "PATCH",
+        f"/repos/{owner}/{name}/issues/{int(issue)}",
+        body={"body": body},
+    )
+
+
+def _collect_pr_inferred_deps(repo: str, issue: int) -> list[int]:
+    """Infer dependency numbers from intentionally linked open PR bodies/titles."""
+    found: list[int] = []
+    seen: set[int] = set()
+    try:
+        prs = linked_open_prs(repo, issue)
+    except GitHubError:
+        return []
+    for pr in prs:
+        blob = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+        for number in parse_dependency_issue_numbers(blob) + infer_dependency_issue_numbers(
+            blob
+        ):
+            if number == int(issue) or number in seen:
+                continue
+            seen.add(number)
+            found.append(number)
+    return found
+
+
+def _parent_from_planner_comments(repo: str, issue: int) -> int | None:
+    """Detect parent from Planner child comments when GraphQL parent is missing."""
+    owner, name = split_repo(repo)
+    comments = (
+        api(
+            "GET",
+            f"/repos/{owner}/{name}/issues/{int(issue)}/comments?per_page=30",
+        )
+        or []
+    )
+    for comment in comments:
+        body = comment.get("body") or ""
+        match = _CHILD_OF_COMMENT_RE.search(body)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def desired_blockers(
+    repo: str,
+    issue: int,
+    *,
+    rel: dict[str, Any] | None = None,
+    body: str | None = None,
+) -> list[dict[str, Any]]:
+    """Compute desired blocker issues (open + closed) with sources."""
+    rel = rel or fetch_issue_relationships(repo, issue)
+    text = body if body is not None else (rel.get("body") or "")
+    desired: dict[int, dict[str, Any]] = {}
+
+    def _remember(number: int, source: str, meta: dict[str, Any] | None = None) -> None:
+        if int(number) == int(issue):
+            return
+        existing = desired.get(int(number))
+        if existing:
+            sources = set(existing.get("sources") or [])
+            sources.add(source)
+            existing["sources"] = sorted(sources)
+            return
+        info = dict(meta or {})
+        info.setdefault("number", int(number))
+        info["sources"] = [source]
+        desired[int(number)] = info
+
+    for node in ((rel.get("blockedBy") or {}).get("nodes")) or []:
+        _remember(int(node["number"]), "blocked_by", node)
+
+    for number in parse_dependency_issue_numbers(text):
+        _remember(number, "body")
+
+    for number in infer_dependency_issue_numbers(text):
+        _remember(number, "inferred_body")
+
+    for number in _collect_pr_inferred_deps(repo, issue):
+        _remember(number, "inferred_pr")
+
+    # Parent with open children must not dequeue until children finish.
+    for node in ((rel.get("subIssues") or {}).get("nodes")) or []:
+        if _node_state(node) == "open":
+            _remember(int(node["number"]), "open_sub_issue", node)
+
+    # Fill missing titles/states for body-only refs.
+    for number, info in list(desired.items()):
+        if info.get("title") and info.get("state"):
+            continue
+        try:
+            meta = _issue_state(repo, number)
+        except GitHubError:
+            continue
+        info.setdefault("title", meta.get("title") or "")
+        info.setdefault("state", meta.get("state") or "open")
+        if meta.get("id"):
+            info.setdefault("id", meta["id"])
+
+    return sorted(desired.values(), key=lambda item: int(item["number"]))
+
+
+def reconcile_issue_dependencies(
+    repo: str,
+    issue: int,
+    *,
+    body: str | None = None,
+    write: bool = True,
+) -> dict[str, Any]:
+    """Derive missing deps, optionally write GitHub links + body, return summary.
+
+    Always considers blockedBy/blocking/parent/subIssues. When ``write`` is true,
+    adds missing ``blockedBy`` and parent/child links and syncs ``Depends on:``.
+    """
+    try:
+        rel = fetch_issue_relationships(repo, issue)
+    except GitHubError as exc:
+        return {
+            "issue": int(issue),
+            "ok": False,
+            "error": str(exc),
+            "blockers": [],
+            "added_blocked_by": [],
+            "added_sub_issues": [],
+            "body_updated": False,
+        }
+
+    text = body if body is not None else (rel.get("body") or "")
+    desired = desired_blockers(repo, issue, rel=rel, body=text)
+    existing_bb = {
+        int(n["number"])
+        for n in ((rel.get("blockedBy") or {}).get("nodes") or [])
+        if n.get("number") is not None
+    }
+    added_bb: list[dict[str, Any]] = []
+    added_sub: list[dict[str, Any]] = []
+    body_updated = False
+
+    # Parent/child: prefer GraphQL parent, else body/planner comment.
+    parent = rel.get("parent") or {}
+    parent_number = int(parent["number"]) if parent.get("number") else None
+    if parent_number is None:
+        parent_number = parse_parent_issue_number(text) or _parent_from_planner_comments(
+            repo, issue
+        )
+        if write and parent_number is not None:
+            status = add_sub_issue_link(repo, parent_number, issue)
+            added_sub.append(
+                {"parent": parent_number, "child": int(issue), "status": status}
+            )
+
+    # Ensure each child spawned under this issue is linked (planner path).
+    # No-op when subIssues already present.
+
+    open_blockers: list[dict[str, Any]] = []
+    for item in desired:
+        number = int(item["number"])
+        state = str(item.get("state") or "open").lower()
+        if write and number not in existing_bb:
+            # Only create blockedBy for issues that still matter (open) or were
+            # explicitly declared — still link open ones; skip closed to avoid noise.
+            if state == "open":
+                status = add_blocked_by_link(repo, issue, number)
+                added_bb.append({"blocking": number, "status": status})
+                if status in {"ok", "exists"}:
+                    existing_bb.add(number)
+        if state == "open":
+            open_blockers.append(
+                {
+                    "number": number,
+                    "title": item.get("title") or "",
+                    "state": "open",
+                    "source": ",".join(item.get("sources") or []),
+                }
+            )
+
+    if write:
+        # Prefer declared+inferred open blockers + existing blockedBy for the body.
+        body_nums = sorted({int(b["number"]) for b in open_blockers} | existing_bb)
+        new_body = sync_depends_on_body(repo, issue, body_nums, text)
+        if new_body != text and body_nums:
+            _patch_issue_body(repo, issue, new_body)
+            body_updated = True
+            text = new_body
+
+    return {
+        "issue": int(issue),
+        "ok": True,
+        "parent": parent_number,
+        "desired": desired,
+        "blockers": open_blockers,
+        "added_blocked_by": added_bb,
+        "added_sub_issues": added_sub,
+        "body_updated": body_updated,
+        "unstructured": has_unstructured_dependencies(text),
+        "body": text,
     }
 
 
@@ -132,12 +506,16 @@ def open_dependency_blockers(
     issue: int,
     *,
     body: str | None = None,
+    reconcile: bool = False,
 ) -> list[dict[str, Any]]:
     """Return still-open blockers for ``issue``.
 
-    Combines GitHub ``blockedBy`` with body ``Depends on:`` / Dependencies
-    section refs. Closed dependencies are ignored.
+    When ``reconcile`` is true, derive/write missing GitHub relationships first.
     """
+    if reconcile:
+        summary = reconcile_issue_dependencies(repo, issue, body=body, write=True)
+        return list(summary.get("blockers") or [])
+
     if body is None:
         owner, name = split_repo(repo)
         issue_data = api("GET", f"/repos/{owner}/{name}/issues/{int(issue)}") or {}
@@ -148,8 +526,7 @@ def open_dependency_blockers(
     try:
         for node in fetch_github_blocked_by(repo, issue):
             number = int(node["number"])
-            state = str(node.get("state") or "OPEN").lower()
-            if state != "open":
+            if _node_state(node) != "open":
                 continue
             blockers[number] = {
                 "number": number,
@@ -158,13 +535,28 @@ def open_dependency_blockers(
                 "source": "blocked_by",
             }
     except GitHubError:
-        # GraphQL may be unavailable for some tokens; body refs still apply.
         pass
 
-    for number in parse_dependency_issue_numbers(body or ""):
-        if number == int(issue):
-            continue
-        if number in blockers:
+    # Also treat open sub-issues as blockers for a parent issue.
+    try:
+        rel = fetch_issue_relationships(repo, issue)
+        for node in ((rel.get("subIssues") or {}).get("nodes")) or []:
+            if _node_state(node) != "open":
+                continue
+            number = int(node["number"])
+            blockers[number] = {
+                "number": number,
+                "title": node.get("title") or "",
+                "state": "open",
+                "source": "open_sub_issue",
+            }
+    except GitHubError:
+        pass
+
+    for number in parse_dependency_issue_numbers(body or "") + infer_dependency_issue_numbers(
+        body or ""
+    ):
+        if number == int(issue) or number in blockers:
             continue
         meta = _issue_state(repo, number)
         if meta["state"] != "open":
@@ -185,22 +577,35 @@ def dependency_block_reason(
     issue: int,
     *,
     body: str | None = None,
+    reconcile: bool = False,
 ) -> str | None:
     """Human-readable reason when dependencies are unmet, else ``None``."""
-    if body is None:
-        owner, name = split_repo(repo)
-        issue_data = api("GET", f"/repos/{owner}/{name}/issues/{int(issue)}") or {}
-        body = issue_data.get("body") or ""
+    summary: dict[str, Any] | None = None
+    if reconcile:
+        summary = reconcile_issue_dependencies(repo, issue, body=body, write=True)
+        body = summary.get("body") or body
+        if summary.get("unstructured"):
+            return (
+                f"#{issue} has a ## Dependencies section without machine-readable "
+                "issue refs. Rewrite as `Depends on: #N, #M` (or `None` / `N/A`), "
+                "or set GitHub blockedBy links — do not invent stand-in schemas "
+                "(learned from #204)."
+            )
+        blockers = list(summary.get("blockers") or [])
+    else:
+        if body is None:
+            owner, name = split_repo(repo)
+            issue_data = api("GET", f"/repos/{owner}/{name}/issues/{int(issue)}") or {}
+            body = issue_data.get("body") or ""
+        if has_unstructured_dependencies(body or ""):
+            return (
+                f"#{issue} has a ## Dependencies section without machine-readable "
+                "issue refs. Rewrite as `Depends on: #N, #M` (or `None` / `N/A`), "
+                "or set GitHub blockedBy links — do not invent stand-in schemas "
+                "(learned from #204)."
+            )
+        blockers = open_dependency_blockers(repo, issue, body=body, reconcile=False)
 
-    if has_unstructured_dependencies(body or ""):
-        return (
-            f"#{issue} has a ## Dependencies section without machine-readable "
-            "issue refs. Rewrite as `Depends on: #N, #M` (or `None` / `N/A`), "
-            "or set GitHub blockedBy links — do not invent stand-in schemas "
-            "(learned from #204)."
-        )
-
-    blockers = open_dependency_blockers(repo, issue, body=body)
     if not blockers:
         return None
     refs = format_blocker_refs(blockers)
@@ -219,9 +624,10 @@ def require_dependencies_met(
     issue: int,
     *,
     body: str | None = None,
+    reconcile: bool = False,
 ) -> None:
     """Raise ``GitHubError`` when open or unstructured dependencies remain."""
-    reason = dependency_block_reason(repo, issue, body=body)
+    reason = dependency_block_reason(repo, issue, body=body, reconcile=reconcile)
     if reason:
         raise GitHubError(reason)
 
@@ -235,19 +641,61 @@ def dispatcher_skip_comment(issue: int, reason: str) -> str:
     )
 
 
+def reconcile_comment(summary: dict[str, Any]) -> str | None:
+    """Build an audit comment when reconcile wrote GitHub links / body."""
+    added_bb = [
+        item
+        for item in (summary.get("added_blocked_by") or [])
+        if item.get("status") == "ok"
+    ]
+    added_sub = [
+        item
+        for item in (summary.get("added_sub_issues") or [])
+        if item.get("status") == "ok"
+    ]
+    if not added_bb and not added_sub and not summary.get("body_updated"):
+        return None
+    lines = [
+        "### dependency_reconcile",
+        f"- issue: `#{summary.get('issue')}`",
+    ]
+    if added_bb:
+        refs = ", ".join(f"#{int(i['blocking'])}" for i in added_bb)
+        lines.append(f"- added_blocked_by: {refs}")
+    if added_sub:
+        for item in added_sub:
+            lines.append(
+                f"- added_sub_issue: `#{item['child']}` under `#{item['parent']}`"
+            )
+    if summary.get("body_updated"):
+        lines.append("- body: synced `Depends on:`")
+    blockers = summary.get("blockers") or []
+    if blockers:
+        lines.append(f"- open_blockers: {format_blocker_refs(blockers)}")
+    return "\n".join(lines) + "\n"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", required=True)
     parser.add_argument("--issue", type=int, required=True)
     parser.add_argument(
         "--mode",
-        choices=("check", "require"),
+        choices=("check", "require", "reconcile"),
         default="check",
-        help="check prints JSON; require exits non-zero when blocked",
+        help="check prints JSON; require exits non-zero when blocked; "
+        "reconcile writes missing GitHub links then prints JSON",
     )
     args = parser.parse_args(argv)
 
     try:
+        if args.mode == "reconcile":
+            summary = reconcile_issue_dependencies(
+                args.repo, args.issue, write=True
+            )
+            print(json.dumps(summary, sort_keys=True, indent=2, default=str))
+            return 0 if summary.get("ok") else 1
+
         owner, name = split_repo(args.repo)
         issue_data = (
             api("GET", f"/repos/{owner}/{name}/issues/{int(args.issue)}") or {}

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -30,7 +30,12 @@ from github_api import (
     post_issue_comment,
     split_repo,
 )
-from issue_deps import dependency_block_reason
+from issue_deps import (
+    add_sub_issue_link,
+    dependency_block_reason,
+    reconcile_comment,
+    reconcile_issue_dependencies,
+)
 from milestones import (
     ensure_open_milestone,
     issue_milestone_number,
@@ -724,8 +729,16 @@ def role_planner(repo: str, issue: int, brief: Path) -> None:
     body = data.get("body") or ""
     labels = {label["name"] for label in data.get("labels") or []}
 
-    # Fail closed on open / unstructured dependencies before queue (#204).
-    dep_reason = dependency_block_reason(repo, issue, body=body)
+    # Derive missing blockedBy / parent-child / Depends-on, then fail closed
+    # if anything is still open or unstructured (#204).
+    reconcile_summary = reconcile_issue_dependencies(
+        repo, issue, body=body, write=True
+    )
+    note = reconcile_comment(reconcile_summary)
+    if note:
+        post_issue_comment(repo, issue, note)
+    body = str(reconcile_summary.get("body") or body)
+    dep_reason = dependency_block_reason(repo, issue, body=body, reconcile=False)
     if dep_reason:
         escalate(
             repo,
@@ -794,6 +807,9 @@ def role_planner(repo: str, issue: int, brief: Path) -> None:
                 body=child_body,
             )
             children.append(int(child["number"]))
+            # GitHub parent/child link so dispatcher treats open children as
+            # blockers for any later parent work.
+            sub_status = add_sub_issue_link(repo, issue, int(child["number"]))
             post_issue_comment(
                 repo,
                 child["number"],
@@ -804,6 +820,7 @@ def role_planner(repo: str, issue: int, brief: Path) -> None:
                     f"- priority: `{priority_label}`\n"
                     f"- milestone: `{milestone_title}`\n"
                     f"- intended_agent: `{agent_label}`\n"
+                    f"- parent_link: `{sub_status}`\n"
                     "- awaiting: dispatcher (priority queue)\n"
                 ),
             )

--- a/tests/test_dispatch_queue.py
+++ b/tests/test_dispatch_queue.py
@@ -238,8 +238,30 @@ def test_dispatch_next_skips_open_dependencies(
     )
     monkeypatch.setattr("dispatch_queue.agent_in_progress", lambda *_a, **_k: False)
     monkeypatch.setattr(
+        "dispatch_queue.reconcile_issue_dependencies",
+        lambda repo, number, body="", write=True: {
+            "issue": number,
+            "ok": True,
+            "blockers": [{"number": 199}] if number == 204 else [],
+            "added_blocked_by": (
+                [{"blocking": 199, "status": "ok"}] if number == 204 else []
+            ),
+            "added_sub_issues": [],
+            "body_updated": number == 204,
+            "body": body,
+        },
+    )
+    monkeypatch.setattr(
+        "dispatch_queue.reconcile_comment",
+        lambda summary: (
+            "### dependency_reconcile\n- added_blocked_by: #199\n"
+            if summary.get("added_blocked_by")
+            else None
+        ),
+    )
+    monkeypatch.setattr(
         "dispatch_queue.dependency_block_reason",
-        lambda repo, number, body="": (
+        lambda repo, number, body="", reconcile=False: (
             f"#{number} is blocked by open dependencies: #199"
             if number == 204
             else None
@@ -266,6 +288,6 @@ def test_dispatch_next_skips_open_dependencies(
             "milestone": "WorldGraph",
         }
     ]
-    assert comments[0][0] == 204
-    assert "### dispatcher_skip" in comments[0][1]
+    assert any("### dependency_reconcile" in body for _, body in comments)
+    assert any("### dispatcher_skip" in body for number, body in comments if number == 204)
     assert any("### dispatcher_dispatch" in body for _, body in comments)

--- a/tests/test_issue_deps.py
+++ b/tests/test_issue_deps.py
@@ -77,6 +77,10 @@ def test_open_blockers_from_body_skips_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("issue_deps.fetch_github_blocked_by", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "issue_deps.fetch_issue_relationships",
+        lambda *_a, **_k: {"subIssues": {"nodes": []}},
+    )
     states = {
         199: {"number": 199, "title": "Manifest", "state": "open"},
         200: {"number": 200, "title": "Corpus", "state": "closed"},
@@ -105,6 +109,10 @@ def test_open_blockers_from_github_blocked_by(
             {"number": 198, "title": "Done", "state": "CLOSED"},
         ],
     )
+    monkeypatch.setattr(
+        "issue_deps.fetch_issue_relationships",
+        lambda *_a, **_k: {"subIssues": {"nodes": []}},
+    )
     blockers = open_dependency_blockers("o/r", 204, body="")
     assert [b["number"] for b in blockers] == [199]
     assert blockers[0]["source"] == "blocked_by"
@@ -127,6 +135,10 @@ def test_require_dependencies_met_raises(
 ) -> None:
     monkeypatch.setattr("issue_deps.fetch_github_blocked_by", lambda *_a, **_k: [])
     monkeypatch.setattr(
+        "issue_deps.fetch_issue_relationships",
+        lambda *_a, **_k: {"subIssues": {"nodes": []}},
+    )
+    monkeypatch.setattr(
         "issue_deps._issue_state",
         lambda *_a, **_k: {"number": 199, "title": "Manifest", "state": "open"},
     )
@@ -140,7 +152,140 @@ def test_require_dependencies_met_ok_when_closed(
 ) -> None:
     monkeypatch.setattr("issue_deps.fetch_github_blocked_by", lambda *_a, **_k: [])
     monkeypatch.setattr(
+        "issue_deps.fetch_issue_relationships",
+        lambda *_a, **_k: {"subIssues": {"nodes": []}},
+    )
+    monkeypatch.setattr(
         "issue_deps._issue_state",
         lambda *_a, **_k: {"number": 199, "title": "Manifest", "state": "closed"},
     )
     require_dependencies_met("o/r", 204, body="Depends on: #199\n")
+
+
+@pytest.mark.unit
+def test_infer_dependency_from_prose() -> None:
+    from issue_deps import infer_dependency_issue_numbers
+
+    body = (
+        "Start only after completing #199. Schema produced by #200. "
+        "#201 must land first before this spike.\n"
+    )
+    assert infer_dependency_issue_numbers(body) == [199, 200, 201]
+
+
+@pytest.mark.unit
+def test_open_sub_issues_block_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("issue_deps.fetch_github_blocked_by", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "issue_deps.fetch_issue_relationships",
+        lambda *_a, **_k: {
+            "subIssues": {
+                "nodes": [
+                    {"number": 401, "title": "Child A", "state": "OPEN"},
+                    {"number": 402, "title": "Child B", "state": "CLOSED"},
+                ]
+            }
+        },
+    )
+    blockers = open_dependency_blockers("o/r", 400, body="")
+    assert [b["number"] for b in blockers] == [401]
+    assert blockers[0]["source"] == "open_sub_issue"
+
+
+@pytest.mark.unit
+def test_reconcile_adds_missing_blocked_by(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from issue_deps import reconcile_issue_dependencies
+
+    calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        "issue_deps.fetch_issue_relationships",
+        lambda *_a, **_k: {
+            "id": "I_parent",
+            "number": 204,
+            "body": "Depends on: #199\n",
+            "parent": None,
+            "blockedBy": {"nodes": []},
+            "blocking": {"nodes": []},
+            "subIssues": {"nodes": []},
+        },
+    )
+    monkeypatch.setattr(
+        "issue_deps._issue_state",
+        lambda *_a, **_k: {
+            "number": 199,
+            "title": "Manifest",
+            "state": "open",
+            "id": "I_199",
+        },
+    )
+    monkeypatch.setattr(
+        "issue_deps.add_blocked_by_link",
+        lambda repo, issue, blocking: (
+            calls.append((issue, blocking)) or "ok"
+        ),
+    )
+    monkeypatch.setattr("issue_deps._patch_issue_body", lambda *_a, **_k: None)
+    monkeypatch.setattr("issue_deps._collect_pr_inferred_deps", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "issue_deps._parent_from_planner_comments", lambda *_a, **_k: None
+    )
+
+    summary = reconcile_issue_dependencies("o/r", 204, write=True)
+    assert calls == [(204, 199)]
+    assert summary["added_blocked_by"][0]["blocking"] == 199
+    assert [b["number"] for b in summary["blockers"]] == [199]
+    # Body already had Depends on: #199 — no rewrite needed.
+    assert summary["body_updated"] is False
+
+
+@pytest.mark.unit
+def test_reconcile_syncs_body_when_missing_depends_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from issue_deps import reconcile_issue_dependencies
+
+    patched: list[str] = []
+    monkeypatch.setattr(
+        "issue_deps.fetch_issue_relationships",
+        lambda *_a, **_k: {
+            "id": "I_parent",
+            "number": 204,
+            "body": (
+                "## Dependencies\n"
+                "Start only after completing #199.\n"
+            ),
+            "parent": None,
+            "blockedBy": {"nodes": []},
+            "blocking": {"nodes": []},
+            "subIssues": {"nodes": []},
+        },
+    )
+    monkeypatch.setattr(
+        "issue_deps._issue_state",
+        lambda *_a, **_k: {
+            "number": 199,
+            "title": "Manifest",
+            "state": "open",
+            "id": "I_199",
+        },
+    )
+    monkeypatch.setattr(
+        "issue_deps.add_blocked_by_link",
+        lambda *_a, **_k: "ok",
+    )
+    monkeypatch.setattr(
+        "issue_deps._patch_issue_body",
+        lambda repo, issue, body: patched.append(body),
+    )
+    monkeypatch.setattr("issue_deps._collect_pr_inferred_deps", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        "issue_deps._parent_from_planner_comments", lambda *_a, **_k: None
+    )
+
+    summary = reconcile_issue_dependencies("o/r", 204, write=True)
+    assert summary["body_updated"] is True
+    assert patched and "Depends on: #199" in patched[0]


### PR DESCRIPTION
## Summary
- Extends `#415` so Planner and Dispatcher **reconcile** dependencies before queue/dequeue: read `blockedBy`/`blocking`/parent/sub-issues, infer missing blockers from related issue/PR text, then write GitHub links and sync `Depends on:`.
- Open sub-issues block the parent; Planner links spawned children via `addSubIssue`.
- Documents `### dependency_reconcile` and updates planner/LABELS briefs.

## Test plan
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_issue_deps.py tests/test_dispatch_queue.py -q` (21 passed)
- [ ] Dry-run dispatcher on a queued issue with prose-only deps and confirm it adds `blockedBy` + skip comment
- [ ] Planner on a multi-child issue: confirm sub-issue links appear on GitHub


Made with [Cursor](https://cursor.com)