### PR TITLE
Fix discovery run advisory lock

### DIFF
--- a/app/discovery/run_lock.py
+++ b/app/discovery/run_lock.py
@@ -31,7 +31,8 @@ class DiscoveryRunLock:
                 TRY_ADVISORY_LOCK_SQL,
                 (DISCOVERY_RUN_ADVISORY_LOCK_KEY1, DISCOVERY_RUN_ADVISORY_LOCK_KEY2),
             )
-            acquired = bool(cur.fetchone()[0])
+            row = cur.fetchone()
+            acquired = bool(row["pg_try_advisory_lock"] if isinstance(row, dict) else row[0])
         self._held = acquired
         return acquired
 

--- a/tests/test_discovery_run_lock.py
+++ b/tests/test_discovery_run_lock.py
@@ -46,3 +46,16 @@ def test_discovery_run_lock_not_acquired() -> None:
     assert lock.held is False
     lock.release()
     cur.execute.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.integration
+def test_discovery_run_lock_supports_dict_rows() -> None:
+    conn = MagicMock()
+    cur = conn.cursor.return_value.__enter__.return_value
+    cur.fetchone.return_value = {"pg_try_advisory_lock": True}
+
+    lock = DiscoveryRunLock(conn)
+
+    assert lock.try_acquire() is True
+    assert lock.held is True


### PR DESCRIPTION
## Summary
- support dictionary-style PostgreSQL rows in the discovery advisory lock
- add regression coverage for Render's `dict_row` connection configuration

## Validation
- `pytest -q tests/test_discovery_run_lock.py`