### PR TITLE
fix: resolve issue-linked PRs strictly

### DIFF
--- a/.github/workflow-governance-paths.json
+++ b/.github/workflow-governance-paths.json
@@ -10,6 +10,10 @@
       "category": "control-plane GitHub API"
     },
     {
+      "path": "scripts/resolve_issue_pr.py",
+      "category": "strict issue-to-PR resolver"
+    },
+    {
       "path": "scripts/copilot_agent.py",
       "category": "agent dispatch adapter"
     },

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -133,26 +133,17 @@ jobs:
             --issue "${ISSUE}" \
             --mode require
 
-          PRS="$(gh pr list --repo "${{ github.repository }}" \
-            --search "${ISSUE} in:title,body" --state open --json number,body,title \
-            --jq "[.[] | select((.title | contains(\"#${ISSUE}\")) or (.body != null and (.body | contains(\"#${ISSUE}\")))) | .number] | .[]")"
-          # Search index can lag; fall back to listing open PRs and filtering locally.
-          if [[ -z "${PRS}" ]]; then
-            PRS="$(gh pr list --repo "${{ github.repository }}" --state open \
-              --json number,body,title \
-              --jq "[.[] | select((.title | contains(\"#${ISSUE}\")) or (.body != null and (.body | contains(\"#${ISSUE}\")))) | .number] | .[]")"
-          fi
-          if [[ -z "${PRS}" ]]; then
+          if ! RESOLUTION="$(python scripts/resolve_issue_pr.py --repo "${{ github.repository }}" --issue "${ISSUE}")"; then
             gh issue comment "${ISSUE}" --repo "${{ github.repository }}" --body "$(cat <<EOF
           ### gate_merge
           - result: \`fail\`
-          - detail: no open PR linked to #${ISSUE}
+          - detail: no unique open PR linked to #${ISSUE}; resolver: ${RESOLUTION}
           EOF
           )"
             exit 1
           fi
-          while read -r pr; do
-            [[ -z "${pr}" ]] && continue
+          pr="$(python -c 'import json,sys; print(json.load(sys.stdin)["pr_number"])' <<<"${RESOLUTION}")"
+          {
             # Main may move while post-deploy commits land; retry merge a few times.
             merged=0
             for attempt in 1 2 3 4 5; do
@@ -196,7 +187,7 @@ jobs:
               --pr "${pr}" \
               --merge-sha "${MERGE_SHA}" \
               --mode close
-          done <<< "${PRS}"
+          }
           for label in status:new status:queued status:in-progress status:blocked status:needs-review status:failed; do
             gh issue edit "${ISSUE}" --repo "${{ github.repository }}" --remove-label "${label}" 2>/dev/null || true
           done

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -54,36 +54,15 @@ jobs:
           set -euo pipefail
           ISSUE="${{ github.event.issue.number }}"
           export ISSUE
-          # Use intentional link rules (builder/{issue}-*, (#issue), Closes/Fixes)
-          # — never bare "#N" prose. Casual mentions in sibling PRs (e.g. #355
-          # referencing issue 123) used to steal pr-head and fail coverage.
-          mapfile -t LINKED < <(python - <<'PY'
-          import os
-          import sys
-
-          sys.path.insert(0, "scripts")
-          from github_api import linked_open_prs, pr_head_ref
-
-          repo = os.environ["GITHUB_REPOSITORY"]
-          issue = int(os.environ["ISSUE"])
-          linked = linked_open_prs(repo, issue)
-          if not linked:
-              sys.exit(0)
-          pr = linked[0]
-          head = pr.get("head") or {}
-          print(pr_head_ref(pr))
-          print(head.get("sha") or "")
-          print(pr.get("number") or "")
-          PY
-          )
-          if [[ "${#LINKED[@]}" -lt 2 || -z "${LINKED[0]:-}" || -z "${LINKED[1]:-}" ]]; then
-            echo "No open PR intentionally linked to #${ISSUE}."
+          # Strict resolver never chooses a first match: zero or multiple
+          # intentional candidates are a visible, safe stop.
+          if ! RESOLUTION="$(python scripts/resolve_issue_pr.py --repo "${GITHUB_REPOSITORY}" --issue "${ISSUE}")"; then
+            echo "No unique linked PR for #${ISSUE}: ${RESOLUTION}"
             echo "has_pr=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          REF="${LINKED[0]}"
-          SHA="${LINKED[1]}"
-          PR_NUMBER="${LINKED[2]:-}"
+          mapfile -t LINKED < <(python -c 'import json,sys; r=json.load(sys.stdin); print(r["head_ref"]); print(r["head_sha"]); print(r["pr_number"])' <<<"${RESOLUTION}")
+          REF="${LINKED[0]}"; SHA="${LINKED[1]}"; PR_NUMBER="${LINKED[2]}"
           echo "Fetching intentionally linked PR #${PR_NUMBER} head ${REF} @ ${SHA} into pr-head/"
           rm -rf pr-head
           git fetch origin "${REF}"

--- a/scripts/acceptance.py
+++ b/scripts/acceptance.py
@@ -532,6 +532,11 @@ def verify_acceptance(
     *,
     use_ai: bool = True,
 ) -> dict[str, Any]:
+    if pr_number is None:
+        # Evidence must describe the same unique PR that Reviewer/Gate use.
+        from github_api import resolve_issue_pr
+
+        pr_number = int(resolve_issue_pr(repo, issue)["pr_number"])
     evidence = gather_evidence(repo, issue, pr_number)
     criteria = parse_criteria(evidence.get("issue_body") or "")
     items: list[dict[str, Any]] = []

--- a/scripts/builder_conflicts.py
+++ b/scripts/builder_conflicts.py
@@ -65,10 +65,11 @@ _NAMEERROR_RE = re.compile(
 
 
 def linked_open_prs(repo: str, issue: int) -> list[dict[str, Any]]:
-    """Delegate to shared intentional-link matcher (anti-loop #109/#181)."""
-    from github_api import linked_open_prs as _linked_open_prs
+    """Compatibility shape backed by the strict shared resolver."""
+    from github_api import unique_open_pr_or_none
 
-    return _linked_open_prs(repo, issue)
+    pr = unique_open_pr_or_none(repo, issue)
+    return [pr] if pr else []
 
 
 def repair_main_wiring(text: str) -> tuple[str, list[str]]:

--- a/scripts/codegen_models.py
+++ b/scripts/codegen_models.py
@@ -404,10 +404,11 @@ def put_file_batch(
 
 
 def linked_open_prs(repo: str, issue: int) -> list[dict]:
-    """Delegate to shared intentional-link matcher (anti-loop #109/#181)."""
-    from github_api import linked_open_prs as _linked_open_prs
+    """Compatibility shape backed by the strict shared resolver."""
+    from github_api import unique_open_pr_or_none
 
-    return _linked_open_prs(repo, issue)
+    pr = unique_open_pr_or_none(repo, issue)
+    return [pr] if pr else []
 
 
 def json_system_prompt(*, ui: bool) -> str:

--- a/scripts/copilot_agent.py
+++ b/scripts/copilot_agent.py
@@ -157,28 +157,11 @@ def assign_copilot(
 
 
 def linked_prs(repo: str, issue: int) -> list[dict[str, Any]]:
-    """Prefer intentional issue links; keep Copilot branch-prefix fallback."""
-    from github_api import linked_open_prs, pr_head_ref, pr_links_issue
+    """Return only the strict resolver's single intentional candidate."""
+    from github_api import unique_open_pr_or_none
 
-    intentional = linked_open_prs(repo, issue)
-    if intentional:
-        return intentional
-
-    owner, name = split_repo(repo)
-    prs = api("GET", f"/repos/{owner}/{name}/pulls?state=open&per_page=100") or []
-    out: list[dict[str, Any]] = []
-    for pr in prs:
-        if pr_links_issue(pr, issue):
-            out.append(pr)
-            continue
-        user = ((pr.get("user") or {}).get("login") or "").lower()
-        head = pr_head_ref(pr)
-        # Copilot may open PRs that lack Closes/#(N) but use a recognizable head.
-        if "copilot" in user and (
-            head.startswith(f"copilot/") or f"/{issue}-" in f"/{head}"
-        ):
-            out.append(pr)
-    return out
+    pr = unique_open_pr_or_none(repo, issue)
+    return [pr] if pr else []
 
 
 def wait_for_copilot_pr(

--- a/scripts/github_api.py
+++ b/scripts/github_api.py
@@ -11,6 +11,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from typing import Any
 
 # Intentional PR↔issue links only. Bare ``#N`` in prose (e.g. “preview #109”
@@ -31,6 +32,17 @@ API_BACKOFF_CAP_S = 30.0
 
 class GitHubError(RuntimeError):
     pass
+
+
+class IssuePRResolutionError(GitHubError):
+    """An issue does not have exactly one intentionally linked open PR."""
+
+    def __init__(self, resolution: dict[str, Any]) -> None:
+        self.resolution = resolution
+        super().__init__(
+            f"issue #{resolution['issue_number']} has "
+            f"{resolution['candidate_count']} intentional open PR candidate(s)"
+        )
 
 
 def token() -> str:
@@ -60,7 +72,7 @@ def pr_links_issue(pr: dict[str, Any], issue: int) -> bool:
     """True when the PR intentionally targets ``issue``.
 
     Counts:
-    - head branch ``builder/{issue}-…`` (or exact ``builder/{issue}``)
+    - head branch ``builder/{issue}-…`` / ``docs/{issue}-…`` (or exact form)
     - title marker ``(#issue)``
     - ``Closes`` / ``Fixes`` / ``Resolves #issue`` in the body
 
@@ -70,7 +82,7 @@ def pr_links_issue(pr: dict[str, Any], issue: int) -> bool:
     """
     n = int(issue)
     head = pr_head_ref(pr)
-    if head == f"builder/{n}" or head.startswith(f"builder/{n}-"):
+    if _is_issue_branch(head, n):
         return True
     title = pr.get("title") or ""
     if any(int(match) == n for match in _TITLE_ISSUE_RE.findall(title)):
@@ -79,6 +91,30 @@ def pr_links_issue(pr: dict[str, Any], issue: int) -> bool:
     if any(int(match) == n for match in _CLOSES_ISSUE_RE.findall(body)):
         return True
     return False
+
+
+def _is_issue_branch(head: str, issue: int) -> bool:
+    """Only the documented Builder and Docs branch conventions bind an issue."""
+    return any(
+        head == f"{role}/{issue}" or head.startswith(f"{role}/{issue}-")
+        for role in ("builder", "docs")
+    )
+
+
+def pr_link_reasons(pr: dict[str, Any], issue: int) -> list[str]:
+    """Return auditable intentional-link reasons for one PR."""
+    n = int(issue)
+    reasons: list[str] = []
+    head = pr_head_ref(pr)
+    if _is_issue_branch(head, n):
+        reasons.append("branch")
+    if any(int(match) == n for match in _TITLE_ISSUE_RE.findall(pr.get("title") or "")):
+        reasons.append("title")
+    if any(int(match) == n for match in _CLOSES_ISSUE_RE.findall(pr.get("body") or "")):
+        reasons.append("closing-reference")
+    if pr.get("_graphql_closing_link"):
+        reasons.append("github-closing-relationship")
+    return reasons
 
 
 def _linked_pr_rank(pr: dict[str, Any], issue: int) -> tuple[int, int]:
@@ -98,12 +134,131 @@ def _linked_pr_rank(pr: dict[str, Any], issue: int) -> tuple[int, int]:
 
 
 def linked_open_prs(repo: str, issue: int) -> list[dict[str, Any]]:
-    """Open PRs that intentionally link ``issue``, strongest binding first."""
+    """Open PR candidates, retained only for non-selecting compatibility callers.
+
+    Privileged consumers must call :func:`resolve_issue_pr`; it refuses to pick
+    a PR when the candidate set is ambiguous.
+    """
     owner, name = split_repo(repo)
-    prs = api("GET", f"/repos/{owner}/{name}/pulls?state=open&per_page=100") or []
-    matched = [pr for pr in prs if pr_links_issue(pr, issue)]
+    # GitHub's relationship is authoritative when the token/schema exposes it;
+    # still enumerate REST pages so search/index lag and relation pagination can
+    # neither hide nor select a different open PR.
+    graphql_links = _graphql_closing_pr_numbers(repo, issue)
+    prs: list[dict[str, Any]] = []
+    for page in range(1, 101):
+        batch = api(
+            "GET", f"/repos/{owner}/{name}/pulls?state=open&per_page=100&page={page}"
+        ) or []
+        prs.extend(batch)
+        if len(batch) < 100:
+            break
+    for pr in prs:
+        if int(pr.get("number") or 0) in graphql_links:
+            pr["_graphql_closing_link"] = True
+    matched = [
+        pr
+        for pr in prs
+        if pr_links_issue(pr, issue) or pr.get("_graphql_closing_link")
+    ]
     matched.sort(key=lambda pr: _linked_pr_rank(pr, issue))
     return matched
+
+
+def _graphql_closing_pr_numbers(repo: str, issue: int) -> set[int]:
+    """Best-effort authoritative closing-relationship lookup.
+
+    Some narrowly scoped App tokens cannot query this GraphQL field, so REST
+    intentional matching remains the deterministic fallback.
+    """
+    owner, name = split_repo(repo)
+    query = """
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        issue(number: $number) {
+          closedByPullRequestsReferences(first: 100) {
+            nodes { number state }
+          }
+        }
+      }
+    }
+    """
+    try:
+        data = graphql(query, {"owner": owner, "name": name, "number": int(issue)})
+    except GitHubError:
+        return set()
+    nodes = (((data.get("repository") or {}).get("issue") or {}).get(
+        "closedByPullRequestsReferences"
+    ) or {}).get("nodes") or []
+    return {int(node["number"]) for node in nodes if node.get("state") == "OPEN"}
+
+
+def issue_pr_resolution(repo: str, issue: int) -> dict[str, Any]:
+    """Inspect all open candidates without selecting one.
+
+    REST pagination makes this deterministic even when GitHub search indexing
+    lags.  The result is deliberately safe to emit in workflow diagnostics.
+    """
+    candidates = linked_open_prs(repo, issue)
+    result: dict[str, Any] = {
+        "repository": repo,
+        "issue_number": int(issue),
+        "candidate_count": len(candidates),
+        "candidates": [
+            {
+                "pr_number": int(pr.get("number") or 0),
+                "pr_url": pr.get("html_url"),
+                "head_ref": pr_head_ref(pr),
+                "head_sha": (pr.get("head") or {}).get("sha"),
+                "linkage_reason": "+".join(pr_link_reasons(pr, issue)),
+            }
+            for pr in candidates
+        ],
+    }
+    if len(candidates) == 1:
+        pr = candidates[0]
+        head = pr.get("head") or {}
+        base = pr.get("base") or {}
+        result.update(
+            {
+                "pr_number": int(pr["number"]),
+                "pr_url": pr.get("html_url"),
+                "base_ref": base.get("ref"),
+                "head_ref": head.get("ref"),
+                "head_sha": head.get("sha"),
+                "linkage_reason": "+".join(pr_link_reasons(pr, issue)),
+            }
+        )
+    return result
+
+
+def resolve_issue_pr(repo: str, issue: int) -> dict[str, Any]:
+    """Return the single linked open PR identity or fail closed.
+
+    The head SHA is required because checkout, review, labels and merging must
+    all act on the same immutable identity, never a list position.
+    """
+    result = issue_pr_resolution(repo, issue)
+    if result["candidate_count"] != 1 or not result.get("head_sha"):
+        raise IssuePRResolutionError(result)
+    return result
+
+
+def unique_open_pr_or_none(repo: str, issue: int) -> dict[str, Any] | None:
+    """Return the one candidate PR, allow zero, and reject ambiguity.
+
+    Creation workflows use this to determine whether they need to open a PR.
+    Multiple candidates never degrade into a ranked-first selection.
+    """
+    result = issue_pr_resolution(repo, issue)
+    if result["candidate_count"] == 0:
+        return None
+    if result["candidate_count"] != 1:
+        raise IssuePRResolutionError(result)
+    number = int(result["pr_number"])
+    for pr in linked_open_prs(repo, issue):
+        if int(pr.get("number") or 0) == number:
+            return pr
+    raise GitHubError(f"resolved PR #{number} disappeared while resolving issue #{issue}")
 
 
 def _retry_delay_s(attempt: int, *, retry_after: str | None = None) -> float:

--- a/scripts/issue_deps.py
+++ b/scripts/issue_deps.py
@@ -26,7 +26,7 @@ import re
 import sys
 from typing import Any
 
-from github_api import GitHubError, api, graphql, linked_open_prs, split_repo
+from github_api import GitHubError, api, graphql, split_repo, unique_open_pr_or_none
 
 DEPENDS_ON_LINE_RE = re.compile(
     r"(?im)^(?:depends\s+on|blocked\s+by|blockers?)\s*:?\s*(.+)$"
@@ -312,7 +312,8 @@ def _collect_pr_inferred_deps(repo: str, issue: int) -> list[int]:
     found: list[int] = []
     seen: set[int] = set()
     try:
-        prs = linked_open_prs(repo, issue)
+        pr = unique_open_pr_or_none(repo, issue)
+        prs = [pr] if pr else []
     except GitHubError:
         return []
     for pr in prs:

--- a/scripts/pr_labels.py
+++ b/scripts/pr_labels.py
@@ -13,7 +13,7 @@ import argparse
 import sys
 from typing import Any, Iterable
 
-from github_api import add_labels, api, delete_label, linked_open_prs, split_repo
+from github_api import add_labels, api, delete_label, split_repo, unique_open_pr_or_none
 from milestones import assign_milestone, issue_milestone_number
 
 # Axes that may appear on PRs (mirrors of the linked issue).
@@ -125,7 +125,8 @@ def apply_to_linked_prs(
     if pr is not None:
         targets = [pr]
     else:
-        targets = [int(item["number"]) for item in linked_open_prs(repo, issue)]
+        resolved = unique_open_pr_or_none(repo, issue)
+        targets = [int(resolved["number"])] if resolved else []
     applied: dict[int, list[str]] = {}
     for number in targets:
         applied[number] = apply_pr_mirror(

--- a/scripts/project_sync.py
+++ b/scripts/project_sync.py
@@ -348,12 +348,11 @@ def content_state(owner: str, repo: str, number: int) -> bool:
 
 
 def linked_open_prs(repo: str, issue: int) -> list[int]:
-    """Open PRs that intentionally link ``issue`` (not casual ``#N`` prose)."""
-    from github_api import pr_links_issue
+    """Compatibility shape backed by the strict shared resolver."""
+    from github_api import unique_open_pr_or_none
 
-    owner, name = split_repo(repo)
-    prs = _rest("GET", f"/repos/{owner}/{name}/pulls?state=open&per_page=50") or []
-    return [int(pr["number"]) for pr in prs if pr_links_issue(pr, issue)]
+    pr = unique_open_pr_or_none(repo, issue)
+    return [int(pr["number"])] if pr else []
 
 
 def sync_number(

--- a/scripts/resolve_issue_pr.py
+++ b/scripts/resolve_issue_pr.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Resolve exactly one intentionally linked open pull request for an issue."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from github_api import GitHubError, IssuePRResolutionError, resolve_issue_pr, issue_pr_resolution
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--issue", required=True, type=int)
+    args = parser.parse_args(argv)
+    try:
+        result = resolve_issue_pr(args.repo, args.issue)
+    except IssuePRResolutionError as exc:
+        print(json.dumps(exc.resolution, sort_keys=True))
+        return 2
+    except GitHubError as exc:
+        print(json.dumps({"repository": args.repo, "issue_number": args.issue, "error": str(exc)}))
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/review_decision.py
+++ b/scripts/review_decision.py
@@ -67,16 +67,10 @@ def resolve_decision(
 
 
 def linked_open_prs(repo: str, issue: int) -> list[dict]:
-    from github_api import linked_open_prs as _linked_open_prs
+    from github_api import unique_open_pr_or_none
 
-    linked = list(_linked_open_prs(repo, issue))
-    owner, name = split_repo(repo)
-    issue_data = api("GET", f"/repos/{owner}/{name}/issues/{issue}")
-    if issue_data.get("pull_request"):
-        pr_num = int(issue_data["number"])
-        if not any(int(p["number"]) == pr_num for p in linked):
-            linked.append(api("GET", f"/repos/{owner}/{name}/pulls/{pr_num}"))
-    return linked
+    pr = unique_open_pr_or_none(repo, issue)
+    return [pr] if pr else []
 
 
 def latest_submitted_review(

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -127,10 +127,11 @@ def slugify(text: str, limit: int = 40) -> str:
 
 
 def linked_open_prs(repo: str, issue: int) -> list[dict]:
-    """Delegate to shared intentional-link matcher (anti-loop #109/#181)."""
-    from github_api import linked_open_prs as _linked_open_prs
+    """Compatibility shape backed by the strict shared resolver."""
+    from github_api import unique_open_pr_or_none
 
-    return _linked_open_prs(repo, issue)
+    pr = unique_open_pr_or_none(repo, issue)
+    return [pr] if pr else []
 
 
 def escalate(repo: str, issue: int, reason: str, assignee_hint: str | None = None) -> None:

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -261,6 +261,50 @@ def test_linked_open_prs_ranks_builder_head_first(
     assert [pr["number"] for pr in linked] == [199, 200]
 
 
+def test_resolve_issue_pr_accepts_closing_title_and_docs_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cases = [
+        {"number": 1, "title": "feature", "body": "Fixes #12", "head": {"ref": "feature/x", "sha": "a"}, "base": {"ref": "main"}},
+        {"number": 2, "title": "feature (#12)", "body": "", "head": {"ref": "feature/x", "sha": "b"}, "base": {"ref": "main"}},
+        {"number": 3, "title": "docs", "body": "", "head": {"ref": "docs/12-update", "sha": "c"}, "base": {"ref": "main"}},
+    ]
+    for pr in cases:
+        monkeypatch.setattr(github_api, "api", lambda *_a, pr=pr, **_k: [pr])
+        resolved = github_api.resolve_issue_pr("o/r", 12)
+        assert resolved["pr_number"] == pr["number"]
+        assert resolved["head_sha"] == pr["head"]["sha"]
+        assert resolved["candidate_count"] == 1
+
+
+def test_resolver_rejects_casual_substring_and_multiple_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    casual = {"number": 1, "title": "depends on #112", "body": "quoted: Fixes #112; depends on #12", "head": {"ref": "feature/x", "sha": "a"}}
+    monkeypatch.setattr(github_api, "api", lambda *_a, **_k: [casual])
+    with pytest.raises(github_api.IssuePRResolutionError) as zero:
+        github_api.resolve_issue_pr("o/r", 12)
+    assert zero.value.resolution["candidate_count"] == 0
+
+    one = {"number": 2, "title": "one (#12)", "body": "", "head": {"ref": "feature/a", "sha": "a"}}
+    two = {"number": 3, "title": "two", "body": "Resolves #12", "head": {"ref": "feature/b", "sha": "b"}}
+    monkeypatch.setattr(github_api, "api", lambda *_a, **_k: [one, two])
+    with pytest.raises(github_api.IssuePRResolutionError) as multiple:
+        github_api.resolve_issue_pr("o/r", 12)
+    assert multiple.value.resolution["candidate_count"] == 2
+
+
+def test_resolver_paginates_before_deciding(monkeypatch: pytest.MonkeyPatch) -> None:
+    page_one = [{"number": n, "title": "other", "body": "", "head": {"ref": f"feature/{n}"}} for n in range(100)]
+    linked = {"number": 101, "title": "feature (#12)", "body": "", "head": {"ref": "feature/12", "sha": "head"}, "base": {"ref": "main"}}
+
+    def fake_api(_method: str, path: str, **_k: Any) -> Any:
+        return page_one if path.endswith("page=1") else [linked]
+
+    monkeypatch.setattr(github_api, "api", fake_api)
+    assert github_api.resolve_issue_pr("o/r", 12)["pr_number"] == 101
+
+
 def test_graphql_posts_query_and_returns_data(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_TOKEN", "test-token")
     captured: dict[str, Any] = {}

--- a/tests/test_pr_labels.py
+++ b/tests/test_pr_labels.py
@@ -162,12 +162,12 @@ def test_mirror_pr_milestone_copies_from_issue(
 
 
 @pytest.mark.unit
-def test_apply_to_linked_prs_uses_open_prs(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_to_linked_prs_uses_unique_open_pr(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[int, str | None]] = []
 
     monkeypatch.setattr(
-        "pr_labels.linked_open_prs",
-        lambda repo, issue: [{"number": 71}, {"number": 72}],
+        "pr_labels.unique_open_pr_or_none",
+        lambda repo, issue: {"number": 71},
     )
 
     def fake_apply(repo, issue, pr, *, review=None, default_review=None):
@@ -177,16 +177,13 @@ def test_apply_to_linked_prs_uses_open_prs(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr("pr_labels.apply_pr_mirror", fake_apply)
 
     out = apply_to_linked_prs("o/r", 9, review="review:changes-requested")
-    assert out == {71: ["pr-71"], 72: ["pr-72"]}
-    assert calls == [
-        (71, "review:changes-requested"),
-        (72, "review:changes-requested"),
-    ]
+    assert out == {71: ["pr-71"]}
+    assert calls == [(71, "review:changes-requested")]
 
 
 @pytest.mark.unit
 def test_apply_to_linked_prs_explicit_pr(monkeypatch: pytest.MonkeyPatch) -> None:
-    with patch("pr_labels.linked_open_prs") as linked:
+    with patch("pr_labels.unique_open_pr_or_none") as linked:
         with patch(
             "pr_labels.apply_pr_mirror",
             return_value=["review:approved"],


### PR DESCRIPTION
Closes #286

## Summary
- add one paginated, fail-closed issue-to-open-PR resolver with auditable identity and head SHA
- route Builder, Docs, Reviewer, Gate, labels, acceptance, project sync, and related consumers through strict unique resolution
- remove Gate broad issue-text matching and Reviewer first-result selection

## Verification
- pytest -q tests/test_github_api.py tests/test_workflow_governance.py tests/test_pr_labels.py tests/test_review_decision.py tests/test_issue_deps.py tests/test_acceptance.py
- workflow YAML parsing

The full non-contract suite was also run: 2,488 passed. Remaining failures are environment limitations: Chromium is absent and the sandbox disallows local socket binding.