### PR TITLE
Audit and fix first-party analytics recording and admin reporting

### DIFF
--- a/app/admin_preview.py
+++ b/app/admin_preview.py
@@ -366,6 +366,7 @@ def build_preview_analytics_dashboard_data(
 
     engagement_events = (
         EventCountRow("Landing Viewed", rng.randint(120, 480), "browser"),
+        EventCountRow("About Viewed", rng.randint(35, 160), "browser"),
         EventCountRow("Services Viewed", rng.randint(40, 180), "browser"),
         EventCountRow("Case Studies Viewed", rng.randint(30, 120), "browser"),
         EventCountRow("Case Study Viewed", rng.randint(20, 90), "browser"),

--- a/app/analytics_dashboard.py
+++ b/app/analytics_dashboard.py
@@ -10,6 +10,7 @@ from typing import Literal
 import psycopg
 
 from app.analytics_event_schema import (
+    EVENT_ABOUT_VIEWED,
     EVENT_BRIEF_FORM_STARTED,
     EVENT_BRIEF_VIEWED,
     EVENT_CASE_STUDIES_VIEWED,
@@ -37,6 +38,7 @@ _DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 DASHBOARD_EVENT_NAMES: tuple[str, ...] = (
     EVENT_LANDING_VIEWED,
+    EVENT_ABOUT_VIEWED,
     EVENT_SERVICES_VIEWED,
     EVENT_CASE_STUDIES_VIEWED,
     EVENT_CASE_STUDY_VIEWED,
@@ -313,6 +315,7 @@ def load_analytics_dashboard(
 
     engagement_order = (
         EVENT_LANDING_VIEWED,
+        EVENT_ABOUT_VIEWED,
         EVENT_SERVICES_VIEWED,
         EVENT_CASE_STUDIES_VIEWED,
         EVENT_CASE_STUDY_VIEWED,

--- a/app/analytics_event_schema.py
+++ b/app/analytics_event_schema.py
@@ -172,7 +172,8 @@ _EVENT_REQUIRED_PROPERTIES: dict[str, frozenset[str]] = {
     EVENT_CASE_STUDY_VIEWED: frozenset({"case_study_slug"}),
     EVENT_INSIGHT_VIEWED: frozenset({"article_slug"}),
     EVENT_CONTACT_INITIATED: frozenset({"contact_channel", "funnel_step"}),
-    EVENT_CHECKOUT_CANCELLED: frozenset({"brief_id", "funnel_step"}),
+    # Client cancel redirect has no brief_id; server Stripe expiry includes it.
+    EVENT_CHECKOUT_CANCELLED: frozenset({"funnel_step"}),
     EVENT_NOTIFICATION_OUTCOME: frozenset(
         {"brief_id", "notification_kind", "notification_outcome"}
     ),

--- a/docs/ANALYTICS_FUNNEL.md
+++ b/docs/ANALYTICS_FUNNEL.md
@@ -75,7 +75,6 @@ Only these properties may appear on stored events:
 | `funnel_step` | int (1–8) | Conversion funnel events |
 | `brief_id` | int | Server events (steps 5–7) |
 | `price_cents` | int | `Checkout Opened`, `Payment Completed` |
-| `discount_cents` | int | `Payment Completed` (when discounted) |
 | `environment` | string | Server events (`production`, `staging`, `development`) |
 | `linkage_source` | string | Server CRM-linked events |
 | `utm_source` | string | Attribution / all events when present |

--- a/tests/test_analytics_dashboard_unit.py
+++ b/tests/test_analytics_dashboard_unit.py
@@ -20,6 +20,7 @@ from app.analytics_dashboard import (
     render_analytics_export_csv,
 )
 from app.analytics_event_schema import (
+    EVENT_ABOUT_VIEWED,
     EVENT_BRIEF_FORM_STARTED,
     EVENT_BRIEF_VIEWED,
     EVENT_CHECKOUT_OPENED,
@@ -124,6 +125,33 @@ def test_load_analytics_dashboard_zero_denominator_rate() -> None:
     empty_den = next(row for row in data.conversion_rates if row.key == "brief_to_form")
     assert empty_den.denominator == 0
     assert empty_den.rate_pct is None
+
+
+@pytest.mark.unit
+def test_load_analytics_dashboard_includes_about_viewed_engagement() -> None:
+    repo = MagicMock()
+    repo.count_events_in_range.return_value = [
+        (EVENT_LANDING_VIEWED, 10),
+        (EVENT_ABOUT_VIEWED, 4),
+    ]
+    repo.count_attribution_in_range.return_value = []
+    repo.count_leads_by_utm_source.return_value = []
+    repo.count_content_engagement.return_value = []
+
+    data = load_analytics_dashboard(
+        MagicMock(),
+        repo,
+        date_range=AnalyticsDateRange(start=NOW - timedelta(days=7), end=NOW, label="7d"),
+        generated_at=NOW,
+    )
+    engagement_names = [row.event_name for row in data.engagement_events]
+    assert EVENT_LANDING_VIEWED in engagement_names
+    assert EVENT_ABOUT_VIEWED in engagement_names
+    about = next(row for row in data.engagement_events if row.event_name == EVENT_ABOUT_VIEWED)
+    assert about.count == 4
+    assert about.source == "browser"
+    called_names = repo.count_events_in_range.call_args.kwargs["event_names"]
+    assert EVENT_ABOUT_VIEWED in called_names
 
 
 @pytest.mark.unit

--- a/tests/test_analytics_event_schema.py
+++ b/tests/test_analytics_event_schema.py
@@ -184,6 +184,31 @@ def test_build_event_payload_accepts_contact_initiated() -> None:
 
 
 @pytest.mark.unit
+def test_checkout_cancelled_accepts_client_payload_without_brief_id() -> None:
+    """Browser cancel redirect sends page + funnel_step only (no brief_id)."""
+    event = schema.build_event_payload(
+        event_name=schema.EVENT_CHECKOUT_CANCELLED,
+        anonymous_session_id=VALID_SESSION,
+        pathname="/brief",
+        properties={"page": "/brief", "funnel_step": 6},
+    )
+    assert event.properties["funnel_step"] == 6
+    assert "brief_id" not in event.properties
+
+
+@pytest.mark.unit
+def test_checkout_cancelled_still_accepts_server_payload_with_brief_id() -> None:
+    event = schema.build_event_payload(
+        event_name=schema.EVENT_CHECKOUT_CANCELLED,
+        anonymous_session_id=VALID_SESSION,
+        pathname="/brief",
+        properties={"brief_id": 9, "funnel_step": 6, "linkage_source": "server_checkout_cancelled"},
+    )
+    assert event.properties["brief_id"] == 9
+    assert event.linkage_state == schema.LinkageState.CRM_BRIEF_LINKED
+
+
+@pytest.mark.unit
 def test_rejects_unknown_event_name() -> None:
     with pytest.raises(schema.AnalyticsEventValidationError, match="Unknown event name"):
         schema.build_event_payload(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited the first-party analytics pipeline (client → `POST /api/events` → Postgres → `/admin/analytics`) and fixed two correctness gaps.

### Fixes
1. **Client `Checkout Cancelled` was never stored** — schema required `brief_id`, but `first_party_analytics.js` (and the funnel docs) send only `page` + `funnel_step` on Stripe cancel redirect. Validation now requires `funnel_step` only; server-side cancels can still include `brief_id`.
2. **`About Viewed` was stored but missing from the admin engagement table** — added to `DASHBOARD_EVENT_NAMES` / engagement order (and preview seed) to match the KPI scorecard SQL in `docs/ANALYTICS_FUNNEL.md`.

### Verified
- Landing page view path: `/` → `Landing Viewed` → `analytics_events` → admin Engagement count (unchanged; works when `FIRST_PARTY_ANALYTICS_ENABLED=true` + `DATABASE_URL`).
- Unit tests for schema + dashboard coverage.

### Coverage notes (for operators)
**On admin dashboard:** Landing/About/Services/Case Studies/Case Study/Insights/Insight/Brief/Brief Form Started/Contact Initiated + server Lead/Checkout/Payment + rates, UTM, content slugs.

**Recorded but not on dashboard:** Nav click events, Brief Success Viewed, Checkout Cancelled, Notification Outcome.

**Requires:** `FIRST_PARTY_ANALYTICS_ENABLED=true` and Postgres; DNT/GPC and bots are intentionally dropped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57e687d7-3aff-4f8c-9933-b414181959a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57e687d7-3aff-4f8c-9933-b414181959a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

