### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+Project overview and contributor docs live in [`README.md`](README.md) and
+[`docs/`](docs/). This file captures durable, non-obvious guidance for agents
+working in this repository.
+
+## Cursor Cloud specific instructions
+
+This repo is a single Python 3.12 FastAPI service (`app.main:app`) that serves
+the saberistic.com marketing site, a hello-world JSON API, project-brief intake,
+Stripe webhooks, and an authenticated admin CRM. There is no frontend build
+step and no separate services — everything is one uvicorn process.
+
+The startup update script already creates `.venv/` and installs
+`requirements.txt` (which includes the dev/test deps: `pytest`, `pytest-cov`).
+Always work inside the venv: `source .venv/bin/activate`.
+
+### Running the app (dev)
+
+- `uvicorn app.main:app --reload --port 8000` (see [docs/HELLO_API.md](docs/HELLO_API.md)).
+- The app runs **without** a database — brief persistence and `/admin` are just
+  disabled, and `/`, `/hello`, `/health` still work. `DATABASE_URL` is only
+  needed for briefs, analytics persistence, and the admin CRM.
+- To exercise `/admin` you must set `DATABASE_URL` plus these admin env vars, or
+  startup validation fails: `ADMIN_USERNAME`, `ADMIN_PASSWORD_HASH` (an argon2
+  hash — generate with `python -c "from argon2 import PasswordHasher; print(PasswordHasher().hash('yourpw'))"`),
+  `ADMIN_SESSION_SECRET`, and `ADMIN_LOGIN_LIMITER_SECRET`. The limiter secret
+  must be ≥32 bytes and not a placeholder-looking value (`changeme`, `test-only`,
+  etc.) or `validate_admin_security_config` rejects it at startup.
+- `FIRST_PARTY_ANALYTICS_ENABLED=true` enables the `POST /api/events` analytics
+  endpoint.
+
+### PostgreSQL (for DB-backed run + contract tests)
+
+PostgreSQL 16 is installed in the VM image but **is not auto-started**. Start it
+and ensure the test role/db exist before running the app with a DB or the
+contract suite:
+
+```bash
+sudo pg_ctlcluster 16 main start
+# one-time (idempotent to re-check): role "test"/pw "test" (superuser) + db "agent_web_test"
+export TEST_DATABASE_URL="postgresql://test:test@127.0.0.1:5432/agent_web_test"
+```
+
+Schema migrations run automatically in app startup (`db.init_db`) and in the
+test fixtures — there is no separate migrate command.
+
+### Tests / coverage
+
+- Fast suite (unit + integration + scripts): `pytest -q -m "not contract"`.
+- Coverage gates (unit ≥90%, integration ≥70% on `app/`): `python scripts/check_coverage.py`.
+- Contract suite (live Postgres): `REQUIRE_TEST_DATABASE=1 TEST_DATABASE_URL=... pytest -q -m contract`.
+  Without `TEST_DATABASE_URL` these tests skip. See [docs/TESTING.md](docs/TESTING.md).
+- Browser (Playwright) suite is opt-in and not in `requirements.txt`:
+  `pip install playwright==1.49.1 && python -m playwright install chromium`, then
+  `pytest -q -m browser`.
+
+### Lint / CI notes
+
+- There is no standalone linter/formatter (no ruff/flake8/mypy config). The CI
+  gate in [.github/workflows/ci.yml](.github/workflows/ci.yml) is `pytest -q -m "not contract"`
+  plus `scripts/check_coverage.py`.
+- `scripts/validate_workflow_governance.py` needs a GitHub token and live repo
+  settings; it is a CI-only check, not part of local dev.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this repo (Python 3.12 FastAPI service) and documents durable, non-obvious startup/run guidance for future cloud agents in a new `AGENTS.md`.

No application code was modified — this PR only adds `AGENTS.md`. The dependency-refresh update script is configured separately via the environment setup (venv + `pip install -r requirements.txt`).

## What was verified

- Installed `requirements.txt` into `.venv` (includes dev/test deps).
- Fast suite: `pytest -q -m "not contract"` → **2263 passed, 96 skipped**.
- Coverage gates: `python scripts/check_coverage.py` → **OK (unit ≥90%, integration ≥70%)**.
- Contract suite against local Postgres 16: `REQUIRE_TEST_DATABASE=1 pytest -q -m contract` → **116 passed, 4 skipped**.
- Ran the app: `uvicorn app.main:app --reload --port 8000`. `/hello`, `/health` (reports `schema_version: 023`), landing page, and `/admin` all respond.
- Hello-world action: logged into the admin CRM and created a company "Hello World Labs", confirmed persisted in Postgres.

[admin_login_and_create_company.mp4](https://cursor.com/agents/bc-6f36e795-89ad-4cbc-94b9-689b05f5445f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_login_and_create_company.mp4)

[Companies list showing Hello World Labs](https://cursor.com/agents/bc-6f36e795-89ad-4cbc-94b9-689b05f5445f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompanies_list_hello_world_labs.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f36e795-89ad-4cbc-94b9-689b05f5445f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f36e795-89ad-4cbc-94b9-689b05f5445f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

